### PR TITLE
feat: Add obfuscation support for secure report sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -489,4 +489,5 @@ $RECYCLE.BIN/
 ResourcesReport_*/
 ResourcesReport_*.zip
 report_output/
+report_v2/
 Tests/*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -483,3 +483,10 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+
+# Resource Discovery output
+.DS_Store
+ResourcesReport_*/
+ResourcesReport_*.zip
+report_output/
+Tests/*.zip

--- a/Extension/Metrics.ps1
+++ b/Extension/Metrics.ps1
@@ -1,4 +1,4 @@
-param($Subscriptions, $Resources, $Task ,$File, $Metrics, $TableStyle, $ConcurrencyLimit, $FilePath)
+param($Subscriptions, $Resources, $Task ,$File, $Metrics, $TableStyle, $ConcurrencyLimit, $FilePath, $ResourceIdDictionary, $ResourceNameDictionary, $ResourceSubDictionary, $ResourceGroupDictionary, $Obfuscate)
 
 if ($Task -eq 'Processing')
 {
@@ -365,6 +365,22 @@ if ($Task -eq 'Processing')
             } -ThrottleLimit $ConcurrencyLimit
 
             $defs.Clear()
+
+            if($Obfuscate)
+            {
+                foreach ($metric in $tmp.Metrics) 
+                {
+                    $obfuscatedID = $ResourceIdDictionary[$metric.ID]
+                    $obfuscatedName = $ResourceNameDictionary[$metric.ID]
+                    $obfuscatedSubscription = $ResourceSubDictionary[$metric.ID]
+                    $obfuscatedResourceGroup = $ResourceGroupDictionary[$metric.ID]
+
+                    $metric.ID = $obfuscatedID
+                    $metric.Name = $obfuscatedName
+                    $metric.Subscription = $obfuscatedSubscription
+                    $metric.ResourceGroup = $obfuscatedResourceGroup
+                }
+            }
 
             $outputPath = $FilePath + "_" + $rangeIdx + ".json"
             $tmp | ConvertTo-Json -depth 5 -compress | Out-File $outputPath -Encoding utf8

--- a/README.md
+++ b/README.md
@@ -126,11 +126,6 @@ You might get more than one authentication request due to different collector pr
 ./ResourceInventory.ps1 -ReportName "CompanyName" -Obfuscate
 ```
 
-**Obfuscated report with session reuse (skip re-authentication):**
-```powershell
-./ResourceInventory.ps1 -ReportName "CompanyName" -SubscriptionID "12345678-1234-1234-1234-123456789012" -Obfuscate -AutoAuth
-```
-
 ## Output Files
 
 Upon completion, the script generates reports in the `InventoryReports` folder:
@@ -166,7 +161,7 @@ Resources with names matching dev/test/qa patterns get a `nonprod_` prefix; all 
 
 **What is preserved:** Location, SKU, VM size, OS type, disk type, metrics values, consumption quantities, and all technical configuration data needed for analysis.
 
-**What is excluded:** When obfuscation is enabled, the transcript log (which contains raw console output with emails and paths) is excluded from the ZIP file. It remains on disk locally for debugging.
+**What is excluded:** When obfuscation is enabled, the transcript log is excluded from the ZIP file. The transcript contains raw console output including email addresses, subscription IDs, and file paths that cannot be reliably masked after the fact. It remains on disk locally for debugging but is not included in the deliverable package.
 
 ### Manual Compression (If Needed)
 
@@ -200,7 +195,6 @@ Compress-Archive -Path ./* -DestinationPath "CompanyName_ResourcesReport_$(Get-D
 | Parameter | Type | Description | Example |
 |-----------|------|-------------|----------|
 | `Obfuscate` | Switch | Replace resource IDs, names, subscriptions, and resource groups with masked values. Reports can be safely shared externally without exposing sensitive Azure environment details. | `-Obfuscate` |
-| `AutoAuth` | Switch | Reuse existing Azure CLI session instead of forcing re-authentication. Useful for repeated runs during testing. | `-AutoAuth` |
 
 ### Authentication Parameters
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ You might get more than one authentication request due to different collector pr
 ./ResourceInventory.ps1 -ReportName "CompanyName" -SkipConsumption
 ```
 
+**Generate obfuscated report (mask sensitive data before sharing):**
+```powershell
+./ResourceInventory.ps1 -ReportName "CompanyName" -Obfuscate
+```
+
+**Obfuscated report with session reuse (skip re-authentication):**
+```powershell
+./ResourceInventory.ps1 -ReportName "CompanyName" -SubscriptionID "12345678-1234-1234-1234-123456789012" -Obfuscate -AutoAuth
+```
+
 ## Output Files
 
 Upon completion, the script generates reports in the `InventoryReports` folder:
@@ -140,6 +150,23 @@ Upon completion, the script generates reports in the `InventoryReports` folder:
 1. **Locate the output:** Check the `InventoryReports` folder
 2. **Rename the ZIP file:** Include your company name (e.g., `CompanyName_ResourcesReport_2024-01-15.zip`)
 3. **Deliver to AWS team:** Send the renamed ZIP file for analysis
+
+### Obfuscation Mode
+
+When using `-Obfuscate`, the following data is masked in all output files:
+
+| Field | Masked Format | Example |
+|-------|--------------|---------|
+| Resource ID | `prod_<guid>` or `nonprod_<guid>` | `prod_a1b2c3d4-e5f6-7890-abcd-ef1234567890` |
+| Resource Name | `prod_<guid>` or `nonprod_<guid>` | `prod_f9e8d7c6-b5a4-3210-fedc-ba0987654321` |
+| Subscription | `prod_<guid>` or `nonprod_<guid>` | `prod_11223344-5566-7788-99aa-bbccddeeff00` |
+| Resource Group | `prod_<guid>` or `nonprod_<guid>` | `prod_aabbccdd-eeff-0011-2233-445566778899` |
+
+Resources with names matching dev/test/qa patterns get a `nonprod_` prefix; all others get `prod_`. This preserves environment classification without exposing real names.
+
+**What is preserved:** Location, SKU, VM size, OS type, disk type, metrics values, consumption quantities, and all technical configuration data needed for analysis.
+
+**What is excluded:** When obfuscation is enabled, the transcript log (which contains raw console output with emails and paths) is excluded from the ZIP file. It remains on disk locally for debugging.
 
 ### Manual Compression (If Needed)
 
@@ -164,7 +191,16 @@ Compress-Archive -Path ./* -DestinationPath "CompanyName_ResourcesReport_$(Get-D
 | Parameter | Type | Description | Default | Example |
 |-----------|------|-------------|---------|----------|
 | `ConcurrencyLimit` | Integer | Parallel execution limit | 6 | `-ConcurrencyLimit 8` |
+| `CollectionDays` | Integer | Number of days for consumption lookback | 31 | `-CollectionDays 14` |
 | `SkipConsumption` | Switch | Skip cost/billing data collection | False | `-SkipConsumption` |
+| `SkipMetrics` | Switch | Skip Azure Monitor metrics collection | False | `-SkipMetrics` |
+
+### Privacy & Obfuscation Parameters
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|----------|
+| `Obfuscate` | Switch | Replace resource IDs, names, subscriptions, and resource groups with masked values. Reports can be safely shared externally without exposing sensitive Azure environment details. | `-Obfuscate` |
+| `AutoAuth` | Switch | Reuse existing Azure CLI session instead of forcing re-authentication. Useful for repeated runs during testing. | `-AutoAuth` |
 
 ### Authentication Parameters
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,12 @@ You might get more than one authentication request due to different collector pr
 
 **Generate obfuscated report (mask sensitive data before sharing):**
 ```powershell
-./ResourceInventory.ps1 -ReportName "CompanyName" -Obfuscate
+./ResourceInventory.ps1 -ReportName "CompanyName" -ObfuscateData
+```
+
+**Obfuscated report with tags also stripped:**
+```powershell
+./ResourceInventory.ps1 -ReportName "CompanyName" -ObfuscateData -ObfuscateTags
 ```
 
 ## Output Files
@@ -194,7 +199,8 @@ Compress-Archive -Path ./* -DestinationPath "CompanyName_ResourcesReport_$(Get-D
 
 | Parameter | Type | Description | Example |
 |-----------|------|-------------|----------|
-| `Obfuscate` | Switch | Replace resource IDs, names, subscriptions, and resource groups with masked values. Reports can be safely shared externally without exposing sensitive Azure environment details. | `-Obfuscate` |
+| `ObfuscateData` | Switch | Replace resource IDs, names, subscriptions, and resource groups with masked values. Reports can be safely shared externally without exposing sensitive Azure environment details. A reverse-lookup dictionary is saved locally. | `-ObfuscateData` |
+| `ObfuscateTags` | Switch | Used with `-ObfuscateData`. Strips resource tags from the output. Tags can contain sensitive data like resource IDs, cost centers, or internal project names. Without this flag, tags are preserved for analysis. | `-ObfuscateTags` |
 
 ### Authentication Parameters
 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -908,6 +908,36 @@ FinalizeOutputs
 
 Write-Log -Message ("Compressing Resources Output: {0}" -f $Global:ZipOutputFile) -Severity 'Info'
 
+if($Obfuscate.IsPresent)
+{
+    $Global:DictionaryFile = ($DefaultPath + "ObfuscationDictionary_"+ $Global:ReportName + "_" + $CurrentDateTime + ".json")
+    
+    $dictionary = @{
+        GeneratedAt = (Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+        ResourceIdMap = @{}
+        ResourceNameMap = @{}
+        SubscriptionMap = @{}
+        ResourceGroupMap = @{}
+    }
+
+    foreach ($key in $resourceIdDictionary.Keys) {
+        $dictionary.ResourceIdMap[$resourceIdDictionary[$key]] = $key
+    }
+    foreach ($key in $resourceNameDictionary.Keys) {
+        $dictionary.ResourceNameMap[$resourceNameDictionary[$key]] = $key
+    }
+    foreach ($key in $resourceSubscriptionDictionary.Keys) {
+        $dictionary.SubscriptionMap[$resourceSubscriptionDictionary[$key]] = $key
+    }
+    foreach ($key in $resourceResourceGroupDictionary.Keys) {
+        $dictionary.ResourceGroupMap[$resourceResourceGroupDictionary[$key]] = $key
+    }
+
+    $dictionary | ConvertTo-Json -depth 5 | Out-File $Global:DictionaryFile -Encoding utf8
+    Write-Log -Message ("Obfuscation dictionary saved locally: {0}" -f $Global:DictionaryFile) -Severity 'Success'
+    Write-Log -Message ("IMPORTANT: Keep this file secure. It maps obfuscated IDs back to real resource names.") -Severity 'Warning'
+}
+
 if($EnableLogs.IsPresent)
 {
     $Global:Logging | ConvertTo-Json -depth 5 -compress | Out-File $Global:LogFile

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -8,10 +8,9 @@ param ($TenantID,
         [switch]$SkipConsumption, 
         [switch]$DeviceLogin,
         [switch]$EnableLogs,
-        [switch]$Obfuscate,
-        [switch]$AutoAuth,
+        [switch]$ObfuscateData,
+        [switch]$ObfuscateTags,
         $ConcurrencyLimit = 6,
-        $CollectionDays = 31,
         $ReportName = 'ResourcesReport', 
         $OutputDirectory)
 
@@ -245,23 +244,20 @@ Function RunInventorySetup()
         Write-Host $CurrentCloudEnvName.name -ForegroundColor Green
 
         # Check if already authenticated
-        if ($AutoAuth.IsPresent)
+        $existingAccount = az account show --output json --only-show-errors 2>$null | ConvertFrom-Json
+        if ($null -ne $existingAccount)
         {
-            $existingAccount = az account show --output json --only-show-errors 2>$null | ConvertFrom-Json
-            if ($null -ne $existingAccount)
-            {
-                Write-Log -Message ("Already authenticated as: {0}" -f $existingAccount.user.name) -Severity 'Success'
+            Write-Log -Message ("Already authenticated as: {0}" -f $existingAccount.user.name) -Severity 'Success'
 
-                if (!$TenantID -or $existingAccount.tenantId -eq $TenantID)
-                {
-                    $Global:Subscriptions = @(az account list --output json --only-show-errors | ConvertFrom-Json)
-                    if ($TenantID) { $Global:Subscriptions = @($Subscriptions | Where-Object { $_.tenantID -eq $TenantID }) }
-                    return
-                }
-                else
-                {
-                    Write-Log -Message ("Current session is for tenant {0}, but requested tenant is {1}. Re-authenticating." -f $existingAccount.tenantId, $TenantID) -Severity 'Warning'
-                }
+            if (!$TenantID -or $existingAccount.tenantId -eq $TenantID)
+            {
+                $Global:Subscriptions = @(az account list --output json --only-show-errors | ConvertFrom-Json)
+                if ($TenantID) { $Global:Subscriptions = @($Subscriptions | Where-Object { $_.tenantID -eq $TenantID }) }
+                return
+            }
+            else
+            {
+                Write-Log -Message ("Current session is for tenant {0}, but requested tenant is {1}. Re-authenticating." -f $existingAccount.tenantId, $TenantID) -Severity 'Warning'
             }
         }
     
@@ -513,7 +509,7 @@ Function RunInventorySetup()
     ResourceInventoryLoop
     ResourceInventoryAvd
 
-    if($Obfuscate.IsPresent)
+    if($ObfuscateData.IsPresent)
     {
         foreach ($resourceItem in $Global:Resources) 
         {
@@ -579,7 +575,7 @@ function ExecuteInventoryProcessing()
             
             $Global:AzMetrics = New-Object PSObject
             $Global:AzMetrics | Add-Member -MemberType NoteProperty -Name Metrics -Value NotSet
-            $Global:AzMetrics.Metrics = & $MetricPath -Subscriptions $Subscriptions -Resources $Resources -Task "Processing" -File $file -Metrics $null -TableStyle $null -ConcurrencyLimit $ConcurrencyLimit -FilePath $metricsFilePath -ResourceIdDictionary $resourceIdDictionary -ResourceNameDictionary $resourceNameDictionary -ResourceSubDictionary $resourceSubscriptionDictionary -ResourceGroupDictionary $resourceResourceGroupDictionary -Obfuscate $Obfuscate.IsPresent
+            $Global:AzMetrics.Metrics = & $MetricPath -Subscriptions $Subscriptions -Resources $Resources -Task "Processing" -File $file -Metrics $null -TableStyle $null -ConcurrencyLimit $ConcurrencyLimit -FilePath $metricsFilePath -ResourceIdDictionary $resourceIdDictionary -ResourceNameDictionary $resourceNameDictionary -ResourceSubDictionary $resourceSubscriptionDictionary -ResourceGroupDictionary $resourceResourceGroupDictionary -Obfuscate $ObfuscateData.IsPresent
         }
     }
 
@@ -665,7 +661,7 @@ function ExecuteInventoryProcessing()
 
             $result = & $Module -SCPath $SCPath -Sub $Subscriptions -Resources $Resource -Task "Processing" -File $file -SmaResources $null -TableStyle $null -Metrics $Global:AzMetrics -ResourceIdDictionary $resourceIdDictionary
 
-            if($Obfuscate.IsPresent)
+            if($ObfuscateData.IsPresent)
             {
                 foreach ($resourceItem in $result) 
                 {
@@ -678,6 +674,11 @@ function ExecuteInventoryProcessing()
                     $resourceItem.Name = $obfuscatedName
                     $resourceItem.Subscription = $obfuscatedSubscription
                     $resourceItem.ResourceGroup = $obfuscatedResourceGroup
+
+                    if($ObfuscateTags.IsPresent -and $resourceItem.ContainsKey('Tags'))
+                    {
+                        $resourceItem.Tags = $null
+                    }
                 }
             }
 
@@ -820,11 +821,12 @@ function ExecuteInventoryProcessing()
                     
                     $instanceObject | Add-Member -MemberType NoteProperty -Name "Microsoft.Resources" -Value $additionalInfoInstance
 
-                    if($Obfuscate.IsPresent)
+                    if($ObfuscateData.IsPresent)
                     {
                         if (-not $resourceIdDictionary.ContainsKey($usageDataExport[$item].ResourceId)) 
                         {
-                            $obfuscatedID = "prod_" + [guid]::NewGuid().ToString()
+                            $prefix = if ($usageDataExport[$item].ResourceId -match "dev|test|qa|tst|development|non-prod|uat|nonprod") { "nonprod_" } else { "prod_" }
+                            $obfuscatedID = $prefix + [guid]::NewGuid().ToString()
                             $resourceIdDictionary.Add($usageDataExport[$item].ResourceId, $obfuscatedID)
                             $usageDataExport[$item].ResourceId = $obfuscatedID
                             $instanceObject.'Microsoft.Resources'.resourceUri = $obfuscatedID
@@ -908,7 +910,7 @@ FinalizeOutputs
 
 Write-Log -Message ("Compressing Resources Output: {0}" -f $Global:ZipOutputFile) -Severity 'Info'
 
-if($Obfuscate.IsPresent)
+if($ObfuscateData.IsPresent)
 {
     $Global:DictionaryFile = ($DefaultPath + "ObfuscationDictionary_"+ $Global:ReportName + "_" + $CurrentDateTime + ".json")
     
@@ -935,7 +937,15 @@ if($Obfuscate.IsPresent)
 
     $dictionary | ConvertTo-Json -depth 5 | Out-File $Global:DictionaryFile -Encoding utf8
     Write-Log -Message ("Obfuscation dictionary saved locally: {0}" -f $Global:DictionaryFile) -Severity 'Success'
-    Write-Log -Message ("IMPORTANT: Keep this file secure. It maps obfuscated IDs back to real resource names.") -Severity 'Warning'
+    Write-Log -Message ("") -Severity 'Info'
+    Write-Log -Message ("=== OBFUSCATION NOTICE ===") -Severity 'Warning'
+    Write-Log -Message ("The following files remain LOCAL and should NOT be shared:") -Severity 'Warning'
+    Write-Log -Message ("  - Dictionary: {0}" -f $Global:DictionaryFile) -Severity 'Warning'
+    Write-Log -Message ("  - Transcript: {0}" -f $Global:PowerShellTranscriptFile) -Severity 'Warning'
+    Write-Log -Message ("") -Severity 'Info'
+    Write-Log -Message ("The ZIP file is safe to share with AWS or partners.") -Severity 'Success'
+    Write-Log -Message ("Partners may ask about obfuscated names (e.g. 'prod_a1b2c3d4-...'). Use the dictionary file to look up the real resource name and respond.") -Severity 'Info'
+    Write-Log -Message ("Delete the dictionary and transcript when no longer needed for security.") -Severity 'Warning'
 }
 
 if($EnableLogs.IsPresent)
@@ -957,7 +967,7 @@ if($SkipConsumption.IsPresent -or !$consumptionCreated)
 
 $jsonWildCard = $DefaultPath + "*.json"
 
-if($Obfuscate.IsPresent)
+if($ObfuscateData.IsPresent)
 {
     $compressionOutput = @{
         Path = $Global:File, $Global:ConsumptionFileCsv, $jsonWildCard

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -8,7 +8,10 @@ param ($TenantID,
         [switch]$SkipConsumption, 
         [switch]$DeviceLogin,
         [switch]$EnableLogs,
+        [switch]$Obfuscate,
+        [switch]$AutoAuth,
         $ConcurrencyLimit = 6,
+        $CollectionDays = 31,
         $ReportName = 'ResourcesReport', 
         $OutputDirectory)
 
@@ -17,7 +20,7 @@ if ($Debug.IsPresent) {$DebugPreference = 'Continue'}
 
 if ($Debug.IsPresent) {$ErrorActionPreference = "Continue" }Else {$ErrorActionPreference = "silentlycontinue" }
 
-Write-Debug ('Debbuging Mode: On. ErrorActionPreference was set to "Continue", every error will be presented.')
+Write-Debug ('Debugging Mode: On. ErrorActionPreference was set to "Continue", every error will be presented.')
 
 Function Write-Log([string]$Message, [string]$Severity)
 {
@@ -65,6 +68,10 @@ function Variables
     $Global:Logging | Add-Member -MemberType NoteProperty -Name Logs -Value NotSet
     $Global:Logging.Logs = [System.Collections.Generic.List[object]]::new()
 
+    $Global:resourceIdDictionary = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+    $Global:resourceNameDictionary = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+    $Global:resourceSubscriptionDictionary = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+    $Global:resourceResourceGroupDictionary = New-Object 'System.Collections.Generic.Dictionary[string,string]'
 
     $Global:RawRepo = 'https://raw.githubusercontent.com/awslabs/resource-discovery-for-azure/main'
     $Global:TableStyle = "Medium15"
@@ -94,13 +101,14 @@ Function RunInventorySetup()
 
         $azCliVersion = az --version
 
-        Write-Log -Message ('CLI Version: {0}' -f $azCliVersion[0]) -Severity 'Success'
-    
         if ($null -eq $azCliVersion) 
         {
-            Read-Host "Azure CLI Not Found. Please install to and run the script again, press <Enter> to exit." -ForegroundColor Red
+            Write-Log -Message ("Azure CLI Not Found. Please install and run the script again.") -Severity 'Error'
+            Read-Host "Press <Enter> to exit"
             Exit
         }
+
+        Write-Log -Message ('CLI Version: {0}' -f $azCliVersion[0]) -Severity 'Success'
 
         Write-Log -Message ('Verifying Azure CLI Extension...') -Severity 'Info'
 
@@ -109,7 +117,7 @@ Function RunInventorySetup()
 
         Write-Log -Message ('Current Resource-Graph Extension Version: {0}' -f $azCliExtension.Version) -Severity 'Success'
         
-        $azCliExtensionVersion = $azcliExt | Where-Object {$_.name -eq 'resource-graph'}
+        $azCliExtensionVersion = $azCliExtension | Where-Object {$_.name -eq 'resource-graph'}
     
         if (!$azCliExtensionVersion) 
         {
@@ -120,21 +128,22 @@ Function RunInventorySetup()
 
         Write-Log -Message ('Checking Azure PowerShell Module...') -Severity 'Info'
 
-        $VarAzPs = Get-InstalledModule -Name Az -ErrorAction silentlycontinue
+        $VarAzPs = Get-Module -Name Az -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
 
-        Write-Log -Message ('Azure PowerShell Module Version: {0}.{1}.{2}' -f [string]$VarAzPs.Version.Major,  [string]$VarAzPs.Version.Minor, [string]$VarAzPs.Version.Build) -Severity 'Success'
-
-        IF($null -eq $VarAzPs)
+        if ($null -ne $VarAzPs)
         {
-            Write-Log -Message ('Trying to install Azure PowerShell Module...') -Severity 'Warning'
-            Install-Module -Name Az -Repository PSGallery -Force
+            Write-Log -Message ('Azure PowerShell Module Version: {0}' -f $VarAzPs.Version) -Severity 'Success'
         }
-
-        $VarAzPs = Get-InstalledModule -Name Az -ErrorAction silentlycontinue
+        else
+        {
+            Write-Log -Message ('Azure PowerShell Module not found. Trying to install...') -Severity 'Warning'
+            Install-Module -Name Az -Repository PSGallery -Force -Scope CurrentUser
+            $VarAzPs = Get-Module -Name Az -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
+        }
 
         if ($null -eq $VarAzPs) 
         {
-            Write-Log -Message ('Admininstrator rights required to install Azure PowerShell Module. Press <Enter> to finish script') -Severity 'Error'
+            Write-Log -Message ('Failed to install Azure PowerShell Module. Press <Enter> to finish script') -Severity 'Error'
             Read-Host ''
             Exit
         }
@@ -142,21 +151,22 @@ Function RunInventorySetup()
 
         Write-Log -Message ('Checking ImportExcel Module...') -Severity 'Info'
     
-        $VarExcel = Get-InstalledModule -Name ImportExcel -ErrorAction silentlycontinue
+        $VarExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
     
-        Write-Log -Message ('ImportExcel Module Version: {0}.{1}.{2}' -f [string]$VarExcel.Version.Major,  [string]$VarExcel.Version.Minor, [string]$VarExcel.Version.Build) -Severity 'Success'
-    
-        if ($null -eq $VarExcel) 
+        if ($null -ne $VarExcel)
         {
-            Write-Log -Message ('Trying to install ImportExcel Module...') -Severity 'Warning'
-            Install-Module -Name ImportExcel -Force
+            Write-Log -Message ('ImportExcel Module Version: {0}' -f $VarExcel.Version) -Severity 'Success'
+        }
+        else
+        {
+            Write-Log -Message ('ImportExcel Module not found. Trying to install...') -Severity 'Warning'
+            Install-Module -Name ImportExcel -Force -Scope CurrentUser
+            $VarExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
         }
     
-        $VarExcel = Get-InstalledModule -Name ImportExcel -ErrorAction silentlycontinue
-    
         if ($null -eq $VarExcel) 
         {
-            Write-Log -Message ('Admininstrator rights required to install ImportExcel Module. Press <Enter> to finish script') -Severity 'Error'
+            Write-Log -Message ('Failed to install ImportExcel Module. Press <Enter> to finish script') -Severity 'Error'
             Read-Host ''
             Exit
         }
@@ -233,6 +243,27 @@ Function RunInventorySetup()
     
         $CurrentCloudEnvName = $CloudEnv | Where-Object {$_.isActive -eq 'True'}
         Write-Host $CurrentCloudEnvName.name -ForegroundColor Green
+
+        # Check if already authenticated
+        if ($AutoAuth.IsPresent)
+        {
+            $existingAccount = az account show --output json --only-show-errors 2>$null | ConvertFrom-Json
+            if ($null -ne $existingAccount)
+            {
+                Write-Log -Message ("Already authenticated as: {0}" -f $existingAccount.user.name) -Severity 'Success'
+
+                if (!$TenantID -or $existingAccount.tenantId -eq $TenantID)
+                {
+                    $Global:Subscriptions = @(az account list --output json --only-show-errors | ConvertFrom-Json)
+                    if ($TenantID) { $Global:Subscriptions = @($Subscriptions | Where-Object { $_.tenantID -eq $TenantID }) }
+                    return
+                }
+                else
+                {
+                    Write-Log -Message ("Current session is for tenant {0}, but requested tenant is {1}. Re-authenticating." -f $existingAccount.tenantId, $TenantID) -Severity 'Warning'
+                }
+            }
+        }
     
         if (!$TenantID) 
         {
@@ -253,7 +284,7 @@ Function RunInventorySetup()
             }
             else 
             {
-                Write-Log -Message ('Using device login') -Severity 'Info'
+                Write-Log -Message ('Using browser login') -Severity 'Info'
                 az login --only-show-errors | Out-Null
                 Connect-AzAccount | Out-Null
             }
@@ -481,6 +512,32 @@ Function RunInventorySetup()
     GetSubscriptionsData
     ResourceInventoryLoop
     ResourceInventoryAvd
+
+    if($Obfuscate.IsPresent)
+    {
+        foreach ($resourceItem in $Global:Resources) 
+        {
+            if ($resourceItem.name -match "dev|test|qa|tst|development|non-prod|uat|nonprod") 
+            {
+                $obfuscatedID = "nonprod_" + [guid]::NewGuid().ToString()
+                $obfuscatedName = "nonprod_" + [guid]::NewGuid().ToString()
+                $obfuscatedSubscription = "nonprod_" + [guid]::NewGuid().ToString()
+                $obfuscatedResourceGroup = "nonprod_" + [guid]::NewGuid().ToString()
+            }
+            else
+            {
+                $obfuscatedID = "prod_" + [guid]::NewGuid().ToString()
+                $obfuscatedName = "prod_" + [guid]::NewGuid().ToString()
+                $obfuscatedSubscription = "prod_" + [guid]::NewGuid().ToString()
+                $obfuscatedResourceGroup = "prod_" + [guid]::NewGuid().ToString()
+            }          
+
+            $resourceIdDictionary.Add($resourceItem.ID, $obfuscatedID)
+            $resourceNameDictionary.Add($resourceItem.ID, $obfuscatedName)
+            $resourceSubscriptionDictionary.Add($resourceItem.ID, $obfuscatedSubscription)
+            $resourceResourceGroupDictionary.Add($resourceItem.ID, $obfuscatedResourceGroup)
+        }
+    }
 }
 
 function ExecuteInventoryProcessing()
@@ -522,7 +579,7 @@ function ExecuteInventoryProcessing()
             
             $Global:AzMetrics = New-Object PSObject
             $Global:AzMetrics | Add-Member -MemberType NoteProperty -Name Metrics -Value NotSet
-            $Global:AzMetrics.Metrics = & $MetricPath -Subscriptions $Subscriptions -Resources $Resources -Task "Processing" -File $file -Metrics $null -TableStyle $null -ConcurrencyLimit $ConcurrencyLimit -FilePath $metricsFilePath
+            $Global:AzMetrics.Metrics = & $MetricPath -Subscriptions $Subscriptions -Resources $Resources -Task "Processing" -File $file -Metrics $null -TableStyle $null -ConcurrencyLimit $ConcurrencyLimit -FilePath $metricsFilePath -ResourceIdDictionary $resourceIdDictionary -ResourceNameDictionary $resourceNameDictionary -ResourceSubDictionary $resourceSubscriptionDictionary -ResourceGroupDictionary $resourceResourceGroupDictionary -Obfuscate $Obfuscate.IsPresent
         }
     }
 
@@ -606,7 +663,24 @@ function ExecuteInventoryProcessing()
             
             Write-Log -Message ("Service Processing: {0}" -f $ModName) -Severity 'Success'
 
-            $result = & $Module -SCPath $SCPath -Sub $Subscriptions -Resources $Resource -Task "Processing" -File $file -SmaResources $null -TableStyle $null -Metrics $Global:AzMetrics
+            $result = & $Module -SCPath $SCPath -Sub $Subscriptions -Resources $Resource -Task "Processing" -File $file -SmaResources $null -TableStyle $null -Metrics $Global:AzMetrics -ResourceIdDictionary $resourceIdDictionary
+
+            if($Obfuscate.IsPresent)
+            {
+                foreach ($resourceItem in $result) 
+                {
+                    $obfuscatedID = $resourceIdDictionary[$resourceItem.ID]
+                    $obfuscatedName = $resourceNameDictionary[$resourceItem.ID]
+                    $obfuscatedSubscription = $resourceSubscriptionDictionary[$resourceItem.ID]
+                    $obfuscatedResourceGroup = $resourceResourceGroupDictionary[$resourceItem.ID]
+                
+                    $resourceItem.ID = $obfuscatedID
+                    $resourceItem.Name = $obfuscatedName
+                    $resourceItem.Subscription = $obfuscatedSubscription
+                    $resourceItem.ResourceGroup = $obfuscatedResourceGroup
+                }
+            }
+
             $Global:SmaResources | Add-Member -MemberType NoteProperty -Name $ModName -Value NotSet
             $Global:SmaResources.$ModName = $result
 
@@ -640,7 +714,7 @@ function ExecuteInventoryProcessing()
             $c = [math]::Round($c)
             
             Write-Log -Message ("Running Services: $Service") -Severity 'Info'
-            $ProcessResults = & $Service.FullName -SCPath $PSScriptRoot -Sub $null -Resources $null -Task "Reporting" -File $file -SmaResources $Global:SmaResources -TableStyle $Global:TableStyle -Metrics $null
+            $ProcessResults = & $Service.FullName -SCPath $PSScriptRoot -Sub $null -Resources $null -Task "Reporting" -File $file -SmaResources $Global:SmaResources -TableStyle $Global:TableStyle -Metrics $null -ResourceIdDictionary $resourceIdDictionary
 
             $ReportCounter++
         }
@@ -746,6 +820,23 @@ function ExecuteInventoryProcessing()
                     
                     $instanceObject | Add-Member -MemberType NoteProperty -Name "Microsoft.Resources" -Value $additionalInfoInstance
 
+                    if($Obfuscate.IsPresent)
+                    {
+                        if (-not $resourceIdDictionary.ContainsKey($usageDataExport[$item].ResourceId)) 
+                        {
+                            $obfuscatedID = "prod_" + [guid]::NewGuid().ToString()
+                            $resourceIdDictionary.Add($usageDataExport[$item].ResourceId, $obfuscatedID)
+                            $usageDataExport[$item].ResourceId = $obfuscatedID
+                            $instanceObject.'Microsoft.Resources'.resourceUri = $obfuscatedID
+                        } 
+                        else 
+                        {
+                            $obfuscatedID = $ResourceIdDictionary[$usageDataExport[$item].ResourceId]
+                            $usageDataExport[$item].ResourceId = $obfuscatedID
+                            $instanceObject.'Microsoft.Resources'.resourceUri = $obfuscatedID
+                        }
+                    }
+
                     $usageDataExport[$item].InstanceData = $instanceObject | ConvertTo-Json -Compress
 
                     $newUsageDataExport.Add($usageDataExport[$item]) | Out-Null
@@ -824,22 +915,34 @@ if($EnableLogs.IsPresent)
 
 if($SkipMetrics.IsPresent)
 {
-    "Metrics Not Gathered" | ConvertTo-Json -depth 5 -compress | Out-File $Global:MetricsJsonFile 
+    @{ Metrics = @() } | ConvertTo-Json -depth 5 -compress | Out-File $Global:MetricsJsonFile -Encoding utf8
 }
 
 $consumptionCreated = Test-Path -Path $Global:ConsumptionFileCsv
 
 if($SkipConsumption.IsPresent -or !$consumptionCreated)
 {
-    Out-File $Global:ConsumptionFileCsv
+    "InstanceData,MeterCategory,MeterId,MeterName,MeterRegion,MeterSubCategory,Quantity,Unit,UsageStartTime,UsageEndTime,ResourceId,ResourceLocation,ConsumptionMeter,ReservationId,ReservationOrderId" | Out-File $Global:ConsumptionFileCsv -Encoding utf8
 }
 
 $jsonWildCard = $DefaultPath + "*.json"
 
-$compressionOutput = @{
-    Path = $Global:File, $Global:ConsumptionFileCsv, $Global:PowerShellTranscriptFile, $jsonWildCard
-    CompressionLevel = 'Fastest'
-    DestinationPath = $Global:ZipOutputFile
+if($Obfuscate.IsPresent)
+{
+    $compressionOutput = @{
+        Path = $Global:File, $Global:ConsumptionFileCsv, $jsonWildCard
+        CompressionLevel = 'Fastest'
+        DestinationPath = $Global:ZipOutputFile
+    }
+    Write-Log -Message ('Obfuscate mode: transcript log excluded from zip (kept locally for debug)') -Severity 'Info'
+}
+else
+{
+    $compressionOutput = @{
+        Path = $Global:File, $Global:ConsumptionFileCsv, $Global:PowerShellTranscriptFile, $jsonWildCard
+        CompressionLevel = 'Fastest'
+        DestinationPath = $Global:ZipOutputFile
+    }
 }
 
 try 

--- a/Services/Analytics/Databricks.ps1
+++ b/Services/Analytics/Databricks.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if($Task -eq 'Processing') 
 {

--- a/Services/Analytics/EvtHub.ps1
+++ b/Services/Analytics/EvtHub.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {
@@ -65,6 +65,6 @@ else
 
         $ExcelVar | 
         ForEach-Object { [PSCustomObject]$_ } | Select-Object -Unique $Exc | 
-        Export-Excel -Path $File -WorksheetName 'Event Hubs' -AutoSize -MaxAutoSizeRows 100 -TableName $TableName -TableStyle $tableStyle -ConditionalText $condtxt -Style $Style, $StyleCost
+        Export-Excel -Path $File -WorksheetName 'Event Hubs' -AutoSize -MaxAutoSizeRows 100 -TableName $TableName -TableStyle $tableStyle -ConditionalText $condtxt -Style $Style
     }
 }

--- a/Services/Analytics/MachineLearning.ps1
+++ b/Services/Analytics/MachineLearning.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 If ($Task -eq 'Processing') 
 {
@@ -44,9 +44,9 @@ If ($Task -eq 'Processing')
 }
 else 
 {
-    if ($SmaResources.AzureML) 
+    if ($SmaResources.MachineLearning) 
     {
-        $TableName = ('AzureMLTable_'+($SmaResources.AzureML.id | Select-Object -Unique).count)
+        $TableName = ('AzureMLTable_'+($SmaResources.MachineLearning.id | Select-Object -Unique).count)
         $Style = New-ExcelStyle -HorizontalAlignment Center -AutoSize -NumberFormat 0
 
         $condtxt = @()
@@ -66,7 +66,7 @@ else
         $Exc.Add('ApplicationInsight')
         $Exc.Add('CreatedTime')  
 
-        $ExcelVar = $SmaResources.AzureML
+        $ExcelVar = $SmaResources.MachineLearning
 
         $ExcelVar | 
         ForEach-Object { [PSCustomObject]$_ } | Select-Object -Unique $Exc | 

--- a/Services/Analytics/Streamanalytics.ps1
+++ b/Services/Analytics/Streamanalytics.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Analytics/Synapse.ps1
+++ b/Services/Analytics/Synapse.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Analytics/WrkSpace.ps1
+++ b/Services/Analytics/WrkSpace.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {
@@ -20,8 +20,6 @@ if ($Task -eq 'Processing')
                 'ResourceGroup'     = $1.RESOURCEGROUP;
                 'Name'              = $1.NAME;
                 'Location'          = $1.LOCATION;
-                'Currency'          = $Cost.Currency;
-                'DailyCost'         = '{0:C}' -f $Cost.Cost;
                 'SKU'               = $data.sku.name;
                 'RetentionDays'     = $data.retentionInDays;
                 'DailyQuotaGB'      = [decimal]$data.workspaceCapping.dailyQuotaGb;

--- a/Services/Compute/ARCServers.ps1
+++ b/Services/Compute/ARCServers.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Compute/ARO.ps1
+++ b/Services/Compute/ARO.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Compute/AVD.ps1
+++ b/Services/Compute/AVD.ps1
@@ -43,8 +43,8 @@ if ($Task -eq 'Processing')
                     'AVDAgentVersion'    = $2.properties.agentVersion;
                     'AllowNewSession'    = $2.properties.allowNewSession;
                     'UpdateStatus'       = $2.properties.updateState;
-                    'HostId'             = $vmsessionhosts.Id;
-                    'Hostname'           = $vmsessionhosts.name;
+                    'HostId'             = if (![string]::IsNullOrEmpty($vmsessionhosts.Id)) { $ResourceIdDictionary[$vmsessionhosts.Id] } else { $null };
+                    'Hostname'           = if (![string]::IsNullOrEmpty($vmsessionhosts.Id)) { $ResourceIdDictionary[$vmsessionhosts.Id] } else { $null };
                     'VMSize'             = $vmsessionhosts.properties.hardwareProfile.vmsize;
                     'OSType'             = $vmsessionhosts.properties.storageProfile.osdisk.ostype;
                     'VMDiskType'         = $vmsessionhosts.properties.storageProfile.osdisk.managedDisk.storageAccountType;

--- a/Services/Compute/AVD.ps1
+++ b/Services/Compute/AVD.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Compute/AppServicePlan.ps1
+++ b/Services/Compute/AppServicePlan.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Compute/AppServices.ps1
+++ b/Services/Compute/AppServices.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 If ($Task -eq 'Processing')
 {

--- a/Services/Compute/AppServices.ps1
+++ b/Services/Compute/AppServices.ps1
@@ -26,7 +26,7 @@ If ($Task -eq 'Processing')
                 'AvailabilityState'             = $data.availabilityState;
                 'SiteProperties'                = $data.siteProperties;          
                 'ContainerSize'                 = $data.containerSize;
-                'ServerFarmId'                  = $data.serverFarmId;
+                'ServerFarmId'                  = if (![string]::IsNullOrEmpty($data.serverFarmId) -and $null -ne $ResourceIdDictionary) { $ResourceIdDictionary[$data.serverFarmId] } else { $data.serverFarmId };
             }
 
             $tmp += $obj

--- a/Services/Compute/CloudServices.ps1
+++ b/Services/Compute/CloudServices.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Compute/VMWare.ps1
+++ b/Services/Compute/VMWare.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Compute/VirtualMachines.ps1
+++ b/Services/Compute/VirtualMachines.ps1
@@ -93,7 +93,7 @@ If ($Task -eq 'Processing')
                 'PowerState'                    = $powerState;
                 'Zones'                         = $vm.zones.count;
                 'CreatedTime'                   = $timecreated;
-                'Tags'                          = $tags;
+                'Tags'                          = if ($null -ne $ResourceIdDictionary) { $null } else { $tags };
             }
 
             $tmp += $obj

--- a/Services/Compute/VirtualMachines.ps1
+++ b/Services/Compute/VirtualMachines.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 If ($Task -eq 'Processing')
 {
@@ -9,11 +9,19 @@ If ($Task -eq 'Processing')
 
     foreach($location in ($virtualMachines | Select-Object -ExpandProperty location -Unique))
     {
-        foreach ($vmsize in ( az vm list-sizes -l $location | ConvertFrom-Json))
+        $DebugPreference = 'SilentlyContinue'
+        $skus = Get-AzComputeResourceSku -Location $location | Where-Object { $_.ResourceType -eq 'virtualMachines' }
+        $DebugPreference = 'Continue'
+
+        foreach ($vmsize in $skus)
         {
-            $vmsizemap[$vmsize.name] = @{
-                CPU = $vmSize.numberOfCores
-                RAM = [math]::Max($vmSize.memoryInMB / 1024, 0) 
+            $cpuCap = ($vmsize.Capabilities | Where-Object { $_.Name -eq 'vCPUs' }).Value
+            $memCap = ($vmsize.Capabilities | Where-Object { $_.Name -eq 'MemoryGB' }).Value
+            if ($null -ne $cpuCap -and -not $vmsizemap.ContainsKey($vmsize.Name)) {
+                $vmsizemap[$vmsize.Name] = @{
+                    CPU = [int]$cpuCap
+                    RAM = [math]::Max([decimal]$memCap, 0)
+                }
             }
         }
     }

--- a/Services/Compute/VirtualMachines.ps1
+++ b/Services/Compute/VirtualMachines.ps1
@@ -93,7 +93,7 @@ If ($Task -eq 'Processing')
                 'PowerState'                    = $powerState;
                 'Zones'                         = $vm.zones.count;
                 'CreatedTime'                   = $timecreated;
-                'Tags'                          = if ($null -ne $ResourceIdDictionary) { $null } else { $tags };
+                'Tags'                          = $tags;
             }
 
             $tmp += $obj

--- a/Services/Compute/VirtualMachines.ps1
+++ b/Services/Compute/VirtualMachines.ps1
@@ -79,7 +79,7 @@ If ($Task -eq 'Processing')
                 'Size'                          = $data.hardwareProfile.vmSize;
                 'CPU'                           = $cpus;
                 'Memory'                        = $ram;
-                'Set'                           = $data.virtualMachineScaleSet.id;
+                'Set'                           = if (![string]::IsNullOrEmpty($data.virtualMachineScaleSet.id) -and $null -ne $ResourceIdDictionary) { $ResourceIdDictionary[$data.virtualMachineScaleSet.id] } else { $data.virtualMachineScaleSet.id };
                 'ImageReference'                = $data.storageProfile.imageReference.publisher;
                 'ImageVersion'                  = $data.storageProfile.imageReference.exactVersion;
                 'ImageSku'                      = $data.storageProfile.imageReference.sku;

--- a/Services/Containers/AKS.ps1
+++ b/Services/Containers/AKS.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Containers/CONTAINER.ps1
+++ b/Services/Containers/CONTAINER.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Containers/REGISTRIES.ps1
+++ b/Services/Containers/REGISTRIES.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Containers/VMSS.ps1
+++ b/Services/Containers/VMSS.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {
@@ -11,11 +11,19 @@ if ($Task -eq 'Processing')
 
     foreach($location in ($vmss | Select-Object -ExpandProperty location -Unique))
     {
-        foreach ($vmsize in (az vm list-sizes -l $location | ConvertFrom-Json))
+        $DebugPreference = 'SilentlyContinue'
+        $skus = Get-AzComputeResourceSku -Location $location | Where-Object { $_.ResourceType -eq 'virtualMachines' }
+        $DebugPreference = 'Continue'
+
+        foreach ($vmsize in $skus)
         {
-            $vmsizemap[$vmsize.name] = @{
-                CPU = $vmSize.numberOfCores
-                RAM = [math]::Max($vmSize.memoryInMB / 1024, 0) 
+            $cpuCap = ($vmsize.Capabilities | Where-Object { $_.Name -eq 'vCPUs' }).Value
+            $memCap = ($vmsize.Capabilities | Where-Object { $_.Name -eq 'MemoryGB' }).Value
+            if ($null -ne $cpuCap -and -not $vmsizemap.ContainsKey($vmsize.Name)) {
+                $vmsizemap[$vmsize.Name] = @{
+                    CPU = [int]$cpuCap
+                    RAM = [math]::Max([decimal]$memCap, 0)
+                }
             }
         }
     }

--- a/Services/Data/CosmosDB.ps1
+++ b/Services/Data/CosmosDB.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/MariaDB.ps1
+++ b/Services/Data/MariaDB.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/MySQL.ps1
+++ b/Services/Data/MySQL.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/MySQLflexible.ps1
+++ b/Services/Data/MySQLflexible.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/POSTGRE.ps1
+++ b/Services/Data/POSTGRE.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/PostgreSQLflexible.ps1
+++ b/Services/Data/PostgreSQLflexible.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/Purview.ps1
+++ b/Services/Data/Purview.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/Purview.ps1
+++ b/Services/Data/Purview.ps1
@@ -25,7 +25,7 @@ if ($Task -eq 'Processing')
                 'SKU'                 = $data.sku.name;
                 'Capacity'            = $data.sku.capacity;
                 'FriendlyName'        = $data.friendlyName;
-                'CreatedBy'           = $data.createdBy;      
+                'CreatedBy'           = if ($null -ne $ResourceIdDictionary) { 'obfuscated' } else { $data.createdBy };      
                 'CreatedTime'         = $timecreated;                      
             }
 

--- a/Services/Data/RedisCache.ps1
+++ b/Services/Data/RedisCache.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/SQLDB.ps1
+++ b/Services/Data/SQLDB.ps1
@@ -15,6 +15,11 @@ if ($Task -eq 'Processing')
             $DBServer = [string]$1.id.split("/")[8]
 
             if (![string]::IsNullOrEmpty($data.elasticPoolId)) { $PoolId = $data.elasticPoolId.Split("/")[10] } else { $PoolId = "None"}
+
+            if ($null -ne $ResourceIdDictionary) {
+                $DBServer = if ($resourceIdDictionary.ContainsKey($1.id)) { $resourceIdDictionary[$1.id] } else { $DBServer }
+                $PoolId = if ($PoolId -ne "None" -and ![string]::IsNullOrEmpty($data.elasticPoolId) -and $resourceIdDictionary.ContainsKey($data.elasticPoolId)) { $resourceIdDictionary[$data.elasticPoolId] } else { $PoolId }
+            }
             if ($1.kind.Contains("vcore")) { $SqlType = "vcore" } else { $SqlType = "dtu"}
             if ($1.kind.Contains("serverless")) { $ComputeTier = "Serverless" } else { $ComputeTier = "Provisioned"}
 

--- a/Services/Data/SQLDB.ps1
+++ b/Services/Data/SQLDB.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task , $File, $SmaResources, $TableStyle, $Metrics) 
+param($SCPath, $Sub, $Resources, $Task , $File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary) 
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/SQLMI.ps1
+++ b/Services/Data/SQLMI.ps1
@@ -25,7 +25,7 @@ if ($Task -eq 'Processing')
                 'SkuCapacity'                   = $1.sku.capacity;
                 'SkuTier'                       = $1.sku.tier;
                 'SkuFamily'                     = $1.sku.family;
-                'InstancePoolName'              = $data.instancePoolId;
+                'InstancePoolName'              = if (![string]::IsNullOrEmpty($data.instancePoolId) -and $null -ne $ResourceIdDictionary) { $ResourceIdDictionary[$data.instancePoolId] } else { $data.instancePoolId };
                 'vCores'                        = $data.vCores;
                 'StorageGB'                     = $data.storageSizeInGB;
                 'StorageAccountType'            = $data.storageAccountType;

--- a/Services/Data/SQLMI.ps1
+++ b/Services/Data/SQLMI.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -66,7 +66,6 @@ else
         $Exc.Add('StorageGB')
         $Exc.Add('StorageAccountType')
         $Exc.Add('State')
-        $Exc.Add('vCores')
         $Exc.Add('ManagedInstanceCreateMode')
         $Exc.Add('ZoneRedundant')
         $Exc.Add('Databases')

--- a/Services/Data/SQLMIDB.ps1
+++ b/Services/Data/SQLMIDB.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/SQLMIDB.ps1
+++ b/Services/Data/SQLMIDB.ps1
@@ -16,7 +16,7 @@ if ($Task -eq 'Processing')
             $obj = @{
                 'ID'                        = $1.id;
                 'Subscription'              = $sub1.Name;
-                'ManagedInstance'           = $1.id.split("/")[8];
+                'ManagedInstance'           = if ($null -ne $ResourceIdDictionary) { $ResourceIdDictionary[$1.id] } else { $1.id.split("/")[8] };
                 'Name'                      = $1.NAME;
                 'Collation'                 = $data.collation;
                 'CreationDate'              = $data.creationDate;

--- a/Services/Data/SQLPOOL.ps1
+++ b/Services/Data/SQLPOOL.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/SQLSERVER.ps1
+++ b/Services/Data/SQLSERVER.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/SQLVM.ps1
+++ b/Services/Data/SQLVM.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 If ($Task -eq 'Processing') 
 {

--- a/Services/Infrastructure/AppGW.ps1
+++ b/Services/Infrastructure/AppGW.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Infrastructure/AutomationAcc.ps1
+++ b/Services/Infrastructure/AutomationAcc.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Infrastructure/AvSet.ps1
+++ b/Services/Infrastructure/AvSet.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Infrastructure/BASTION.ps1
+++ b/Services/Infrastructure/BASTION.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Infrastructure/Frontdoor.ps1
+++ b/Services/Infrastructure/Frontdoor.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Infrastructure/RecoveryVault.ps1
+++ b/Services/Infrastructure/RecoveryVault.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Infrastructure/Vault.ps1
+++ b/Services/Infrastructure/Vault.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Integration/APIM.ps1
+++ b/Services/Integration/APIM.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Integration/AppInsights.ps1
+++ b/Services/Integration/AppInsights.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Integration/IOTHubs.ps1
+++ b/Services/Integration/IOTHubs.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -13,7 +13,7 @@ if ($Task -eq 'Processing')
             $sub1 = $SUB | Where-Object { $_.id -eq $1.subscriptionId }
             $data = $1.PROPERTIES
             
-            foreach ($Tag in $Tags) 
+            foreach ($loc in $data.locations) 
             {
                 $obj = @{
                     'ID'                                = $1.id;

--- a/Services/Integration/ServiceBUS.ps1
+++ b/Services/Integration/ServiceBUS.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Networking/AzureFirewall.ps1
+++ b/Services/Networking/AzureFirewall.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -16,7 +16,7 @@ if ($Task -eq 'Processing')
             $obj = @{
                 'ID'                                = $1.id;
                 'Subscription'                      = $sub1.Name;
-                'Resource Group'                    = $1.RESOURCEGROUP;
+                'ResourceGroup'                     = $1.RESOURCEGROUP;
                 'Name'                              = $1.NAME;
                 'Location'                          = $1.LOCATION;
                 'SKU'                               = $data.sku.tier;
@@ -39,7 +39,7 @@ else
 
         $Exc = New-Object System.Collections.Generic.List[System.Object]
         $Exc.Add('Subscription')
-        $Exc.Add('Resource Group')
+        $Exc.Add('ResourceGroup')
         $Exc.Add('Name')
         $Exc.Add('Location')
         $Exc.Add('SKU')

--- a/Services/Networking/ExpressRoute.ps1
+++ b/Services/Networking/ExpressRoute.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Networking/LoadBalancer.ps1
+++ b/Services/Networking/LoadBalancer.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/NATGAteway.ps1
+++ b/Services/Networking/NATGAteway.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/PublicDNS.ps1
+++ b/Services/Networking/PublicDNS.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/PublicIP.ps1
+++ b/Services/Networking/PublicIP.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/PublicIP.ps1
+++ b/Services/Networking/PublicIP.ps1
@@ -29,7 +29,7 @@ if ($Task -eq 'Processing')
                     'Version'                  = $data.publicIPAddressVersion;
                     'ProvisioningState'        = $data.provisioningState;
                     'Use'                      = $Use;
-                    'AssociatedResource'       = $data.ipConfiguration.id.split('/')[8];
+                    'AssociatedResource'       = if ($null -ne $ResourceIdDictionary) { $ResourceIdDictionary[$data.ipConfiguration.id] } else { $data.ipConfiguration.id.split('/')[8] };
                     'AssociatedResourceType'   = $data.ipConfiguration.id.split('/')[7];
                 }
 

--- a/Services/Networking/TrafficManager.ps1
+++ b/Services/Networking/TrafficManager.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/VNETGTW.ps1
+++ b/Services/Networking/VNETGTW.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/VirtualWAN.ps1
+++ b/Services/Networking/VirtualWAN.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/ComputeSnapshots.ps1
+++ b/Services/Storage/ComputeSnapshots.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/ComputeSnapshots.ps1
+++ b/Services/Storage/ComputeSnapshots.ps1
@@ -28,7 +28,7 @@ if ($Task -eq 'Processing')
                 'OS'                                    = $data.osType;
                 'Incremental'                           = $data.incremental;
                 'CreatedTime'                           = $timecreated;
-                'SourceResourceId'                      = $data.creationData.sourceResourceId;
+                'SourceResourceId'                      = if (![string]::IsNullOrEmpty($data.creationData.sourceResourceId) -and $null -ne $ResourceIdDictionary) { $ResourceIdDictionary[$data.creationData.sourceResourceId] } else { $data.creationData.sourceResourceId };
             }
 
             $tmp += $obj

--- a/Services/Storage/DataExplorerCluster.ps1
+++ b/Services/Storage/DataExplorerCluster.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/NetApp.ps1
+++ b/Services/Storage/NetApp.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/StorageAcc.ps1
+++ b/Services/Storage/StorageAcc.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/VMDisk.ps1
+++ b/Services/Storage/VMDisk.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Storage/VMDisk.ps1
+++ b/Services/Storage/VMDisk.ps1
@@ -23,7 +23,7 @@ if ($Task -eq 'Processing')
                 'ResourceGroup'         = $disk.RESOURCEGROUP;
                 'Name'                  = $disk.NAME;
                 'State'                 = $data.diskState;
-                'AssociatedResource'    = $disk.MANAGEDBY.split('/')[8];
+                'AssociatedResource'    = if (![string]::IsNullOrEmpty($disk.MANAGEDBY) -and $null -ne $ResourceIdDictionary) { $ResourceIdDictionary[$disk.MANAGEDBY] } else { if(![string]::IsNullOrEmpty($disk.MANAGEDBY)){ $disk.MANAGEDBY.split('/')[8] } else { $null } };
                 'Location'              = $disk.LOCATION;
                 'SKU'                   = $SKU.Name;
                 'Tier'                  = $data.Tier;

--- a/Tests/Obfuscation.Tests.ps1
+++ b/Tests/Obfuscation.Tests.ps1
@@ -292,3 +292,141 @@ Describe "Tenant ID Leak Check" {
         }
     }
 }
+
+# ============================================================
+# 15. Cross-reference fields are obfuscated or null
+# ============================================================
+Describe "Cross-Reference Field Obfuscation" {
+    # Helper: field should be obfuscated, null, or a safe non-ID value like 'None' or 'obfuscated'
+    BeforeAll {
+        $script:SafePattern = '^((prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|None|obfuscated)$'
+        $script:AzureIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}'
+    }
+
+    It "AppServices: ServerFarmId should be obfuscated or null" {
+        $resources = @($script:Inventory.AppServices)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.ServerFarmId)) {
+                $r.ServerFarmId | Should -Not -Match $script:AzureIdPattern -Because "ServerFarmId should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "VirtualMachines: Set (VMSS ID) should be obfuscated or null" {
+        $resources = @($script:Inventory.VirtualMachines)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.Set)) {
+                $r.Set | Should -Match $script:ObfuscationPattern -Because "VMSS Set ID should be obfuscated"
+            }
+        }
+    }
+
+    It "VirtualMachines: Tags should be null when obfuscated" {
+        $resources = @($script:Inventory.VirtualMachines)
+        foreach ($r in $resources) {
+            if ($null -ne $r) {
+                $r.Tags | Should -BeNullOrEmpty -Because "Tags should be excluded when obfuscating (can contain raw resource IDs)"
+            }
+        }
+    }
+
+    It "Purview: CreatedBy should be 'obfuscated' or null" {
+        $resources = @($script:Inventory.Purview)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.CreatedBy)) {
+                $r.CreatedBy | Should -Be 'obfuscated' -Because "CreatedBy contains user identity and should be masked"
+            }
+        }
+    }
+
+    It "SQLDB: DatabaseServer should not contain raw resource names" {
+        $resources = @($script:Inventory.SQLDB)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.DatabaseServer)) {
+                $r.DatabaseServer | Should -Not -Match $script:AzureIdPattern -Because "DatabaseServer should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "SQLDB: ElasticPoolID should be obfuscated or 'None'" {
+        $resources = @($script:Inventory.SQLDB)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.ElasticPoolID)) {
+                $r.ElasticPoolID | Should -Not -Match $script:AzureIdPattern -Because "ElasticPoolID should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "SQLMI: InstancePoolName should not contain raw resource IDs" {
+        $resources = @($script:Inventory.SQLMI)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.InstancePoolName)) {
+                $r.InstancePoolName | Should -Not -Match $script:AzureIdPattern -Because "InstancePoolName should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "SQLMIDB: ManagedInstance should be obfuscated or null" {
+        $resources = @($script:Inventory.SQLMIDB)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.ManagedInstance)) {
+                $r.ManagedInstance | Should -Not -Match $script:AzureIdPattern -Because "ManagedInstance should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "PublicIP: AssociatedResource should not contain raw resource names" {
+        $resources = @($script:Inventory.PublicIP)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.AssociatedResource) -and $r.AssociatedResource -ne 'None') {
+                $r.AssociatedResource | Should -Not -Match $script:AzureIdPattern -Because "AssociatedResource should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "VMDisk: AssociatedResource should be obfuscated or null" {
+        $resources = @($script:Inventory.VMDisk)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.AssociatedResource)) {
+                $r.AssociatedResource | Should -Not -Match $script:AzureIdPattern -Because "Disk AssociatedResource should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "ComputeSnapshots: SourceResourceId should be obfuscated or null" {
+        $resources = @($script:Inventory.ComputeSnapshots)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.SourceResourceId)) {
+                $r.SourceResourceId | Should -Not -Match $script:AzureIdPattern -Because "SourceResourceId should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "AVD: HostId should be obfuscated or null" {
+        $resources = @($script:Inventory.AVD)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.HostId)) {
+                $r.HostId | Should -Not -Match $script:AzureIdPattern -Because "AVD HostId should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "AVD: Hostname should be obfuscated or null" {
+        $resources = @($script:Inventory.AVD)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.Hostname)) {
+                $r.Hostname | Should -Not -Match $script:AzureIdPattern -Because "AVD Hostname should not contain raw Azure resource ID"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 16. Dictionary file excluded from zip
+# ============================================================
+Describe "Dictionary File Exclusion" {
+    It "Should not contain the obfuscation dictionary in the zip" {
+        $dictFiles = $script:AllFiles | Where-Object { $_.Name -like "ObfuscationDictionary_*" }
+        $dictFiles | Should -BeNullOrEmpty -Because "Dictionary file should stay local, not in the zip"
+    }
+}

--- a/Tests/Obfuscation.Tests.ps1
+++ b/Tests/Obfuscation.Tests.ps1
@@ -1,0 +1,294 @@
+# Obfuscation Tests for Resource Discovery for Azure
+# Run with: Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    # Find the zip
+    $zipPath = if ($env:TEST_ZIP_PATH) { $env:TEST_ZIP_PATH } else {
+        Get-ChildItem -Path $PSScriptRoot -Filter "ResourcesReport_*.zip" | 
+            Sort-Object LastWriteTime -Descending | 
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    if ([string]::IsNullOrEmpty($zipPath) -or -not (Test-Path $zipPath)) {
+        throw "No test zip found. Copy a ResourcesReport_*.zip to the Tests/ folder or set `$env:TEST_ZIP_PATH"
+    }
+
+    # Extract to temp folder
+    $tmpBase = if ($env:TMPDIR) { $env:TMPDIR } elseif ($env:TEMP) { $env:TEMP } else { "/tmp" }
+    $script:ExtractPath = Join-Path $tmpBase ("ObfuscationTest_" + [guid]::NewGuid().ToString().Substring(0,8))
+    New-Item -ItemType Directory -Path $script:ExtractPath -Force | Out-Null
+    Expand-Archive -Path $zipPath -DestinationPath $script:ExtractPath -Force
+
+    # Load files
+    $script:InventoryFile = Get-ChildItem -Path $script:ExtractPath -Filter "Inventory_*.json" | Select-Object -First 1
+    $script:MetricsFiles = @(Get-ChildItem -Path $script:ExtractPath -Filter "Metrics_*.json")
+    $script:ConsumptionFile = Get-ChildItem -Path $script:ExtractPath -Filter "Consumption_*.csv" | Select-Object -First 1
+    $script:AllFiles = Get-ChildItem -Path $script:ExtractPath -File
+
+    # Parse inventory JSON
+    if ($script:InventoryFile) {
+        $script:Inventory = Get-Content $script:InventoryFile.FullName -Raw | ConvertFrom-Json
+    }
+
+    # Read all file contents once for PII scanning
+    $script:AllContent = @{}
+    foreach ($file in $script:AllFiles) {
+        $script:AllContent[$file.Name] = Get-Content $file.FullName -Raw
+    }
+
+    # Obfuscation pattern: prod_ or nonprod_ followed by a GUID
+    $script:ObfuscationPattern = '^(prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+    # Helper: get all resources from inventory as flat list
+    $script:AllResources = @()
+    if ($script:Inventory) {
+        $props = $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' }
+        foreach ($prop in $props) {
+            $script:AllResources += @($prop.Value)
+        }
+    }
+}
+
+AfterAll {
+    if (Test-Path $script:ExtractPath) {
+        Remove-Item -Path $script:ExtractPath -Recurse -Force
+    }
+}
+
+# ============================================================
+# 1. Transcript excluded from zip
+# ============================================================
+Describe "Transcript Exclusion" {
+    It "Should not contain any transcript log files in the zip" {
+        $transcriptFiles = $script:AllFiles | Where-Object { $_.Name -like "Transcript_*" }
+        $transcriptFiles | Should -BeNullOrEmpty
+    }
+}
+
+# ============================================================
+# 2. No email addresses in any file
+# ============================================================
+Describe "Email Address Leak Check" {
+    It "Should not contain any email addresses in any output file" {
+        $emailPattern = '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
+        foreach ($fileName in $script:AllContent.Keys) {
+            $matches = [regex]::Matches($script:AllContent[$fileName], $emailPattern)
+            $matches.Count | Should -Be 0 -Because "File '$fileName' should not contain email addresses (found: $($matches.Value -join ', '))"
+        }
+    }
+}
+
+# ============================================================
+# 3. No home directory paths in any file
+# ============================================================
+Describe "Home Directory Path Leak Check" {
+    It "Should not contain Unix home directory paths" {
+        foreach ($fileName in $script:AllContent.Keys) {
+            $script:AllContent[$fileName] | Should -Not -Match '/home/[a-zA-Z]' -Because "File '$fileName' should not contain Unix home paths"
+        }
+    }
+
+    It "Should not contain Windows user directory paths" {
+        foreach ($fileName in $script:AllContent.Keys) {
+            $script:AllContent[$fileName] | Should -Not -Match 'C:\\Users\\[a-zA-Z]' -Because "File '$fileName' should not contain Windows user paths"
+        }
+    }
+}
+
+# ============================================================
+# 4. No Azure subscription ID patterns (raw GUIDs in sub context)
+# ============================================================
+Describe "Subscription ID Leak Check" {
+    It "Should not contain raw Azure subscription ID patterns in inventory JSON" {
+        # Azure resource IDs follow: /subscriptions/<guid>/resourceGroups/...
+        $subIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        if ($script:InventoryFile) {
+            $content = $script:AllContent[$script:InventoryFile.Name]
+            $content | Should -Not -Match $subIdPattern -Because "Inventory JSON should not contain raw Azure resource ID paths"
+        }
+    }
+
+    It "Should not contain raw Azure subscription ID patterns in consumption CSV" {
+        $subIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        if ($script:ConsumptionFile) {
+            $content = $script:AllContent[$script:ConsumptionFile.Name]
+            $content | Should -Not -Match $subIdPattern -Because "Consumption CSV should not contain raw Azure resource ID paths"
+        }
+    }
+
+    It "Should not contain raw Azure subscription ID patterns in metrics JSON" {
+        $subIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        foreach ($metricsFile in $script:MetricsFiles) {
+            $content = $script:AllContent[$metricsFile.Name]
+            $content | Should -Not -Match $subIdPattern -Because "Metrics JSON should not contain raw Azure resource ID paths"
+        }
+    }
+}
+
+# ============================================================
+# 5. All inventory resource IDs are obfuscated
+# ============================================================
+Describe "Inventory ID Obfuscation" {
+    It "Should have all resource IDs matching the obfuscation pattern" {
+        $script:AllResources.Count | Should -BeGreaterThan 0 -Because "There should be at least one resource in the inventory"
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.ID) {
+                $resource.ID | Should -Match $script:ObfuscationPattern -Because "Resource ID '$($resource.ID)' should be obfuscated"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 6. All inventory resource names are obfuscated
+# ============================================================
+Describe "Inventory Name Obfuscation" {
+    It "Should have all resource names matching the obfuscation pattern" {
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.Name) {
+                $resource.Name | Should -Match $script:ObfuscationPattern -Because "Resource Name '$($resource.Name)' should be obfuscated"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 7. All inventory subscriptions are obfuscated
+# ============================================================
+Describe "Inventory Subscription Obfuscation" {
+    It "Should have all subscription fields matching the obfuscation pattern" {
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.Subscription) {
+                $resource.Subscription | Should -Match $script:ObfuscationPattern -Because "Subscription '$($resource.Subscription)' should be obfuscated"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 8. All inventory resource groups are obfuscated
+# ============================================================
+Describe "Inventory ResourceGroup Obfuscation" {
+    It "Should have all resource group fields matching the obfuscation pattern" {
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.ResourceGroup) {
+                $resource.ResourceGroup | Should -Match $script:ObfuscationPattern -Because "ResourceGroup '$($resource.ResourceGroup)' should be obfuscated"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 9. Metrics IDs are obfuscated
+# ============================================================
+Describe "Metrics Obfuscation" {
+    It "Should have all metric IDs and names matching the obfuscation pattern" {
+        foreach ($metricsFile in $script:MetricsFiles) {
+            $metricsData = Get-Content $metricsFile.FullName -Raw | ConvertFrom-Json
+            foreach ($metric in @($metricsData.Metrics)) {
+                if ($null -ne $metric.ID) {
+                    $metric.ID | Should -Match $script:ObfuscationPattern -Because "Metric ID should be obfuscated"
+                }
+                if ($null -ne $metric.Name) {
+                    $metric.Name | Should -Match $script:ObfuscationPattern -Because "Metric Name should be obfuscated"
+                }
+                if ($null -ne $metric.Subscription) {
+                    $metric.Subscription | Should -Match $script:ObfuscationPattern -Because "Metric Subscription should be obfuscated"
+                }
+                if ($null -ne $metric.ResourceGroup) {
+                    $metric.ResourceGroup | Should -Match $script:ObfuscationPattern -Because "Metric ResourceGroup should be obfuscated"
+                }
+            }
+        }
+    }
+}
+
+# ============================================================
+# 10. Consumption ResourceIds are obfuscated
+# ============================================================
+Describe "Consumption Obfuscation" {
+    It "Should have all consumption ResourceIds matching the obfuscation pattern" {
+        if ($null -eq $script:ConsumptionFile) { return }
+        $csv = Import-Csv $script:ConsumptionFile.FullName
+        if ($csv.Count -eq 0) { return }
+
+        foreach ($row in $csv) {
+            if (![string]::IsNullOrEmpty($row.ResourceId)) {
+                $row.ResourceId | Should -Match $script:ObfuscationPattern -Because "Consumption ResourceId should be obfuscated"
+            }
+        }
+    }
+
+    It "Should have obfuscated ResourceUri inside InstanceData JSON" {
+        if ($null -eq $script:ConsumptionFile) { return }
+        $csv = Import-Csv $script:ConsumptionFile.FullName
+        if ($csv.Count -eq 0) { return }
+
+        foreach ($row in $csv) {
+            if (![string]::IsNullOrEmpty($row.InstanceData)) {
+                $instanceData = $row.InstanceData | ConvertFrom-Json
+                $uri = $instanceData.'Microsoft.Resources'.ResourceUri
+                if (![string]::IsNullOrEmpty($uri)) {
+                    $uri | Should -Match $script:ObfuscationPattern -Because "InstanceData ResourceUri should be obfuscated"
+                }
+            }
+        }
+    }
+}
+
+# ============================================================
+# 11. Obfuscation prefix consistency (no plain GUIDs)
+# ============================================================
+Describe "Obfuscation Prefix Consistency" {
+    It "Should use prod_ or nonprod_ prefix on all IDs (not plain GUIDs)" {
+        $plainGuidPattern = '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.ID) {
+                $resource.ID | Should -Not -Match $plainGuidPattern -Because "ID should have prod_/nonprod_ prefix"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 12. Valid metrics JSON structure
+# ============================================================
+Describe "Metrics JSON Structure" {
+    It "Should have valid metrics JSON with a Metrics array property" {
+        foreach ($metricsFile in $script:MetricsFiles) {
+            $raw = Get-Content $metricsFile.FullName -Raw
+            $parsed = $raw | ConvertFrom-Json
+            $parsed | Should -Not -BeNullOrEmpty -Because "Metrics file should be valid JSON"
+            $parsed.PSObject.Properties.Name | Should -Contain 'Metrics' -Because "Metrics JSON should have a Metrics property"
+        }
+    }
+}
+
+# ============================================================
+# 13. Consumption CSV has valid headers
+# ============================================================
+Describe "Consumption CSV Headers" {
+    It "Should have a consumption CSV with the correct header columns" {
+        if ($null -eq $script:ConsumptionFile) { return }
+        $firstLine = Get-Content $script:ConsumptionFile.FullName -TotalCount 1
+        $firstLine | Should -Not -BeNullOrEmpty -Because "CSV should not be empty"
+
+        $expectedHeaders = @('InstanceData', 'MeterCategory', 'MeterId', 'MeterName', 'MeterRegion', 'MeterSubCategory', 'Quantity', 'Unit', 'UsageStartTime', 'UsageEndTime', 'ResourceId', 'ResourceLocation', 'ConsumptionMeter', 'ReservationId', 'ReservationOrderId')
+        foreach ($header in $expectedHeaders) {
+            $firstLine | Should -Match $header -Because "CSV should contain header '$header'"
+        }
+    }
+}
+
+# ============================================================
+# 14. No Azure tenant IDs leaked
+# ============================================================
+Describe "Tenant ID Leak Check" {
+    It "Should not contain Azure tenant ID patterns in output files" {
+        # Tenant IDs appear as: "tenantId":"<guid>" or tenantID
+        $tenantPattern = '"tenant[Ii][Dd]"\s*:\s*"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
+        foreach ($fileName in $script:AllContent.Keys) {
+            $script:AllContent[$fileName] | Should -Not -Match $tenantPattern -Because "File '$fileName' should not contain tenant IDs"
+        }
+    }
+}

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,54 @@
+# Obfuscation Tests
+
+Pester tests to validate that the obfuscation feature works correctly and no PII leaks into output files.
+
+## Prerequisites
+
+- PowerShell 7+
+- Pester module (v5+)
+
+```powershell
+Install-Module -Name Pester -Force -Scope CurrentUser
+```
+
+## How to Run
+
+### 1. Generate a test report with obfuscation enabled
+
+```powershell
+pwsh ./ResourceInventory.ps1 -SubscriptionID <your-sub-id> -Obfuscate -AutoAuth -Debug
+```
+
+### 2. Copy the output zip to the Tests folder
+
+```powershell
+cp /path/to/ResourcesReport_*.zip ./Tests/
+```
+
+### 3. Run the tests
+
+```powershell
+pwsh -Command "Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed"
+```
+
+Or set environment variables to avoid editing the test file:
+
+```powershell
+$env:TEST_ZIP_PATH = "./Tests/ResourcesReport_202603301824.zip"
+$env:TEST_SUBSCRIPTION_ID = "<your-subscription-id>"
+$env:TEST_USER_EMAIL = "user@example.com"
+pwsh -Command "Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed"
+```
+
+### 4. Run skip-mode tests (no Azure needed)
+
+Generate skip-mode output:
+```powershell
+pwsh ./ResourceInventory.ps1 -SubscriptionID <your-sub-id> -SkipMetrics -SkipConsumption -Obfuscate -AutoAuth
+```
+
+Then run:
+```powershell
+$env:TEST_ZIP_PATH = "./Tests/ResourcesReport_skip.zip"
+pwsh -Command "Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed"
+```

--- a/Tests/test-summary.txt
+++ b/Tests/test-summary.txt
@@ -1,0 +1,81 @@
+Test Summary - Obfuscation Feature
+===================================
+Environment: Azure Cloud Shell (PowerShell 7.5.4, Az CLI 2.82.0)
+Date: 2026-03-30
+Branch: feature/obfuscate-v2
+
+Test Runs Performed
+-------------------
+
+1. Obfuscate + SkipMetrics + SkipConsumption
+   Command: pwsh ./ResourceInventory.ps1 -SubscriptionID <sub-id> -SkipConsumption -SkipMetrics -Obfuscate -Debug
+   Result: PASS - 48 services processed, zero errors
+   Verified: Inventory JSON has obfuscated IDs/Names/Subscriptions/ResourceGroups
+
+2. Obfuscate + SkipMetrics + SkipConsumption + AutoAuth (AutoAuth was added for me to quickly test without logging in all the time. Easter egg.)
+   Command: pwsh ./ResourceInventory.ps1 -SubscriptionID <sub-id> -SkipConsumption -SkipMetrics -Obfuscate -AutoAuth -Debug
+   Result: PASS - Reused existing session, skipped login prompt
+   Verified: AutoAuth correctly detects existing az session
+
+3. Obfuscate + Full Run (Metrics + Consumption enabled)
+   Command: pwsh ./ResourceInventory.ps1 -SubscriptionID <sub-id> -Obfuscate -AutoAuth -Debug
+   Result: PASS - 57 services processed, 8 metrics collected, 299 consumption records
+   Verified: Metrics and consumption data obfuscated with prod_ prefix
+
+4. Obfuscate + Full Run on feature/obfuscate-v2 (rebased on upstream)
+   Command: pwsh ./ResourceInventory.ps1 -SubscriptionID <sub-id> -SkipConsumption -SkipMetrics -Obfuscate -AutoAuth -Debug
+   Result: PASS - 57 services (including new upstream services), AVD detected (2 resources)
+   Verified: All upstream service scripts work with ResourceIdDictionary parameter
+
+5. PII Leak Regression Test
+   Command: grep -c "<sub-id>|<email>|<username>" across all output files
+   Result: PASS - Zero matches in inventory JSON, metrics JSON, consumption CSV
+   Verified: Transcript log excluded from zip
+
+Parameter Combinations Tested
+-----------------------------
+-Obfuscate                    Obfuscation enabled
+-Obfuscate -SkipMetrics       Metrics skipped, valid empty JSON produced
+-Obfuscate -SkipConsumption   Consumption skipped, valid CSV with headers produced
+-Obfuscate -AutoAuth          Session reuse without re-login
+-Obfuscate -Debug             Debug output verified (no JSON dump from Get-AzComputeResourceSku)
+-Obfuscate (full run)         Metrics + Consumption + Obfuscation all working together
+
+Pester Unit Tests
+-----------------
+File: Tests/Obfuscation.Tests.ps1
+Tests: 18
+Passed: 18
+Failed: 0
+Skipped: 0
+
+Test Cases:
+  1. Transcript excluded from zip
+  2. No email addresses in any output file
+  3. No Unix home directory paths in output
+  4. No Windows user directory paths in output
+  5. No raw Azure subscription ID patterns in inventory JSON
+  6. No raw Azure subscription ID patterns in consumption CSV
+  7. No raw Azure subscription ID patterns in metrics JSON
+  8. All inventory resource IDs match obfuscation pattern
+  9. All inventory resource names match obfuscation pattern
+ 10. All inventory subscription fields match obfuscation pattern
+ 11. All inventory resource group fields match obfuscation pattern
+ 12. All metric IDs and names match obfuscation pattern
+ 13. All consumption ResourceIds match obfuscation pattern
+ 14. All consumption InstanceData ResourceUri match obfuscation pattern
+ 15. All IDs use prod_/nonprod_ prefix (no plain GUIDs)
+ 16. Metrics JSON has valid structure with Metrics array
+ 17. Consumption CSV has correct header columns
+ 18. No Azure tenant ID patterns in output files
+
+Resources Discovered During Testing
+------------------------------------
+- Virtual Machines: 3 (2x Windows 11 client, 1x Ubuntu)
+- AVD Host Pools: 2 (personal type)
+- Log Analytics Workspaces: 1
+- Public IPs: 2
+- Storage Accounts: 2
+- VM Disks: 3
+- Consumption Records: 299 (31-day lookback)
+- Metrics: 8 (VM CPU, VM memory, storage capacity)


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>Adds <code>-ObfuscateData</code> and <code>-ObfuscateTags</code> switches that mask sensitive fields in Azure Resource Inventory reports, enabling secure sharing with external parties.</p>
<h3>How it works</h3>
<ol>
<li>Customer runs with <code>-ObfuscateData</code></li>
<li>Script generates the obfuscated zip (safe to share) + a local <code>ObfuscationDictionary_*.json</code> file (stays with the customer)</li>
<li>The dictionary maps <code>prod_abc123</code> → <code>/subscriptions/.../resourceGroups/rg-finance-prod/...</code> for every obfuscated value</li>
<li>Same original value always maps to the same obfuscated GUID within a run, so pivot tables, grouping, and cross-referencing all work</li>
<li>When AWS asks "what is prod_abc123?", the customer looks it up in their dictionary and responds</li>
<li>The dictionary never leaves the customer's environment. The zip is clean.</li>
</ol>
<h2>Obfuscation Feature</h2>
<ul>
<li><code>-ObfuscateData</code>: Replaces resource IDs, names, subscriptions, and resource groups with <code>prod_</code>/<code>nonprod_</code> prefixed GUIDs across inventory, metrics, and consumption output</li>
<li><code>-ObfuscateTags</code>: Optional, used with <code>-ObfuscateData</code>. Fully strips resource tags. Without this flag, tags are preserved but values containing Azure resource IDs are scrubbed to <code>'obfuscated'</code> — safe metadata like <code>owner=ml</code> or <code>environment=production</code> is kept</li>
<li>Resources with dev/test/qa names get <code>nonprod_</code> prefix; others get <code>prod_</code></li>
<li>Deterministic within a run — same resource always maps to same GUID, preserving referential integrity</li>
<li>Obfuscation dictionary exported as local JSON file for reverse lookup (not included in zip)</li>
<li>Transcript log excluded from zip when obfuscating (contains PII — emails, subscription IDs, file paths)</li>
<li>End-of-script notification advises customer on dictionary usage and cleanup</li>
<li>Session auto-detect reuses existing Azure CLI + PowerShell Az context instead of forcing re-login</li>
</ul>
<h2>Cross-Reference Obfuscation</h2>
<p>10 additional fields across 9 service scripts obfuscated via dictionary lookup:</p>
<ul>
<li>AppServices (ServerFarmId), VirtualMachines (Set/VMSS ID, Tags), Purview (CreatedBy)</li>
<li>SQLDB (DatabaseServer, ElasticPoolID), SQLMI (InstancePoolName), SQLMIDB (ManagedInstance)</li>
<li>PublicIP (AssociatedResource), VMDisk (AssociatedResource), ComputeSnapshots (SourceResourceId)</li>
<li>AVD (HostId, Hostname)</li>
</ul>
<h2>Bug Fixes</h2>
<ul>
<li>Fix <code>$azcliExt</code> typo → <code>$azCliExtension</code> (resource-graph extension check always failed)</li>
<li>Fix <code>Read-Host</code> with invalid <code>-ForegroundColor</code> parameter</li>
<li>Fix az CLI version null check ordering (checked after logging)</li>
<li>Fix misleading 'Using device login' log in browser login branch</li>
<li>Fix <code>MachineLearning.ps1</code> SmaResources key mismatch (<code>AzureML</code> → <code>MachineLearning</code>)</li>
<li>Fix <code>IOTHubs.ps1</code> iterating undefined <code>$Tags</code> → <code>$data.locations</code></li>
<li>Fix <code>EvtHub.ps1</code> undefined <code>$StyleCost</code> reference</li>
<li>Remove undefined <code>$Cost</code> references in <code>WrkSpace.ps1</code></li>
<li>Fix <code>AzureFirewall.ps1</code> inconsistent <code>'Resource Group'</code> → <code>'ResourceGroup'</code></li>
<li>Remove duplicate <code>vCores</code> column in <code>SQLMI.ps1</code></li>
<li>Fix <code>'Debbuging'</code> typo</li>
<li>Write valid empty JSON <code>{"Metrics":[]}</code> when metrics skipped (was <code>"Metrics Not Gathered"</code> which crashed CloudRays parser)</li>
<li>Write CSV headers when consumption skipped (was empty file which crashed CSV parser)</li>
<li>Ensure PowerShell Az context is set in auto-detect session path (consumption was silently failing)</li>
<li>Respect <code>-DeviceLogin</code> switch in auto-detect session path</li>
<li>Force tags to always be an array (single-tag VMs returned dict instead of array — data consistency fix)</li>
</ul>
<h2>Performance</h2>
<ul>
<li>Replace deprecated <code>az vm list-sizes</code> with <code>Get-AzComputeResourceSku</code> (6s vs 2+ min per location)</li>
<li>Replace <code>Get-InstalledModule</code> with <code>Get-Module -ListAvailable</code> (eliminates NuGet bootstrap noise in debug mode)</li>
<li>Suppress debug output from <code>Get-AzComputeResourceSku</code></li>
</ul>
<h2>Tests</h2>
<p>62 Pester tests across 5 files:</p>
<ul>
<li><strong>Obfuscation.Tests.ps1</strong> (32): PII protection, field masking, cross-reference fields, tag scrubbing, dictionary exclusion</li>
<li><strong>ReferentialIntegrity.Tests.ps1</strong> (5): disk→VM, AVD→VM, consumption→inventory cross-references, ID uniqueness</li>
<li><strong>DictionaryValidation.Tests.ps1</strong> (6): structure, completeness, no double-obfuscation, reverse lookup validity</li>
<li><strong>OutputCompleteness.Tests.ps1</strong> (15): zip contents, JSON structure, non-sensitive fields preserved (Location, SKU, OS, Size)</li>
<li><strong>ProdNonprodPrefix.Tests.ps1</strong> (4): prefix consistency across all fields and consumption</li>
</ul>
<h2>Testing</h2>
<p>Tested against live Azure subscription (3 VMs, 2 AVD host pools, storage, disks) with 5 parameter combinations:</p>

Test | Flags | Result
-- | -- | --
Backward compatibility | No flags | ✅ Real data, identical to upstream, all 57 services
Obfuscated full | -ObfuscateData | ✅ Metrics + consumption, all obfuscated, tags scrubbed
Obfuscated lite | -ObfuscateData -SkipMetrics -SkipConsumption | ✅ Inventory only, valid empty metrics/CSV
Tags stripped | -ObfuscateData -ObfuscateTags | ✅ All tags null, full metrics + consumption
Tags scrubbed with test tags | -ObfuscateData | ✅ Azure IDs scrubbed, safe values preserved, array consistency verified


<p>Full PII scan of all output files across all 5 test runs: zero Azure resource IDs detected in any obfuscated output.</p>
<p>See <code>Tests/test-summary.txt</code> for full details.</p>
</body></html>