### PR TITLE
feat: Add obfuscation support for secure report sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -483,3 +483,14 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+
+# Resource Discovery output
+.DS_Store
+ResourcesReport_*/
+ResourcesReport_*.zip
+report_output/
+report_v2/
+Tests/*.zip
+
+Transcript_Log_*
+ObfuscationDictionary_*

--- a/Extension/Metrics.ps1
+++ b/Extension/Metrics.ps1
@@ -1,4 +1,4 @@
-param($Subscriptions, $Resources, $Task ,$File, $Metrics, $TableStyle, $ConcurrencyLimit, $FilePath)
+param($Subscriptions, $Resources, $Task ,$File, $Metrics, $TableStyle, $ConcurrencyLimit, $FilePath, $ResourceIdDictionary, $ResourceNameDictionary, $ResourceSubscriptionDictionary, $ResourceResourceGroupDictionary, $Obfuscate)
 
 if ($Task -eq 'Processing')
 {
@@ -365,6 +365,34 @@ if ($Task -eq 'Processing')
             } -ThrottleLimit $ConcurrencyLimit
 
             $defs.Clear()
+
+            if($Obfuscate)
+            {
+                foreach ($metric in $tmp.Metrics) 
+                {
+                    $origMetricID = $metric.ID
+                    if ($ResourceIdDictionary.ContainsKey($origMetricID)) {
+                        $metric.Name = $ResourceNameDictionary[$origMetricID]
+                        $metric.Subscription = $ResourceSubscriptionDictionary[$origMetricID]
+                        $metric.ResourceGroup = $ResourceResourceGroupDictionary[$origMetricID]
+                        $metric.ID = $ResourceIdDictionary[$origMetricID]
+                    } else {
+                        $prefix = if ($origMetricID -match '\b(dev|test|qa|tst|development|non-prod|uat|nonprod)\b' -or $origMetricID -match '(^|/|-)([dts])-') { "nonprod_" } else { "prod_" }
+                        $obfId = $prefix + [guid]::NewGuid().ToString()
+                        $obfName = $prefix + [guid]::NewGuid().ToString()
+                        $obfSub = $prefix + [guid]::NewGuid().ToString()
+                        $obfRG = $prefix + [guid]::NewGuid().ToString()
+                        $ResourceIdDictionary[$origMetricID] = $obfId
+                        $ResourceNameDictionary[$origMetricID] = $obfName
+                        $ResourceSubscriptionDictionary[$origMetricID] = $obfSub
+                        $ResourceResourceGroupDictionary[$origMetricID] = $obfRG
+                        $metric.ID = $obfId
+                        $metric.Name = $obfName
+                        $metric.Subscription = $obfSub
+                        $metric.ResourceGroup = $obfRG
+                    }
+                }
+            }
 
             $outputPath = $FilePath + "_" + $rangeIdx + ".json"
             $tmp | ConvertTo-Json -depth 5 -compress | Out-File $outputPath -Encoding utf8

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ You might get more than one authentication request due to different collector pr
 ./ResourceInventory.ps1 -ReportName "CompanyName" -SkipConsumption
 ```
 
+**Generate obfuscated report (mask sensitive data before sharing):**
+```powershell
+./ResourceInventory.ps1 -ReportName "CompanyName" -Obfuscate
+```
+
 ## Output Files
 
 Upon completion, the script generates reports in the `InventoryReports` folder:
@@ -140,6 +145,33 @@ Upon completion, the script generates reports in the `InventoryReports` folder:
 1. **Locate the output:** Check the `InventoryReports` folder
 2. **Rename the ZIP file:** Include your company name (e.g., `CompanyName_ResourcesReport_2024-01-15.zip`)
 3. **Deliver to AWS team:** Send the renamed ZIP file for analysis
+
+### Obfuscation Mode
+
+When using `-Obfuscate`, the following data is masked in all output files:
+
+| Category | What is masked | Masked Format |
+|----------|---------------|---------------|
+| Resource ID | All resource IDs across inventory, metrics, and consumption | `prod_<guid>` or `nonprod_<guid>` |
+| Resource Name | All resource names | `prod_<guid>` or `nonprod_<guid>` |
+| Subscription | Subscription names (deterministic — same real sub always maps to the same value) | `prod_<guid>` or `nonprod_<guid>` |
+| Resource Group | Resource group names (deterministic — same real RG always maps to the same value) | `prod_<guid>` or `nonprod_<guid>` |
+| Tags | All resource tags stripped | `null` |
+| Cross-references | Fields that reference other resources by name or ID (e.g. DatabaseServer, ManagedInstance, HostId, StorageAccount, KeyVault, WAF policy) | Dictionary lookup or `obfuscated` |
+| Consumption IDs | ReservationId and ReservationOrderId in billing data | `obfuscated` |
+| User identity | Fields containing user emails or identity (e.g. Purview CreatedBy) | `obfuscated` |
+
+Resources with names matching dev/test/qa patterns (including short prefixes like `d-`, `t-`, `s-`) get a `nonprod_` prefix; all others get `prod_`. This preserves environment classification without exposing real names.
+
+**Deterministic mapping:** The same real subscription or resource group always maps to the same obfuscated value within a run. This means pivot tables, grouping, and cross-referencing all work correctly in the obfuscated output.
+
+**Reverse-lookup dictionary:** A local `ObfuscationDictionary_*.json` file maps every obfuscated value back to the real resource. This file stays with the customer and is never included in the ZIP. When the receiving party asks about a specific obfuscated name, the customer looks it up in the dictionary and responds.
+
+**What is preserved:** Location, SKU, VM size, OS type, disk type, metrics values, consumption quantities, and all technical configuration data needed for analysis.
+
+**What is excluded from the ZIP:**
+- Transcript log (contains raw console output with emails, subscription IDs, file paths)
+- Obfuscation dictionary (contains the real-to-obfuscated mapping)
 
 ### Manual Compression (If Needed)
 
@@ -164,7 +196,15 @@ Compress-Archive -Path ./* -DestinationPath "CompanyName_ResourcesReport_$(Get-D
 | Parameter | Type | Description | Default | Example |
 |-----------|------|-------------|---------|----------|
 | `ConcurrencyLimit` | Integer | Parallel execution limit | 6 | `-ConcurrencyLimit 8` |
+| `CollectionDays` | Integer | Number of days for consumption lookback | 31 | `-CollectionDays 14` |
 | `SkipConsumption` | Switch | Skip cost/billing data collection | False | `-SkipConsumption` |
+| `SkipMetrics` | Switch | Skip Azure Monitor metrics collection | False | `-SkipMetrics` |
+
+### Privacy & Obfuscation Parameters
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|----------|
+| `Obfuscate` | Switch | Replace resource IDs, names, subscriptions, resource groups, and tags with masked values. A reverse-lookup dictionary is saved locally. Reports can be safely shared externally without exposing sensitive Azure environment details. | `-Obfuscate` |
 
 ### Authentication Parameters
 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -8,6 +8,7 @@ param ($TenantID,
         [switch]$SkipConsumption, 
         [switch]$DeviceLogin,
         [switch]$EnableLogs,
+        [switch]$Obfuscate,
         $ConcurrencyLimit = 6,
         $ReportName = 'ResourcesReport', 
         $OutputDirectory)
@@ -17,7 +18,7 @@ if ($Debug.IsPresent) {$DebugPreference = 'Continue'}
 
 if ($Debug.IsPresent) {$ErrorActionPreference = "Continue" }Else {$ErrorActionPreference = "silentlycontinue" }
 
-Write-Debug ('Debbuging Mode: On. ErrorActionPreference was set to "Continue", every error will be presented.')
+Write-Debug ('Debugging Mode: On. ErrorActionPreference was set to "Continue", every error will be presented.')
 
 Function Write-Log([string]$Message, [string]$Severity)
 {
@@ -65,6 +66,17 @@ function Variables
     $Global:Logging | Add-Member -MemberType NoteProperty -Name Logs -Value NotSet
     $Global:Logging.Logs = [System.Collections.Generic.List[object]]::new()
 
+    $Global:ResourceIdDictionary = $null
+    $Global:ResourceNameDictionary = $null
+    $Global:ResourceSubscriptionDictionary = $null
+    $Global:ResourceResourceGroupDictionary = $null
+
+    if ($Obfuscate.IsPresent) {
+        $Global:ResourceIdDictionary = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+        $Global:ResourceNameDictionary = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+        $Global:ResourceSubscriptionDictionary = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+        $Global:ResourceResourceGroupDictionary = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+    }
 
     $Global:RawRepo = 'https://raw.githubusercontent.com/awslabs/resource-discovery-for-azure/main'
     $Global:TableStyle = "Medium15"
@@ -94,13 +106,14 @@ Function RunInventorySetup()
 
         $azCliVersion = az --version
 
-        Write-Log -Message ('CLI Version: {0}' -f $azCliVersion[0]) -Severity 'Success'
-    
         if ($null -eq $azCliVersion) 
         {
-            Read-Host "Azure CLI Not Found. Please install to and run the script again, press <Enter> to exit." -ForegroundColor Red
+            Write-Log -Message ("Azure CLI Not Found. Please install and run the script again.") -Severity 'Error'
+            Read-Host "Press <Enter> to exit"
             Exit
         }
+
+        Write-Log -Message ('CLI Version: {0}' -f $azCliVersion[0]) -Severity 'Success'
 
         Write-Log -Message ('Verifying Azure CLI Extension...') -Severity 'Info'
 
@@ -109,7 +122,7 @@ Function RunInventorySetup()
 
         Write-Log -Message ('Current Resource-Graph Extension Version: {0}' -f $azCliExtension.Version) -Severity 'Success'
         
-        $azCliExtensionVersion = $azcliExt | Where-Object {$_.name -eq 'resource-graph'}
+        $azCliExtensionVersion = $azCliExtension | Where-Object {$_.name -eq 'resource-graph'}
     
         if (!$azCliExtensionVersion) 
         {
@@ -120,21 +133,22 @@ Function RunInventorySetup()
 
         Write-Log -Message ('Checking Azure PowerShell Module...') -Severity 'Info'
 
-        $VarAzPs = Get-InstalledModule -Name Az -ErrorAction silentlycontinue
+        $VarAzPs = Get-Module -Name Az -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
 
-        Write-Log -Message ('Azure PowerShell Module Version: {0}.{1}.{2}' -f [string]$VarAzPs.Version.Major,  [string]$VarAzPs.Version.Minor, [string]$VarAzPs.Version.Build) -Severity 'Success'
-
-        IF($null -eq $VarAzPs)
+        if ($null -ne $VarAzPs)
         {
-            Write-Log -Message ('Trying to install Azure PowerShell Module...') -Severity 'Warning'
-            Install-Module -Name Az -Repository PSGallery -Force
+            Write-Log -Message ('Azure PowerShell Module Version: {0}' -f $VarAzPs.Version) -Severity 'Success'
         }
-
-        $VarAzPs = Get-InstalledModule -Name Az -ErrorAction silentlycontinue
+        else
+        {
+            Write-Log -Message ('Azure PowerShell Module not found. Trying to install...') -Severity 'Warning'
+            Install-Module -Name Az -Repository PSGallery -Force -Scope CurrentUser
+            $VarAzPs = Get-Module -Name Az -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
+        }
 
         if ($null -eq $VarAzPs) 
         {
-            Write-Log -Message ('Admininstrator rights required to install Azure PowerShell Module. Press <Enter> to finish script') -Severity 'Error'
+            Write-Log -Message ('Failed to install Azure PowerShell Module. Press <Enter> to finish script') -Severity 'Error'
             Read-Host ''
             Exit
         }
@@ -142,21 +156,22 @@ Function RunInventorySetup()
 
         Write-Log -Message ('Checking ImportExcel Module...') -Severity 'Info'
     
-        $VarExcel = Get-InstalledModule -Name ImportExcel -ErrorAction silentlycontinue
+        $VarExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
     
-        Write-Log -Message ('ImportExcel Module Version: {0}.{1}.{2}' -f [string]$VarExcel.Version.Major,  [string]$VarExcel.Version.Minor, [string]$VarExcel.Version.Build) -Severity 'Success'
-    
-        if ($null -eq $VarExcel) 
+        if ($null -ne $VarExcel)
         {
-            Write-Log -Message ('Trying to install ImportExcel Module...') -Severity 'Warning'
-            Install-Module -Name ImportExcel -Force
+            Write-Log -Message ('ImportExcel Module Version: {0}' -f $VarExcel.Version) -Severity 'Success'
+        }
+        else
+        {
+            Write-Log -Message ('ImportExcel Module not found. Trying to install...') -Severity 'Warning'
+            Install-Module -Name ImportExcel -Force -Scope CurrentUser
+            $VarExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
         }
     
-        $VarExcel = Get-InstalledModule -Name ImportExcel -ErrorAction silentlycontinue
-    
         if ($null -eq $VarExcel) 
         {
-            Write-Log -Message ('Admininstrator rights required to install ImportExcel Module. Press <Enter> to finish script') -Severity 'Error'
+            Write-Log -Message ('Failed to install ImportExcel Module. Press <Enter> to finish script') -Severity 'Error'
             Read-Host ''
             Exit
         }
@@ -233,6 +248,39 @@ Function RunInventorySetup()
     
         $CurrentCloudEnvName = $CloudEnv | Where-Object {$_.isActive -eq 'True'}
         Write-Host $CurrentCloudEnvName.name -ForegroundColor Green
+
+        # Check if already authenticated
+        $existingAccount = az account show --output json --only-show-errors 2>$null | ConvertFrom-Json
+        if ($null -ne $existingAccount)
+        {
+            Write-Log -Message ("Already authenticated as: {0}" -f $existingAccount.user.name) -Severity 'Success'
+
+            if (!$TenantID -or $existingAccount.tenantId -eq $TenantID)
+            {
+                # Ensure PowerShell Az context is also set
+                $azContext = Get-AzContext -ErrorAction SilentlyContinue
+                if ($null -eq $azContext -or $azContext.Subscription.Id -ne $existingAccount.id)
+                {
+                    Write-Log -Message ('Setting PowerShell Az context...') -Severity 'Info'
+                    if($DeviceLogin.IsPresent)
+                    {
+                        Connect-AzAccount -UseDeviceAuthentication -Tenant $existingAccount.tenantId | Out-Null
+                    }
+                    else
+                    {
+                        Connect-AzAccount -Tenant $existingAccount.tenantId | Out-Null
+                    }
+                }
+
+                $Global:Subscriptions = @(az account list --output json --only-show-errors | ConvertFrom-Json)
+                if ($TenantID) { $Global:Subscriptions = @($Subscriptions | Where-Object { $_.tenantID -eq $TenantID }) }
+                return
+            }
+            else
+            {
+                Write-Log -Message ("Current session is for tenant {0}, but requested tenant is {1}. Re-authenticating." -f $existingAccount.tenantId, $TenantID) -Severity 'Warning'
+            }
+        }
     
         if (!$TenantID) 
         {
@@ -253,7 +301,7 @@ Function RunInventorySetup()
             }
             else 
             {
-                Write-Log -Message ('Using device login') -Severity 'Info'
+                Write-Log -Message ('Using browser login') -Severity 'Info'
                 az login --only-show-errors | Out-Null
                 Connect-AzAccount | Out-Null
             }
@@ -481,6 +529,46 @@ Function RunInventorySetup()
     GetSubscriptionsData
     ResourceInventoryLoop
     ResourceInventoryAvd
+
+    if($Obfuscate.IsPresent)
+    {
+        # Lookup tables keyed by real subscription name / real RG name so the same
+        # real value always maps to the same obfuscated value across resources.
+        $subLookup = @{}
+        $rgLookup  = @{}
+
+        foreach ($resourceItem in $Global:Resources) 
+        {
+            $isNonProd = $resourceItem.name -match '\b(dev|test|qa|tst|development|non-prod|uat|nonprod)\b' -or $resourceItem.name -match '(^|-)([dts])-'
+            $prefix = if ($isNonProd) { "nonprod_" } else { "prod_" }
+
+            $obfuscatedID   = $prefix + [guid]::NewGuid().ToString()
+            $obfuscatedName = $prefix + [guid]::NewGuid().ToString()
+
+            # Deterministic subscription obfuscation: derive prefix from sub name, not resource name
+            $realSub = ($Global:Subscriptions | Where-Object { $_.id -eq $resourceItem.subscriptionId }).Name
+            if ([string]::IsNullOrEmpty($realSub)) { $realSub = $resourceItem.subscriptionId }
+            if (-not $subLookup.ContainsKey($realSub)) {
+                $subPrefix = if ($realSub -match '\b(dev|test|qa|tst|development|non-prod|uat|nonprod)\b' -or $realSub -match '(^|-)([dts])-') { "nonprod_" } else { "prod_" }
+                $subLookup[$realSub] = $subPrefix + [guid]::NewGuid().ToString()
+            }
+            $obfuscatedSubscription = $subLookup[$realSub]
+
+            # Deterministic RG obfuscation: derive prefix from RG name, not resource name
+            $realRG = $resourceItem.resourceGroup
+            if ([string]::IsNullOrEmpty($realRG)) { $realRG = '__none__' }
+            if (-not $rgLookup.ContainsKey($realRG)) {
+                $rgPrefix = if ($realRG -match '\b(dev|test|qa|tst|development|non-prod|uat|nonprod)\b' -or $realRG -match '(^|-)([dts])-') { "nonprod_" } else { "prod_" }
+                $rgLookup[$realRG] = $rgPrefix + [guid]::NewGuid().ToString()
+            }
+            $obfuscatedResourceGroup = $rgLookup[$realRG]
+
+            $ResourceIdDictionary.Add($resourceItem.ID, $obfuscatedID)
+            $ResourceNameDictionary.Add($resourceItem.ID, $obfuscatedName)
+            $ResourceSubscriptionDictionary.Add($resourceItem.ID, $obfuscatedSubscription)
+            $ResourceResourceGroupDictionary.Add($resourceItem.ID, $obfuscatedResourceGroup)
+        }
+    }
 }
 
 function ExecuteInventoryProcessing()
@@ -522,7 +610,7 @@ function ExecuteInventoryProcessing()
             
             $Global:AzMetrics = New-Object PSObject
             $Global:AzMetrics | Add-Member -MemberType NoteProperty -Name Metrics -Value NotSet
-            $Global:AzMetrics.Metrics = & $MetricPath -Subscriptions $Subscriptions -Resources $Resources -Task "Processing" -File $file -Metrics $null -TableStyle $null -ConcurrencyLimit $ConcurrencyLimit -FilePath $metricsFilePath
+            $Global:AzMetrics.Metrics = & $MetricPath -Subscriptions $Subscriptions -Resources $Resources -Task "Processing" -File $file -Metrics $null -TableStyle $null -ConcurrencyLimit $ConcurrencyLimit -FilePath $metricsFilePath -ResourceIdDictionary $(if ($Obfuscate.IsPresent) { $ResourceIdDictionary } else { $null }) -ResourceNameDictionary $(if ($Obfuscate.IsPresent) { $ResourceNameDictionary } else { $null }) -ResourceSubscriptionDictionary $(if ($Obfuscate.IsPresent) { $ResourceSubscriptionDictionary } else { $null }) -ResourceResourceGroupDictionary $(if ($Obfuscate.IsPresent) { $ResourceResourceGroupDictionary } else { $null }) -Obfuscate $Obfuscate.IsPresent
         }
     }
 
@@ -606,7 +694,56 @@ function ExecuteInventoryProcessing()
             
             Write-Log -Message ("Service Processing: {0}" -f $ModName) -Severity 'Success'
 
-            $result = & $Module -SCPath $SCPath -Sub $Subscriptions -Resources $Resource -Task "Processing" -File $file -SmaResources $null -TableStyle $null -Metrics $Global:AzMetrics
+            $result = & $Module -SCPath $SCPath -Sub $Subscriptions -Resources $Resource -Task "Processing" -File $file -SmaResources $null -TableStyle $null -Metrics $Global:AzMetrics -ResourceIdDictionary $(if ($Obfuscate.IsPresent) { $ResourceIdDictionary } else { $null })
+
+            if($Obfuscate.IsPresent)
+            {
+                foreach ($resourceItem in $result) 
+                {
+                    $origID = $resourceItem.ID
+
+                    if ($ResourceIdDictionary.ContainsKey($origID)) {
+                        $resourceItem.ID = $ResourceIdDictionary[$origID]
+                    } else {
+                        $prefix = if ($origID -match '\b(dev|test|qa|tst|development|non-prod|uat|nonprod)\b' -or $origID -match '(^|-)([dts])-') { "nonprod_" } else { "prod_" }
+                        $fallback = $prefix + [guid]::NewGuid().ToString()
+                        $ResourceIdDictionary.Add($origID, $fallback)
+                        $resourceItem.ID = $fallback
+                    }
+
+                    $prefix = $resourceItem.ID.Split('_')[0] + '_'
+
+                    if ($ResourceNameDictionary.ContainsKey($origID)) {
+                        $resourceItem.Name = $ResourceNameDictionary[$origID]
+                    } else {
+                        $fbName = $prefix + [guid]::NewGuid().ToString()
+                        $ResourceNameDictionary[$origID] = $fbName
+                        $resourceItem.Name = $fbName
+                    }
+
+                    if ($ResourceSubscriptionDictionary.ContainsKey($origID)) {
+                        $resourceItem.Subscription = $ResourceSubscriptionDictionary[$origID]
+                    } else {
+                        $fbSub = $prefix + [guid]::NewGuid().ToString()
+                        $ResourceSubscriptionDictionary[$origID] = $fbSub
+                        $resourceItem.Subscription = $fbSub
+                    }
+
+                    if ($ResourceResourceGroupDictionary.ContainsKey($origID)) {
+                        $resourceItem.ResourceGroup = $ResourceResourceGroupDictionary[$origID]
+                    } else {
+                        $fbRG = $prefix + [guid]::NewGuid().ToString()
+                        $ResourceResourceGroupDictionary[$origID] = $fbRG
+                        $resourceItem.ResourceGroup = $fbRG
+                    }
+
+                    if($resourceItem.ContainsKey('Tags') -and $null -ne $resourceItem.Tags)
+                    {
+                        $resourceItem.Tags = $null
+                    }
+                }
+            }
+
             $Global:SmaResources | Add-Member -MemberType NoteProperty -Name $ModName -Value NotSet
             $Global:SmaResources.$ModName = $result
 
@@ -640,7 +777,7 @@ function ExecuteInventoryProcessing()
             $c = [math]::Round($c)
             
             Write-Log -Message ("Running Services: $Service") -Severity 'Info'
-            $ProcessResults = & $Service.FullName -SCPath $PSScriptRoot -Sub $null -Resources $null -Task "Reporting" -File $file -SmaResources $Global:SmaResources -TableStyle $Global:TableStyle -Metrics $null
+            $ProcessResults = & $Service.FullName -SCPath $PSScriptRoot -Sub $null -Resources $null -Task "Reporting" -File $file -SmaResources $Global:SmaResources -TableStyle $Global:TableStyle -Metrics $null -ResourceIdDictionary $(if ($Obfuscate.IsPresent) { $ResourceIdDictionary } else { $null })
 
             $ReportCounter++
         }
@@ -746,6 +883,32 @@ function ExecuteInventoryProcessing()
                     
                     $instanceObject | Add-Member -MemberType NoteProperty -Name "Microsoft.Resources" -Value $additionalInfoInstance
 
+                    if($Obfuscate.IsPresent)
+                    {
+                        if (-not $ResourceIdDictionary.ContainsKey($usageDataExport[$item].ResourceId)) 
+                        {
+                            $prefix = if ($usageDataExport[$item].ResourceId -match '\b(dev|test|qa|tst|development|non-prod|uat|nonprod)\b' -or $usageDataExport[$item].ResourceId -match '(^|/|-)([dts])-') { "nonprod_" } else { "prod_" }
+                            $obfuscatedID = $prefix + [guid]::NewGuid().ToString()
+                            $ResourceIdDictionary.Add($usageDataExport[$item].ResourceId, $obfuscatedID)
+                            $usageDataExport[$item].ResourceId = $obfuscatedID
+                            $instanceObject.'Microsoft.Resources'.resourceUri = $obfuscatedID
+                        } 
+                        else 
+                        {
+                            $obfuscatedID = $ResourceIdDictionary[$usageDataExport[$item].ResourceId]
+                            $usageDataExport[$item].ResourceId = $obfuscatedID
+                            $instanceObject.'Microsoft.Resources'.resourceUri = $obfuscatedID
+                        }
+
+                        # Obfuscate reservation identifiers (customer purchasing fingerprints)
+                        if (![string]::IsNullOrEmpty($usageDataExport[$item].ReservationId)) {
+                            $usageDataExport[$item].ReservationId = 'obfuscated'
+                        }
+                        if (![string]::IsNullOrEmpty($usageDataExport[$item].ReservationOrderId)) {
+                            $usageDataExport[$item].ReservationOrderId = 'obfuscated'
+                        }
+                    }
+
                     $usageDataExport[$item].InstanceData = $instanceObject | ConvertTo-Json -Compress
 
                     $newUsageDataExport.Add($usageDataExport[$item]) | Out-Null
@@ -817,6 +980,44 @@ FinalizeOutputs
 
 Write-Log -Message ("Compressing Resources Output: {0}" -f $Global:ZipOutputFile) -Severity 'Info'
 
+if($Obfuscate.IsPresent)
+{
+    $Global:DictionaryFile = ($DefaultPath + "ObfuscationDictionary_"+ $Global:ReportName + "_" + $CurrentDateTime + ".json")
+    
+    $dictionary = @{
+        GeneratedAt = (Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+        ResourceIdMap = @{}
+        ResourceNameMap = @{}
+        SubscriptionMap = @{}
+        ResourceGroupMap = @{}
+    }
+
+    foreach ($key in $ResourceIdDictionary.Keys) {
+        $dictionary.ResourceIdMap[$ResourceIdDictionary[$key]] = $key
+    }
+    foreach ($key in $ResourceNameDictionary.Keys) {
+        $dictionary.ResourceNameMap[$ResourceNameDictionary[$key]] = $key
+    }
+    foreach ($key in $ResourceSubscriptionDictionary.Keys) {
+        $dictionary.SubscriptionMap[$ResourceSubscriptionDictionary[$key]] = $key
+    }
+    foreach ($key in $ResourceResourceGroupDictionary.Keys) {
+        $dictionary.ResourceGroupMap[$ResourceResourceGroupDictionary[$key]] = $key
+    }
+
+    $dictionary | ConvertTo-Json -depth 5 | Out-File $Global:DictionaryFile -Encoding utf8
+    Write-Log -Message ("Obfuscation dictionary saved locally: {0}" -f $Global:DictionaryFile) -Severity 'Success'
+    Write-Log -Message ("") -Severity 'Info'
+    Write-Log -Message ("=== OBFUSCATION NOTICE ===") -Severity 'Warning'
+    Write-Log -Message ("The following files remain LOCAL and should NOT be shared:") -Severity 'Warning'
+    Write-Log -Message ("  - Dictionary: {0}" -f $Global:DictionaryFile) -Severity 'Warning'
+    Write-Log -Message ("  - Transcript: {0}" -f $Global:PowerShellTranscriptFile) -Severity 'Warning'
+    Write-Log -Message ("") -Severity 'Info'
+    Write-Log -Message ("The ZIP file is safe to share with AWS or partners.") -Severity 'Success'
+    Write-Log -Message ("Partners may ask about obfuscated names (e.g. 'prod_a1b2c3d4-...'). Use the dictionary file to look up the real resource name and respond.") -Severity 'Info'
+    Write-Log -Message ("Delete the dictionary and transcript when no longer needed for security.") -Severity 'Warning'
+}
+
 if($EnableLogs.IsPresent)
 {
     $Global:Logging | ConvertTo-Json -depth 5 -compress | Out-File $Global:LogFile
@@ -824,22 +1025,36 @@ if($EnableLogs.IsPresent)
 
 if($SkipMetrics.IsPresent)
 {
-    "Metrics Not Gathered" | ConvertTo-Json -depth 5 -compress | Out-File $Global:MetricsJsonFile 
+    @{ Metrics = @() } | ConvertTo-Json -depth 5 -compress | Out-File $Global:MetricsJsonFile -Encoding utf8
 }
 
 $consumptionCreated = Test-Path -Path $Global:ConsumptionFileCsv
 
 if($SkipConsumption.IsPresent -or !$consumptionCreated)
 {
-    Out-File $Global:ConsumptionFileCsv
+    "InstanceData,MeterCategory,MeterId,MeterName,MeterRegion,MeterSubCategory,Quantity,Unit,UsageStartTime,UsageEndTime,ResourceId,ResourceLocation,ConsumptionMeter,ReservationId,ReservationOrderId" | Out-File $Global:ConsumptionFileCsv -Encoding utf8
 }
 
 $jsonWildCard = $DefaultPath + "*.json"
 
-$compressionOutput = @{
-    Path = $Global:File, $Global:ConsumptionFileCsv, $Global:PowerShellTranscriptFile, $jsonWildCard
-    CompressionLevel = 'Fastest'
-    DestinationPath = $Global:ZipOutputFile
+if($Obfuscate.IsPresent)
+{
+    # Exclude dictionary and transcript from zip - use specific json files only
+    $jsonFiles = Get-ChildItem -Path $DefaultPath -Filter "*.json" | Where-Object { $_.Name -notlike "ObfuscationDictionary_*" } | Select-Object -ExpandProperty FullName
+    $compressionOutput = @{
+        Path = @($Global:File, $Global:ConsumptionFileCsv) + $jsonFiles
+        CompressionLevel = 'Fastest'
+        DestinationPath = $Global:ZipOutputFile
+    }
+    Write-Log -Message ('Obfuscate mode: transcript log excluded from zip (kept locally for debug)') -Severity 'Info'
+}
+else
+{
+    $compressionOutput = @{
+        Path = $Global:File, $Global:ConsumptionFileCsv, $Global:PowerShellTranscriptFile, $jsonWildCard
+        CompressionLevel = 'Fastest'
+        DestinationPath = $Global:ZipOutputFile
+    }
 }
 
 try 

--- a/Services/Analytics/Databricks.ps1
+++ b/Services/Analytics/Databricks.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if($Task -eq 'Processing') 
 {
@@ -24,8 +24,8 @@ if($Task -eq 'Processing')
                 'Name'                      = $1.NAME;
                 'Location'                  = $1.LOCATION;
                 'PricingTier'               = $sku.name;
-                'ManagedResourceGroup'      = $data.managedResourceGroupId.split('/')[4];
-                'StorageAccount'            = $data.parameters.storageAccountName.value;
+                'ManagedResourceGroup'      = if ($null -ne $ResourceIdDictionary) { 'obfuscated' } else { $data.managedResourceGroupId.split('/')[4] };
+                'StorageAccount'            = if ($null -ne $ResourceIdDictionary) { 'obfuscated' } else { $data.parameters.storageAccountName.value };
                 'StorageAccountSKU'         = $data.parameters.storageAccountSkuName.value;
                 'CreatedTime'               = $timecreated;
             }

--- a/Services/Analytics/EvtHub.ps1
+++ b/Services/Analytics/EvtHub.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {
@@ -65,6 +65,6 @@ else
 
         $ExcelVar | 
         ForEach-Object { [PSCustomObject]$_ } | Select-Object -Unique $Exc | 
-        Export-Excel -Path $File -WorksheetName 'Event Hubs' -AutoSize -MaxAutoSizeRows 100 -TableName $TableName -TableStyle $tableStyle -ConditionalText $condtxt -Style $Style, $StyleCost
+        Export-Excel -Path $File -WorksheetName 'Event Hubs' -AutoSize -MaxAutoSizeRows 100 -TableName $TableName -TableStyle $tableStyle -ConditionalText $condtxt -Style $Style
     }
 }

--- a/Services/Analytics/MachineLearning.ps1
+++ b/Services/Analytics/MachineLearning.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 If ($Task -eq 'Processing') 
 {
@@ -18,6 +18,14 @@ If ($Task -eq 'Processing')
             $KeyVault = $data.keyVault.split('/')[8]
             $Insight = $data.applicationInsights.split('/')[8]
             $containerRegistry = $data.containerRegistry.split('/')[8]
+
+            # Obfuscate cross-reference names when dictionary is present
+            if ($null -ne $ResourceIdDictionary) {
+                $StorageAcc = if (![string]::IsNullOrEmpty($data.storageAccount) -and $ResourceIdDictionary.ContainsKey($data.storageAccount)) { $ResourceIdDictionary[$data.storageAccount] } else { 'obfuscated' }
+                $KeyVault = if (![string]::IsNullOrEmpty($data.keyVault) -and $ResourceIdDictionary.ContainsKey($data.keyVault)) { $ResourceIdDictionary[$data.keyVault] } else { 'obfuscated' }
+                $Insight = if (![string]::IsNullOrEmpty($data.applicationInsights) -and $ResourceIdDictionary.ContainsKey($data.applicationInsights)) { $ResourceIdDictionary[$data.applicationInsights] } else { 'obfuscated' }
+                $containerRegistry = if (![string]::IsNullOrEmpty($data.containerRegistry) -and $ResourceIdDictionary.ContainsKey($data.containerRegistry)) { $ResourceIdDictionary[$data.containerRegistry] } else { 'obfuscated' }
+            }
 
             $obj = @{
                 'ID'                        = $1.id;
@@ -44,9 +52,9 @@ If ($Task -eq 'Processing')
 }
 else 
 {
-    if ($SmaResources.AzureML) 
+    if ($SmaResources.MachineLearning) 
     {
-        $TableName = ('AzureMLTable_'+($SmaResources.AzureML.id | Select-Object -Unique).count)
+        $TableName = ('AzureMLTable_'+($SmaResources.MachineLearning.id | Select-Object -Unique).count)
         $Style = New-ExcelStyle -HorizontalAlignment Center -AutoSize -NumberFormat 0
 
         $condtxt = @()
@@ -66,7 +74,7 @@ else
         $Exc.Add('ApplicationInsight')
         $Exc.Add('CreatedTime')  
 
-        $ExcelVar = $SmaResources.AzureML
+        $ExcelVar = $SmaResources.MachineLearning
 
         $ExcelVar | 
         ForEach-Object { [PSCustomObject]$_ } | Select-Object -Unique $Exc | 

--- a/Services/Analytics/Streamanalytics.ps1
+++ b/Services/Analytics/Streamanalytics.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Analytics/Synapse.ps1
+++ b/Services/Analytics/Synapse.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Analytics/WrkSpace.ps1
+++ b/Services/Analytics/WrkSpace.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {
@@ -20,8 +20,6 @@ if ($Task -eq 'Processing')
                 'ResourceGroup'     = $1.RESOURCEGROUP;
                 'Name'              = $1.NAME;
                 'Location'          = $1.LOCATION;
-                'Currency'          = $Cost.Currency;
-                'DailyCost'         = '{0:C}' -f $Cost.Cost;
                 'SKU'               = $data.sku.name;
                 'RetentionDays'     = $data.retentionInDays;
                 'DailyQuotaGB'      = [decimal]$data.workspaceCapping.dailyQuotaGb;

--- a/Services/Compute/ARCServers.ps1
+++ b/Services/Compute/ARCServers.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Compute/ARO.ps1
+++ b/Services/Compute/ARO.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Compute/AVD.ps1
+++ b/Services/Compute/AVD.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -30,6 +30,25 @@ if ($Task -eq 'Processing')
             {
                 $vmsessionhosts = $VM | Where-Object { $_.ID -eq $2.properties.resourceId}
 
+                # Resolve HostId and Hostname
+                $hostIdValue = $null
+                $hostnameValue = $null
+                if (![string]::IsNullOrEmpty($vmsessionhosts.Id)) {
+                    if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.ContainsKey($vmsessionhosts.Id)) {
+                        $hostIdValue = $ResourceIdDictionary[$vmsessionhosts.Id]
+                        # Deterministic hostname: derive from VM ID hash so same input = same output
+                        $hnPrefix = $hostIdValue.Split('_')[0]
+                        $sha = [System.Security.Cryptography.SHA256]::Create()
+                        try {
+                            $hnHash = [System.BitConverter]::ToString($sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($vmsessionhosts.Id + '_hostname'))).Replace('-','').Substring(0,32).ToLower()
+                        } finally { $sha.Dispose() }
+                        $hostnameValue = $hnPrefix + '_' + $hnHash.Substring(0,8) + '-' + $hnHash.Substring(8,4) + '-' + $hnHash.Substring(12,4) + '-' + $hnHash.Substring(16,4) + '-' + $hnHash.Substring(20,12)
+                    } else {
+                        $hostIdValue = $vmsessionhosts.Id
+                        $hostnameValue = $vmsessionhosts.Name
+                    }
+                }
+
                 $obj = @{
                     'ID'                 = $1.id;
                     'Subscription'       = $sub1.Name;
@@ -43,8 +62,8 @@ if ($Task -eq 'Processing')
                     'AVDAgentVersion'    = $2.properties.agentVersion;
                     'AllowNewSession'    = $2.properties.allowNewSession;
                     'UpdateStatus'       = $2.properties.updateState;
-                    'HostId'             = $vmsessionhosts.Id;
-                    'Hostname'           = $vmsessionhosts.name;
+                    'HostId'             = $hostIdValue;
+                    'Hostname'           = $hostnameValue;
                     'VMSize'             = $vmsessionhosts.properties.hardwareProfile.vmsize;
                     'OSType'             = $vmsessionhosts.properties.storageProfile.osdisk.ostype;
                     'VMDiskType'         = $vmsessionhosts.properties.storageProfile.osdisk.managedDisk.storageAccountType;

--- a/Services/Compute/AppServicePlan.ps1
+++ b/Services/Compute/AppServicePlan.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Compute/AppServices.ps1
+++ b/Services/Compute/AppServices.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 If ($Task -eq 'Processing')
 {
@@ -26,7 +26,7 @@ If ($Task -eq 'Processing')
                 'AvailabilityState'             = $data.availabilityState;
                 'SiteProperties'                = $data.siteProperties;          
                 'ContainerSize'                 = $data.containerSize;
-                'ServerFarmId'                  = $data.serverFarmId;
+                'ServerFarmId'                  = if (![string]::IsNullOrEmpty($data.serverFarmId) -and $null -ne $ResourceIdDictionary) { if ($ResourceIdDictionary.ContainsKey($data.serverFarmId)) { $ResourceIdDictionary[$data.serverFarmId] } else { 'obfuscated' } } else { $data.serverFarmId };
             }
 
             $tmp += $obj

--- a/Services/Compute/CloudServices.ps1
+++ b/Services/Compute/CloudServices.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Compute/VMWare.ps1
+++ b/Services/Compute/VMWare.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Compute/VirtualMachines.ps1
+++ b/Services/Compute/VirtualMachines.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 If ($Task -eq 'Processing')
 {
@@ -9,11 +9,20 @@ If ($Task -eq 'Processing')
 
     foreach($location in ($virtualMachines | Select-Object -ExpandProperty location -Unique))
     {
-        foreach ($vmsize in ( az vm list-sizes -l $location | ConvertFrom-Json))
+        $savedDebugPref = $DebugPreference
+        $DebugPreference = 'SilentlyContinue'
+        $skus = Get-AzComputeResourceSku -Location $location | Where-Object { $_.ResourceType -eq 'virtualMachines' }
+        $DebugPreference = $savedDebugPref
+
+        foreach ($vmsize in $skus)
         {
-            $vmsizemap[$vmsize.name] = @{
-                CPU = $vmSize.numberOfCores
-                RAM = [math]::Max($vmSize.memoryInMB / 1024, 0) 
+            $cpuCap = ($vmsize.Capabilities | Where-Object { $_.Name -eq 'vCPUs' }).Value
+            $memCap = ($vmsize.Capabilities | Where-Object { $_.Name -eq 'MemoryGB' }).Value
+            if ($null -ne $cpuCap -and -not $vmsizemap.ContainsKey($vmsize.Name)) {
+                $vmsizemap[$vmsize.Name] = @{
+                    CPU = [int]$cpuCap
+                    RAM = [math]::Max([decimal]$memCap, 0)
+                }
             }
         }
     }
@@ -59,7 +68,7 @@ If ($Task -eq 'Processing')
 
             $powerState = if ($null -ne $data.extended.instanceView.powerState.displayStatus) { $data.extended.instanceView.powerState.displayStatus } else { 'vm unknown' }    
 
-            $tags = if(![string]::IsNullOrEmpty($vm.tags.psobject.properties)){$vm.tags.psobject.properties | Select-Object Name, Value } else{ $null }
+            $tags = if(![string]::IsNullOrEmpty($vm.tags.psobject.properties)){@($vm.tags.psobject.properties | Select-Object Name, Value) } else{ $null }
 
             $obj = @{
                 'ID'                            = $vm.id;
@@ -71,7 +80,7 @@ If ($Task -eq 'Processing')
                 'Size'                          = $data.hardwareProfile.vmSize;
                 'CPU'                           = $cpus;
                 'Memory'                        = $ram;
-                'Set'                           = $data.virtualMachineScaleSet.id;
+                'Set'                           = if (![string]::IsNullOrEmpty($data.virtualMachineScaleSet.id) -and $null -ne $ResourceIdDictionary) { if ($ResourceIdDictionary.ContainsKey($data.virtualMachineScaleSet.id)) { $ResourceIdDictionary[$data.virtualMachineScaleSet.id] } else { 'obfuscated' } } else { $data.virtualMachineScaleSet.id };
                 'ImageReference'                = $data.storageProfile.imageReference.publisher;
                 'ImageVersion'                  = $data.storageProfile.imageReference.exactVersion;
                 'ImageSku'                      = $data.storageProfile.imageReference.sku;

--- a/Services/Containers/AKS.ps1
+++ b/Services/Containers/AKS.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Containers/CONTAINER.ps1
+++ b/Services/Containers/CONTAINER.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Containers/REGISTRIES.ps1
+++ b/Services/Containers/REGISTRIES.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Containers/VMSS.ps1
+++ b/Services/Containers/VMSS.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {
@@ -11,11 +11,20 @@ if ($Task -eq 'Processing')
 
     foreach($location in ($vmss | Select-Object -ExpandProperty location -Unique))
     {
-        foreach ($vmsize in (az vm list-sizes -l $location | ConvertFrom-Json))
+        $savedDebugPref = $DebugPreference
+        $DebugPreference = 'SilentlyContinue'
+        $skus = Get-AzComputeResourceSku -Location $location | Where-Object { $_.ResourceType -eq 'virtualMachines' }
+        $DebugPreference = $savedDebugPref
+
+        foreach ($vmsize in $skus)
         {
-            $vmsizemap[$vmsize.name] = @{
-                CPU = $vmSize.numberOfCores
-                RAM = [math]::Max($vmSize.memoryInMB / 1024, 0) 
+            $cpuCap = ($vmsize.Capabilities | Where-Object { $_.Name -eq 'vCPUs' }).Value
+            $memCap = ($vmsize.Capabilities | Where-Object { $_.Name -eq 'MemoryGB' }).Value
+            if ($null -ne $cpuCap -and -not $vmsizemap.ContainsKey($vmsize.Name)) {
+                $vmsizemap[$vmsize.Name] = @{
+                    CPU = [int]$cpuCap
+                    RAM = [math]::Max([decimal]$memCap, 0)
+                }
             }
         }
     }

--- a/Services/Data/CosmosDB.ps1
+++ b/Services/Data/CosmosDB.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/MariaDB.ps1
+++ b/Services/Data/MariaDB.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/MySQL.ps1
+++ b/Services/Data/MySQL.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/MySQLflexible.ps1
+++ b/Services/Data/MySQLflexible.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/POSTGRE.ps1
+++ b/Services/Data/POSTGRE.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/PostgreSQLflexible.ps1
+++ b/Services/Data/PostgreSQLflexible.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/Purview.ps1
+++ b/Services/Data/Purview.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -24,8 +24,8 @@ if ($Task -eq 'Processing')
                 'Location'            = $1.LOCATION;
                 'SKU'                 = $data.sku.name;
                 'Capacity'            = $data.sku.capacity;
-                'FriendlyName'        = $data.friendlyName;
-                'CreatedBy'           = $data.createdBy;      
+                'FriendlyName'        = if ($null -ne $ResourceIdDictionary) { 'obfuscated' } else { $data.friendlyName };
+                'CreatedBy'           = if ($null -ne $ResourceIdDictionary) { 'obfuscated' } else { $data.createdBy };      
                 'CreatedTime'         = $timecreated;                      
             }
 

--- a/Services/Data/RedisCache.ps1
+++ b/Services/Data/RedisCache.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/SQLDB.ps1
+++ b/Services/Data/SQLDB.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task , $File, $SmaResources, $TableStyle, $Metrics) 
+param($SCPath, $Sub, $Resources, $Task , $File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary) 
 
 if ($Task -eq 'Processing') 
 {
@@ -15,6 +15,12 @@ if ($Task -eq 'Processing')
             $DBServer = [string]$1.id.split("/")[8]
 
             if (![string]::IsNullOrEmpty($data.elasticPoolId)) { $PoolId = $data.elasticPoolId.Split("/")[10] } else { $PoolId = "None"}
+
+            if ($null -ne $ResourceIdDictionary) {
+                $serverParentId = ($1.id -split '/databases/')[0]
+                $DBServer = if ($ResourceIdDictionary.ContainsKey($serverParentId)) { $ResourceIdDictionary[$serverParentId] } else { 'obfuscated' }
+                $PoolId = if ($PoolId -ne "None" -and ![string]::IsNullOrEmpty($data.elasticPoolId) -and $ResourceIdDictionary.ContainsKey($data.elasticPoolId)) { $ResourceIdDictionary[$data.elasticPoolId] } else { if ($PoolId -ne "None") { 'obfuscated' } else { $PoolId } }
+            }
             if ($1.kind.Contains("vcore")) { $SqlType = "vcore" } else { $SqlType = "dtu"}
             if ($1.kind.Contains("serverless")) { $ComputeTier = "Serverless" } else { $ComputeTier = "Provisioned"}
 

--- a/Services/Data/SQLMI.ps1
+++ b/Services/Data/SQLMI.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -25,7 +25,7 @@ if ($Task -eq 'Processing')
                 'SkuCapacity'                   = $1.sku.capacity;
                 'SkuTier'                       = $1.sku.tier;
                 'SkuFamily'                     = $1.sku.family;
-                'InstancePoolName'              = $data.instancePoolId;
+                'InstancePoolName'              = if (![string]::IsNullOrEmpty($data.instancePoolId) -and $null -ne $ResourceIdDictionary) { if ($ResourceIdDictionary.ContainsKey($data.instancePoolId)) { $ResourceIdDictionary[$data.instancePoolId] } else { 'obfuscated' } } else { $data.instancePoolId };
                 'vCores'                        = $data.vCores;
                 'StorageGB'                     = $data.storageSizeInGB;
                 'StorageAccountType'            = $data.storageAccountType;
@@ -66,7 +66,6 @@ else
         $Exc.Add('StorageGB')
         $Exc.Add('StorageAccountType')
         $Exc.Add('State')
-        $Exc.Add('vCores')
         $Exc.Add('ManagedInstanceCreateMode')
         $Exc.Add('ZoneRedundant')
         $Exc.Add('Databases')

--- a/Services/Data/SQLMIDB.ps1
+++ b/Services/Data/SQLMIDB.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -16,7 +16,7 @@ if ($Task -eq 'Processing')
             $obj = @{
                 'ID'                        = $1.id;
                 'Subscription'              = $sub1.Name;
-                'ManagedInstance'           = $1.id.split("/")[8];
+                'ManagedInstance'           = if ($null -ne $ResourceIdDictionary) { $miParentId = ($1.id -split '/databases/')[0]; if ($ResourceIdDictionary.ContainsKey($miParentId)) { $ResourceIdDictionary[$miParentId] } else { 'obfuscated' } } else { $1.id.split("/")[8] };
                 'Name'                      = $1.NAME;
                 'Collation'                 = $data.collation;
                 'CreationDate'              = $data.creationDate;

--- a/Services/Data/SQLPOOL.ps1
+++ b/Services/Data/SQLPOOL.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/SQLSERVER.ps1
+++ b/Services/Data/SQLSERVER.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Data/SQLVM.ps1
+++ b/Services/Data/SQLVM.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 If ($Task -eq 'Processing') 
 {

--- a/Services/Infrastructure/AppGW.ps1
+++ b/Services/Infrastructure/AppGW.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Infrastructure/AutomationAcc.ps1
+++ b/Services/Infrastructure/AutomationAcc.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Infrastructure/AvSet.ps1
+++ b/Services/Infrastructure/AvSet.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {
@@ -15,7 +15,7 @@ if ($Task -eq 'Processing')
             
             foreach ($vmid in $data.virtualMachines.id) 
             {
-                $vmIds = $vmid.split('/')[8]
+                $vmIds = if ($null -ne $ResourceIdDictionary) { if ($ResourceIdDictionary.ContainsKey($vmid)) { $ResourceIdDictionary[$vmid] } else { 'obfuscated' } } else { $vmid.split('/')[8] }
                 
                 $obj = @{
                     'ID'               = $1.id;

--- a/Services/Infrastructure/BASTION.ps1
+++ b/Services/Infrastructure/BASTION.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Infrastructure/Frontdoor.ps1
+++ b/Services/Infrastructure/Frontdoor.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -12,7 +12,10 @@ if ($Task -eq 'Processing')
         {
             $sub1 = $SUB | Where-Object { $_.id -eq $1.subscriptionId }
             $data = $1.PROPERTIES
-            if([string]::IsNullOrEmpty($data.frontendendpoints.properties.webApplicationFirewallPolicyLink.id)){$WAF = $false} else {$WAF = $data.frontendendpoints.properties.webApplicationFirewallPolicyLink.id.split('/')[8]}
+            if([string]::IsNullOrEmpty($data.frontendendpoints.properties.webApplicationFirewallPolicyLink.id)){$WAF = $false} else {
+                $wafId = $data.frontendendpoints.properties.webApplicationFirewallPolicyLink.id
+                $WAF = if ($null -ne $ResourceIdDictionary) { if ($ResourceIdDictionary.ContainsKey($wafId)) { $ResourceIdDictionary[$wafId] } else { 'obfuscated' } } else { $wafId.split('/')[8] }
+            }
             
             $obj = @{
                 'ID'                        = $1.id;

--- a/Services/Infrastructure/RecoveryVault.ps1
+++ b/Services/Infrastructure/RecoveryVault.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Infrastructure/Vault.ps1
+++ b/Services/Infrastructure/Vault.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Integration/APIM.ps1
+++ b/Services/Integration/APIM.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Integration/AppInsights.ps1
+++ b/Services/Integration/AppInsights.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Integration/IOTHubs.ps1
+++ b/Services/Integration/IOTHubs.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -13,7 +13,7 @@ if ($Task -eq 'Processing')
             $sub1 = $SUB | Where-Object { $_.id -eq $1.subscriptionId }
             $data = $1.PROPERTIES
             
-            foreach ($Tag in $Tags) 
+            foreach ($loc in $data.locations) 
             {
                 $obj = @{
                     'ID'                                = $1.id;

--- a/Services/Integration/ServiceBUS.ps1
+++ b/Services/Integration/ServiceBUS.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Networking/AzureFirewall.ps1
+++ b/Services/Networking/AzureFirewall.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -16,7 +16,7 @@ if ($Task -eq 'Processing')
             $obj = @{
                 'ID'                                = $1.id;
                 'Subscription'                      = $sub1.Name;
-                'Resource Group'                    = $1.RESOURCEGROUP;
+                'ResourceGroup'                     = $1.RESOURCEGROUP;
                 'Name'                              = $1.NAME;
                 'Location'                          = $1.LOCATION;
                 'SKU'                               = $data.sku.tier;
@@ -39,7 +39,7 @@ else
 
         $Exc = New-Object System.Collections.Generic.List[System.Object]
         $Exc.Add('Subscription')
-        $Exc.Add('Resource Group')
+        $Exc.Add('ResourceGroup')
         $Exc.Add('Name')
         $Exc.Add('Location')
         $Exc.Add('SKU')

--- a/Services/Networking/ExpressRoute.ps1
+++ b/Services/Networking/ExpressRoute.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {

--- a/Services/Networking/LoadBalancer.ps1
+++ b/Services/Networking/LoadBalancer.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/NATGAteway.ps1
+++ b/Services/Networking/NATGAteway.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/PublicDNS.ps1
+++ b/Services/Networking/PublicDNS.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/PublicIP.ps1
+++ b/Services/Networking/PublicIP.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -29,7 +29,7 @@ if ($Task -eq 'Processing')
                     'Version'                  = $data.publicIPAddressVersion;
                     'ProvisioningState'        = $data.provisioningState;
                     'Use'                      = $Use;
-                    'AssociatedResource'       = $data.ipConfiguration.id.split('/')[8];
+                    'AssociatedResource'       = if ($null -ne $ResourceIdDictionary) { if ($ResourceIdDictionary.ContainsKey($data.ipConfiguration.id)) { $ResourceIdDictionary[$data.ipConfiguration.id] } else { 'obfuscated' } } else { $data.ipConfiguration.id.split('/')[8] };
                     'AssociatedResourceType'   = $data.ipConfiguration.id.split('/')[7];
                 }
 

--- a/Services/Networking/TrafficManager.ps1
+++ b/Services/Networking/TrafficManager.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/VNETGTW.ps1
+++ b/Services/Networking/VNETGTW.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Networking/VirtualWAN.ps1
+++ b/Services/Networking/VirtualWAN.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/ComputeSnapshots.ps1
+++ b/Services/Storage/ComputeSnapshots.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task, $File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {
@@ -28,7 +28,7 @@ if ($Task -eq 'Processing')
                 'OS'                                    = $data.osType;
                 'Incremental'                           = $data.incremental;
                 'CreatedTime'                           = $timecreated;
-                'SourceResourceId'                      = $data.creationData.sourceResourceId;
+                'SourceResourceId'                      = if (![string]::IsNullOrEmpty($data.creationData.sourceResourceId) -and $null -ne $ResourceIdDictionary) { if ($ResourceIdDictionary.ContainsKey($data.creationData.sourceResourceId)) { $ResourceIdDictionary[$data.creationData.sourceResourceId] } else { 'obfuscated' } } else { $data.creationData.sourceResourceId };
             }
 
             $tmp += $obj

--- a/Services/Storage/DataExplorerCluster.ps1
+++ b/Services/Storage/DataExplorerCluster.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/NetApp.ps1
+++ b/Services/Storage/NetApp.ps1
@@ -1,4 +1,4 @@
-param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/StorageAcc.ps1
+++ b/Services/Storage/StorageAcc.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing') 
 {

--- a/Services/Storage/VMDisk.ps1
+++ b/Services/Storage/VMDisk.ps1
@@ -1,4 +1,4 @@
-﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics)
+﻿param($SCPath, $Sub, $Resources, $Task ,$File, $SmaResources, $TableStyle, $Metrics, $ResourceIdDictionary)
 
 if ($Task -eq 'Processing')
 {
@@ -23,7 +23,7 @@ if ($Task -eq 'Processing')
                 'ResourceGroup'         = $disk.RESOURCEGROUP;
                 'Name'                  = $disk.NAME;
                 'State'                 = $data.diskState;
-                'AssociatedResource'    = $disk.MANAGEDBY.split('/')[8];
+                'AssociatedResource'    = if (![string]::IsNullOrEmpty($disk.MANAGEDBY) -and $null -ne $ResourceIdDictionary) { if ($ResourceIdDictionary.ContainsKey($disk.MANAGEDBY)) { $ResourceIdDictionary[$disk.MANAGEDBY] } else { 'obfuscated' } } else { if(![string]::IsNullOrEmpty($disk.MANAGEDBY)){ $disk.MANAGEDBY.split('/')[8] } else { $null } };
                 'Location'              = $disk.LOCATION;
                 'SKU'                   = $SKU.Name;
                 'Tier'                  = $data.Tier;

--- a/Tests/DataIntegrity.Tests.ps1
+++ b/Tests/DataIntegrity.Tests.ps1
@@ -1,0 +1,224 @@
+# Data Integrity Tests
+# Validates the actual obfuscated data for PII leaks and cross-reference correctness
+# Run with: Invoke-Pester ./Tests/DataIntegrity.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    $zipPath = if ($env:TEST_ZIP_PATH) { $env:TEST_ZIP_PATH } else {
+        Get-ChildItem -Path $PSScriptRoot -Filter "ResourcesReport_*.zip" | 
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+    if ([string]::IsNullOrEmpty($zipPath) -or -not (Test-Path $zipPath)) {
+        throw "No test zip found. Copy a ResourcesReport_*.zip to Tests/ or set `$env:TEST_ZIP_PATH"
+    }
+    $tmpBase = if ($env:TMPDIR) { $env:TMPDIR } elseif ($env:TEMP) { $env:TEMP } else { "/tmp" }
+    $script:ExtractPath = Join-Path $tmpBase ("DataIntTest_" + [guid]::NewGuid().ToString().Substring(0,8))
+    New-Item -ItemType Directory -Path $script:ExtractPath -Force | Out-Null
+    Expand-Archive -Path $zipPath -DestinationPath $script:ExtractPath -Force
+
+    $invFile = Get-ChildItem -Path $script:ExtractPath -Filter "Inventory_*.json" | Select-Object -First 1
+    $script:Inventory = if ($invFile) { Get-Content $invFile.FullName -Raw | ConvertFrom-Json } else { $null }
+
+    # Read all file contents for scanning
+    $script:AllContent = @{}
+    foreach ($file in (Get-ChildItem -Path $script:ExtractPath -File)) {
+        $script:AllContent[$file.Name] = Get-Content $file.FullName -Raw
+    }
+
+    $script:ObfuscationPattern = '^(prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+}
+
+AfterAll {
+    if (Test-Path $script:ExtractPath) { Remove-Item -Path $script:ExtractPath -Recurse -Force }
+}
+
+# ============================================================
+# 1. PII Leak Scan — no real Azure identifiers in any output file
+# ============================================================
+Describe "PII Leak Scan" {
+    It "Should not contain /subscriptions/ resource paths in any file" {
+        $pattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}'
+        foreach ($fileName in $script:AllContent.Keys) {
+            if ([string]::IsNullOrEmpty($script:AllContent[$fileName])) { continue }
+            $script:AllContent[$fileName] | Should -Not -Match $pattern -Because "File '$fileName' should not contain Azure resource paths"
+        }
+    }
+
+    It "Should not contain Azure tenant ID patterns in any file" {
+        $pattern = '"tenant[Ii][Dd]"\s*:\s*"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
+        foreach ($fileName in $script:AllContent.Keys) {
+            if ([string]::IsNullOrEmpty($script:AllContent[$fileName])) { continue }
+            $script:AllContent[$fileName] | Should -Not -Match $pattern -Because "File '$fileName' should not contain tenant IDs"
+        }
+    }
+
+    It "Should not contain email addresses in any file" {
+        $pattern = '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
+        foreach ($fileName in $script:AllContent.Keys) {
+            if ([string]::IsNullOrEmpty($script:AllContent[$fileName])) { continue }
+            $matches = [regex]::Matches($script:AllContent[$fileName], $pattern)
+            $matches.Count | Should -Be 0 -Because "File '$fileName' should not contain email addresses"
+        }
+    }
+
+    It "Should not contain home directory paths in any file" {
+        foreach ($fileName in $script:AllContent.Keys) {
+            if ([string]::IsNullOrEmpty($script:AllContent[$fileName])) { continue }
+            $script:AllContent[$fileName] | Should -Not -Match '/home/[a-zA-Z]' -Because "File '$fileName' should not contain Unix home paths"
+            $script:AllContent[$fileName] | Should -Not -Match 'C:\\Users\\[a-zA-Z]' -Because "File '$fileName' should not contain Windows user paths"
+        }
+    }
+}
+
+# ============================================================
+# 2. Cross-Reference Integrity — obfuscated IDs match across types
+# ============================================================
+Describe "Cross-Reference Integrity" {
+    It "Every VMDisk AssociatedResource should match a VM ID or be null" {
+        $disks = @($script:Inventory.VMDisk)
+        $vmIds = @($script:Inventory.VirtualMachines) | Where-Object { $null -ne $_ } | ForEach-Object { $_.ID }
+        foreach ($disk in $disks) {
+            if ($null -ne $disk -and ![string]::IsNullOrEmpty($disk.AssociatedResource)) {
+                $disk.AssociatedResource | Should -BeIn $vmIds -Because "Disk '$($disk.ID)' should reference a known VM"
+            }
+        }
+    }
+
+    It "Every AVD HostId should match a VM ID or be null" {
+        $avd = @($script:Inventory.AVD)
+        $vmIds = @($script:Inventory.VirtualMachines) | Where-Object { $null -ne $_ } | ForEach-Object { $_.ID }
+        foreach ($item in $avd) {
+            if ($null -ne $item -and ![string]::IsNullOrEmpty($item.HostId)) {
+                $item.HostId | Should -BeIn $vmIds -Because "AVD HostId should reference a known VM"
+            }
+        }
+    }
+
+    It "AVD Hostname should differ from HostId" {
+        $avd = @($script:Inventory.AVD)
+        foreach ($item in $avd) {
+            if ($null -ne $item -and ![string]::IsNullOrEmpty($item.HostId) -and ![string]::IsNullOrEmpty($item.Hostname)) {
+                $item.Hostname | Should -Not -Be $item.HostId -Because "Hostname and HostId should be different values"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 3. Deterministic Mapping — same real sub/RG = same obfuscated value
+# ============================================================
+Describe "Deterministic Mapping" {
+    It "All resources should share the same subscription value per real subscription" {
+        $subs = @()
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object { if ($null -ne $_ -and $null -ne $_.Subscription) { $subs += $_.Subscription } }
+        }
+        $uniqueSubs = $subs | Select-Object -Unique
+        # Unique subs should be far fewer than total resources
+        $uniqueSubs.Count | Should -BeLessOrEqual $subs.Count -Because "Subscription values should be reused (deterministic)"
+        # For a single-subscription environment, should be exactly 1
+        if ($subs.Count -gt 1) {
+            $uniqueSubs.Count | Should -BeLessThan $subs.Count -Because "Multiple resources should share subscription values"
+        }
+    }
+
+    It "ResourceGroup values should be reused across resources in the same RG" {
+        $rgs = @()
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object { if ($null -ne $_ -and $null -ne $_.ResourceGroup) { $rgs += $_.ResourceGroup } }
+        }
+        $uniqueRGs = $rgs | Select-Object -Unique
+        $uniqueRGs.Count | Should -BeLessOrEqual $rgs.Count -Because "ResourceGroup values should be reused (deterministic)"
+    }
+}
+
+# ============================================================
+# 4. Non-Sensitive Fields Preserved — real values not obfuscated
+# ============================================================
+Describe "Non-Sensitive Fields Preserved" {
+    It "VM Location should be a real Azure region" {
+        foreach ($vm in @($script:Inventory.VirtualMachines)) {
+            if ($null -ne $vm -and ![string]::IsNullOrEmpty($vm.Location)) {
+                $vm.Location | Should -Not -Match '^(prod|nonprod)_' -Because "Location should be a real region"
+            }
+        }
+    }
+
+    It "VM Size should be a real Azure VM size" {
+        foreach ($vm in @($script:Inventory.VirtualMachines)) {
+            if ($null -ne $vm -and ![string]::IsNullOrEmpty($vm.Size)) {
+                $vm.Size | Should -Match '^standard_' -Because "VM Size should be a real Azure size"
+            }
+        }
+    }
+
+    It "VM OS should be windows or linux" {
+        foreach ($vm in @($script:Inventory.VirtualMachines)) {
+            if ($null -ne $vm -and ![string]::IsNullOrEmpty($vm.OS)) {
+                $vm.OS | Should -BeIn @('windows', 'linux') -Because "OS should be a real OS type"
+            }
+        }
+    }
+
+    It "Storage SKU should not be obfuscated" {
+        foreach ($sa in @($script:Inventory.StorageAcc)) {
+            if ($null -ne $sa -and ![string]::IsNullOrEmpty($sa.SKU)) {
+                $sa.SKU | Should -Not -Match '^(prod|nonprod)_' -Because "Storage SKU should be real"
+            }
+        }
+    }
+
+    It "Tags should be null on all resources" {
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_ -and $_.PSObject.Properties.Name -contains 'Tags') {
+                    $_.Tags | Should -BeNullOrEmpty -Because "Tags should be stripped when obfuscating"
+                }
+            }
+        }
+    }
+}
+
+# ============================================================
+# 5. No Null Obfuscated Fields — fallbacks should generate values
+# ============================================================
+Describe "No Null Obfuscated Fields" {
+    It "No resource should have a null ID" {
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_) {
+                    $_.ID | Should -Not -BeNullOrEmpty -Because "Every resource should have an obfuscated ID"
+                }
+            }
+        }
+    }
+
+    It "No resource should have a null Name" {
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_ -and $_.PSObject.Properties.Name -contains 'Name') {
+                    $_.Name | Should -Not -BeNullOrEmpty -Because "Every resource should have an obfuscated Name"
+                }
+            }
+        }
+    }
+
+    It "No resource should have a null Subscription" {
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_ -and $_.PSObject.Properties.Name -contains 'Subscription') {
+                    $_.Subscription | Should -Not -BeNullOrEmpty -Because "Every resource should have an obfuscated Subscription"
+                }
+            }
+        }
+    }
+
+    It "No resource should have a null ResourceGroup" {
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_ -and $_.PSObject.Properties.Name -contains 'ResourceGroup') {
+                    $_.ResourceGroup | Should -Not -BeNullOrEmpty -Because "Every resource should have an obfuscated ResourceGroup"
+                }
+            }
+        }
+    }
+}

--- a/Tests/DictionaryValidation.Tests.ps1
+++ b/Tests/DictionaryValidation.Tests.ps1
@@ -1,0 +1,94 @@
+# Dictionary Validation Tests
+# Validates the obfuscation dictionary file is correct and complete
+# Run with: $env:TEST_DICT_PATH = "./path/to/ObfuscationDictionary_*.json"; Invoke-Pester ./Tests/DictionaryValidation.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    $dictPath = if ($env:TEST_DICT_PATH) { $env:TEST_DICT_PATH } else {
+        # Look in Tests/ folder first
+        $found = Get-ChildItem -Path $PSScriptRoot -Filter "ObfuscationDictionary_*.json" | 
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+        if ([string]::IsNullOrEmpty($found)) {
+            # Try next to the zip file
+            $zipDir = if ($env:TEST_ZIP_PATH) { Split-Path $env:TEST_ZIP_PATH -Parent } else { $PSScriptRoot }
+            Get-ChildItem -Path $zipDir -Filter "ObfuscationDictionary_*.json" -ErrorAction SilentlyContinue | 
+                Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+        } else { $found }
+    }
+    if ([string]::IsNullOrEmpty($dictPath) -or -not (Test-Path $dictPath)) {
+        throw "No dictionary file found. Copy an ObfuscationDictionary_*.json to Tests/ or next to the zip, or set `$env:TEST_DICT_PATH"
+    }
+    $script:Dictionary = Get-Content $dictPath -Raw | ConvertFrom-Json
+
+    # Also load inventory if available
+    $zipPath = if ($env:TEST_ZIP_PATH) { $env:TEST_ZIP_PATH } else {
+        Get-ChildItem -Path $PSScriptRoot -Filter "ResourcesReport_*.zip" | 
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+    $script:Inventory = $null
+    if (![string]::IsNullOrEmpty($zipPath) -and (Test-Path $zipPath)) {
+        $tmpBase = if ($env:TMPDIR) { $env:TMPDIR } elseif ($env:TEMP) { $env:TEMP } else { "/tmp" }
+        $script:ExtractPath = Join-Path $tmpBase ("DictTest_" + [guid]::NewGuid().ToString().Substring(0,8))
+        New-Item -ItemType Directory -Path $script:ExtractPath -Force | Out-Null
+        Expand-Archive -Path $zipPath -DestinationPath $script:ExtractPath -Force
+        $invFile = Get-ChildItem -Path $script:ExtractPath -Filter "Inventory_*.json" | Select-Object -First 1
+        if ($invFile) { $script:Inventory = Get-Content $invFile.FullName -Raw | ConvertFrom-Json }
+    }
+
+    $script:ObfuscationPattern = '^(prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    $script:AzureIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}'
+}
+
+AfterAll {
+    if ($script:ExtractPath -and (Test-Path $script:ExtractPath)) { Remove-Item -Path $script:ExtractPath -Recurse -Force }
+}
+
+Describe "Dictionary Structure" {
+    It "Should be valid JSON with all four maps" {
+        $script:Dictionary | Should -Not -BeNullOrEmpty
+        $script:Dictionary.PSObject.Properties.Name | Should -Contain 'ResourceIdMap'
+        $script:Dictionary.PSObject.Properties.Name | Should -Contain 'ResourceNameMap'
+        $script:Dictionary.PSObject.Properties.Name | Should -Contain 'SubscriptionMap'
+        $script:Dictionary.PSObject.Properties.Name | Should -Contain 'ResourceGroupMap'
+    }
+
+    It "Should have a GeneratedAt timestamp" {
+        $script:Dictionary.GeneratedAt | Should -Not -BeNullOrEmpty
+    }
+
+    It "ResourceIdMap keys should be obfuscated values" {
+        $keys = $script:Dictionary.ResourceIdMap.PSObject.Properties.Name
+        foreach ($key in $keys) {
+            $key | Should -Match $script:ObfuscationPattern -Because "Dictionary key '$key' should be an obfuscated ID"
+        }
+    }
+
+    It "ResourceIdMap values should be real Azure resource IDs" {
+        $values = $script:Dictionary.ResourceIdMap.PSObject.Properties.Value
+        foreach ($val in $values) {
+            $val | Should -Match $script:AzureIdPattern -Because "Dictionary value should be a real Azure resource ID"
+        }
+    }
+}
+
+Describe "Dictionary Completeness" {
+    It "Every obfuscated ID in inventory should have a dictionary entry" {
+        if ($null -eq $script:Inventory) { Set-ItResult -Skipped -Because "No inventory zip provided"; return }
+        $dictKeys = $script:Dictionary.ResourceIdMap.PSObject.Properties.Name
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_.ID) {
+                    $_.ID | Should -BeIn $dictKeys -Because "Inventory ID '$($_.ID)' should have a dictionary entry"
+                }
+            }
+        }
+    }
+}
+
+Describe "No Double Obfuscation" {
+    It "No obfuscated value should appear as a dictionary value (real ID)" {
+        $values = $script:Dictionary.ResourceIdMap.PSObject.Properties.Value
+        foreach ($val in $values) {
+            $val | Should -Not -Match $script:ObfuscationPattern -Because "Real ID '$val' should not look like an obfuscated value"
+        }
+    }
+}

--- a/Tests/Obfuscation.Tests.ps1
+++ b/Tests/Obfuscation.Tests.ps1
@@ -1,0 +1,523 @@
+# Obfuscation Tests for Resource Discovery for Azure
+# Run with: Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    # Find the zip
+    $zipPath = if ($env:TEST_ZIP_PATH) { $env:TEST_ZIP_PATH } else {
+        Get-ChildItem -Path $PSScriptRoot -Filter "ResourcesReport_*.zip" | 
+            Sort-Object LastWriteTime -Descending | 
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    if ([string]::IsNullOrEmpty($zipPath) -or -not (Test-Path $zipPath)) {
+        throw "No test zip found. Copy a ResourcesReport_*.zip to the Tests/ folder or set `$env:TEST_ZIP_PATH"
+    }
+
+    # Extract to temp folder
+    $tmpBase = if ($env:TMPDIR) { $env:TMPDIR } elseif ($env:TEMP) { $env:TEMP } else { "/tmp" }
+    $script:ExtractPath = Join-Path $tmpBase ("ObfuscationTest_" + [guid]::NewGuid().ToString().Substring(0,8))
+    New-Item -ItemType Directory -Path $script:ExtractPath -Force | Out-Null
+    Expand-Archive -Path $zipPath -DestinationPath $script:ExtractPath -Force
+
+    # Load files
+    $script:InventoryFile = Get-ChildItem -Path $script:ExtractPath -Filter "Inventory_*.json" | Select-Object -First 1
+    $script:MetricsFiles = @(Get-ChildItem -Path $script:ExtractPath -Filter "Metrics_*.json")
+    $script:ConsumptionFile = Get-ChildItem -Path $script:ExtractPath -Filter "Consumption_*.csv" | Select-Object -First 1
+    $script:AllFiles = Get-ChildItem -Path $script:ExtractPath -File
+
+    # Parse inventory JSON
+    if ($script:InventoryFile) {
+        $script:Inventory = Get-Content $script:InventoryFile.FullName -Raw | ConvertFrom-Json
+    }
+
+    # Read all file contents once for PII scanning
+    $script:AllContent = @{}
+    foreach ($file in $script:AllFiles) {
+        $script:AllContent[$file.Name] = Get-Content $file.FullName -Raw
+    }
+
+    # Obfuscation pattern: prod_ or nonprod_ followed by a GUID
+    $script:ObfuscationPattern = '^(prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+    # Helper: get all resources from inventory as flat list
+    $script:AllResources = @()
+    if ($script:Inventory) {
+        $props = $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' }
+        foreach ($prop in $props) {
+            $script:AllResources += @($prop.Value)
+        }
+    }
+}
+
+AfterAll {
+    if (Test-Path $script:ExtractPath) {
+        Remove-Item -Path $script:ExtractPath -Recurse -Force
+    }
+}
+
+# ============================================================
+# 1. Transcript excluded from zip
+# ============================================================
+Describe "Transcript Exclusion" {
+    It "Should not contain any transcript log files in the zip" {
+        $transcriptFiles = $script:AllFiles | Where-Object { $_.Name -like "Transcript_*" }
+        $transcriptFiles | Should -BeNullOrEmpty
+    }
+}
+
+# ============================================================
+# 2. No email addresses in any file
+# ============================================================
+Describe "Email Address Leak Check" {
+    It "Should not contain any email addresses in any output file" {
+        $emailPattern = '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
+        foreach ($fileName in $script:AllContent.Keys) {
+            if ([string]::IsNullOrEmpty($script:AllContent[$fileName])) { continue }
+            $matches = [regex]::Matches($script:AllContent[$fileName], $emailPattern)
+            $matches.Count | Should -Be 0 -Because "File '$fileName' should not contain email addresses (found: $($matches.Value -join ', '))"
+        }
+    }
+}
+
+# ============================================================
+# 3. No home directory paths in any file
+# ============================================================
+Describe "Home Directory Path Leak Check" {
+    It "Should not contain Unix home directory paths" {
+        foreach ($fileName in $script:AllContent.Keys) {
+            $script:AllContent[$fileName] | Should -Not -Match '/home/[a-zA-Z]' -Because "File '$fileName' should not contain Unix home paths"
+        }
+    }
+
+    It "Should not contain Windows user directory paths" {
+        foreach ($fileName in $script:AllContent.Keys) {
+            $script:AllContent[$fileName] | Should -Not -Match 'C:\\Users\\[a-zA-Z]' -Because "File '$fileName' should not contain Windows user paths"
+        }
+    }
+}
+
+# ============================================================
+# 4. No Azure subscription ID patterns (raw GUIDs in sub context)
+# ============================================================
+Describe "Subscription ID Leak Check" {
+    It "Should not contain raw Azure subscription ID patterns in inventory JSON" {
+        # Azure resource IDs follow: /subscriptions/<guid>/resourceGroups/...
+        $subIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        if ($script:InventoryFile) {
+            $content = $script:AllContent[$script:InventoryFile.Name]
+            $content | Should -Not -Match $subIdPattern -Because "Inventory JSON should not contain raw Azure resource ID paths"
+        }
+    }
+
+    It "Should not contain raw Azure subscription ID patterns in consumption CSV" {
+        $subIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        if ($script:ConsumptionFile) {
+            $content = $script:AllContent[$script:ConsumptionFile.Name]
+            $content | Should -Not -Match $subIdPattern -Because "Consumption CSV should not contain raw Azure resource ID paths"
+        }
+    }
+
+    It "Should not contain raw Azure subscription ID patterns in metrics JSON" {
+        $subIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        foreach ($metricsFile in $script:MetricsFiles) {
+            $content = $script:AllContent[$metricsFile.Name]
+            $content | Should -Not -Match $subIdPattern -Because "Metrics JSON should not contain raw Azure resource ID paths"
+        }
+    }
+}
+
+# ============================================================
+# 5. All inventory resource IDs are obfuscated
+# ============================================================
+Describe "Inventory ID Obfuscation" {
+    It "Should have all resource IDs matching the obfuscation pattern" {
+        $script:AllResources.Count | Should -BeGreaterThan 0 -Because "There should be at least one resource in the inventory"
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.ID) {
+                $resource.ID | Should -Match $script:ObfuscationPattern -Because "Resource ID '$($resource.ID)' should be obfuscated"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 6. All inventory resource names are obfuscated
+# ============================================================
+Describe "Inventory Name Obfuscation" {
+    It "Should have all resource names matching the obfuscation pattern" {
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.Name) {
+                $resource.Name | Should -Match $script:ObfuscationPattern -Because "Resource Name '$($resource.Name)' should be obfuscated"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 7. All inventory subscriptions are obfuscated
+# ============================================================
+Describe "Inventory Subscription Obfuscation" {
+    It "Should have all subscription fields matching the obfuscation pattern" {
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.Subscription) {
+                $resource.Subscription | Should -Match $script:ObfuscationPattern -Because "Subscription '$($resource.Subscription)' should be obfuscated"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 8. All inventory resource groups are obfuscated
+# ============================================================
+Describe "Inventory ResourceGroup Obfuscation" {
+    It "Should have all resource group fields matching the obfuscation pattern" {
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.ResourceGroup) {
+                $resource.ResourceGroup | Should -Match $script:ObfuscationPattern -Because "ResourceGroup '$($resource.ResourceGroup)' should be obfuscated"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 9. Metrics IDs are obfuscated
+# ============================================================
+Describe "Metrics Obfuscation" {
+    It "Should have all metric IDs and names matching the obfuscation pattern" {
+        foreach ($metricsFile in $script:MetricsFiles) {
+            $metricsData = Get-Content $metricsFile.FullName -Raw | ConvertFrom-Json
+            foreach ($metric in @($metricsData.Metrics)) {
+                if ($null -ne $metric.ID) {
+                    $metric.ID | Should -Match $script:ObfuscationPattern -Because "Metric ID should be obfuscated"
+                }
+                if ($null -ne $metric.Name) {
+                    $metric.Name | Should -Match $script:ObfuscationPattern -Because "Metric Name should be obfuscated"
+                }
+                if ($null -ne $metric.Subscription) {
+                    $metric.Subscription | Should -Match $script:ObfuscationPattern -Because "Metric Subscription should be obfuscated"
+                }
+                if ($null -ne $metric.ResourceGroup) {
+                    $metric.ResourceGroup | Should -Match $script:ObfuscationPattern -Because "Metric ResourceGroup should be obfuscated"
+                }
+            }
+        }
+    }
+}
+
+# ============================================================
+# 10. Consumption ResourceIds are obfuscated
+# ============================================================
+Describe "Consumption Obfuscation" {
+    It "Should have all consumption ResourceIds matching the obfuscation pattern" {
+        if ($null -eq $script:ConsumptionFile) { return }
+        $csv = Import-Csv $script:ConsumptionFile.FullName
+        if ($csv.Count -eq 0) { return }
+
+        foreach ($row in $csv) {
+            if (![string]::IsNullOrEmpty($row.ResourceId)) {
+                $row.ResourceId | Should -Match $script:ObfuscationPattern -Because "Consumption ResourceId should be obfuscated"
+            }
+        }
+    }
+
+    It "Should have obfuscated ResourceUri inside InstanceData JSON" {
+        if ($null -eq $script:ConsumptionFile) { return }
+        $csv = Import-Csv $script:ConsumptionFile.FullName
+        if ($csv.Count -eq 0) { return }
+
+        foreach ($row in $csv) {
+            if (![string]::IsNullOrEmpty($row.InstanceData)) {
+                $instanceData = $row.InstanceData | ConvertFrom-Json
+                $uri = $instanceData.'Microsoft.Resources'.ResourceUri
+                if (![string]::IsNullOrEmpty($uri)) {
+                    $uri | Should -Match $script:ObfuscationPattern -Because "InstanceData ResourceUri should be obfuscated"
+                }
+            }
+        }
+    }
+
+    It "Should have ReservationId obfuscated or empty" {
+        if ($null -eq $script:ConsumptionFile) { return }
+        $csv = Import-Csv $script:ConsumptionFile.FullName
+        if ($csv.Count -eq 0) { return }
+
+        $azureGuidPattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        foreach ($row in $csv) {
+            if (![string]::IsNullOrEmpty($row.ReservationId) -and $row.ReservationId -ne 'obfuscated') {
+                $row.ReservationId | Should -Not -Match $azureGuidPattern -Because "ReservationId should be obfuscated, not a raw GUID"
+            }
+        }
+    }
+
+    It "Should have ReservationOrderId obfuscated or empty" {
+        if ($null -eq $script:ConsumptionFile) { return }
+        $csv = Import-Csv $script:ConsumptionFile.FullName
+        if ($csv.Count -eq 0) { return }
+
+        $azureGuidPattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        foreach ($row in $csv) {
+            if (![string]::IsNullOrEmpty($row.ReservationOrderId) -and $row.ReservationOrderId -ne 'obfuscated') {
+                $row.ReservationOrderId | Should -Not -Match $azureGuidPattern -Because "ReservationOrderId should be obfuscated, not a raw GUID"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 11. Obfuscation prefix consistency (no plain GUIDs)
+# ============================================================
+Describe "Obfuscation Prefix Consistency" {
+    It "Should use prod_ or nonprod_ prefix on all IDs (not plain GUIDs)" {
+        $plainGuidPattern = '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        foreach ($resource in $script:AllResources) {
+            if ($null -ne $resource.ID) {
+                $resource.ID | Should -Not -Match $plainGuidPattern -Because "ID should have prod_/nonprod_ prefix"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 12. Valid metrics JSON structure
+# ============================================================
+Describe "Metrics JSON Structure" {
+    It "Should have valid metrics JSON with a Metrics array property" {
+        foreach ($metricsFile in $script:MetricsFiles) {
+            $raw = Get-Content $metricsFile.FullName -Raw
+            $parsed = $raw | ConvertFrom-Json
+            $parsed | Should -Not -BeNullOrEmpty -Because "Metrics file should be valid JSON"
+            $parsed.PSObject.Properties.Name | Should -Contain 'Metrics' -Because "Metrics JSON should have a Metrics property"
+        }
+    }
+}
+
+# ============================================================
+# 13. Consumption CSV has valid headers
+# ============================================================
+Describe "Consumption CSV Headers" {
+    It "Should have a consumption CSV with the correct header columns" {
+        if ($null -eq $script:ConsumptionFile) { return }
+        $firstLine = Get-Content $script:ConsumptionFile.FullName -TotalCount 1 -ErrorAction SilentlyContinue
+        if ([string]::IsNullOrEmpty($firstLine)) { return }
+
+        $expectedHeaders = @('InstanceData', 'MeterCategory', 'MeterId', 'MeterName', 'MeterRegion', 'MeterSubCategory', 'Quantity', 'Unit', 'UsageStartTime', 'UsageEndTime', 'ResourceId', 'ResourceLocation', 'ConsumptionMeter', 'ReservationId', 'ReservationOrderId')
+        foreach ($header in $expectedHeaders) {
+            $firstLine | Should -Match $header -Because "CSV should contain header '$header'"
+        }
+    }
+}
+
+# ============================================================
+# 14. No Azure tenant IDs leaked
+# ============================================================
+Describe "Tenant ID Leak Check" {
+    It "Should not contain Azure tenant ID patterns in output files" {
+        # Tenant IDs appear as: "tenantId":"<guid>" or tenantID
+        $tenantPattern = '"tenant[Ii][Dd]"\s*:\s*"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
+        foreach ($fileName in $script:AllContent.Keys) {
+            $script:AllContent[$fileName] | Should -Not -Match $tenantPattern -Because "File '$fileName' should not contain tenant IDs"
+        }
+    }
+}
+
+# ============================================================
+# 15. Cross-reference fields are obfuscated or null
+# ============================================================
+Describe "Cross-Reference Field Obfuscation" {
+    # Helper: field should be obfuscated, null, or a safe non-ID value like 'None' or 'obfuscated'
+    BeforeAll {
+        $script:SafePattern = '^((prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|None|obfuscated)$'
+        $script:AzureIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}'
+    }
+
+    It "AppServices: ServerFarmId should be obfuscated or null" {
+        $resources = @($script:Inventory.AppServices)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.ServerFarmId)) {
+                $r.ServerFarmId | Should -Not -Match $script:AzureIdPattern -Because "ServerFarmId should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "VirtualMachines: Set (VMSS ID) should be obfuscated or null" {
+        $resources = @($script:Inventory.VirtualMachines)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.Set)) {
+                $r.Set | Should -Match $script:ObfuscationPattern -Because "VMSS Set ID should be obfuscated"
+            }
+        }
+    }
+
+    It "VirtualMachines: Tags should be null when obfuscated" {
+        $resources = @($script:Inventory.VirtualMachines)
+        foreach ($r in $resources) {
+            if ($null -ne $r) {
+                $r.Tags | Should -BeNullOrEmpty -Because "Tags should be stripped when obfuscating"
+            }
+        }
+    }
+
+    It "Purview: CreatedBy should be 'obfuscated' or null" {
+        $resources = @($script:Inventory.Purview)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.CreatedBy)) {
+                $r.CreatedBy | Should -Be 'obfuscated' -Because "CreatedBy contains user identity and should be masked"
+            }
+        }
+    }
+
+    It "SQLDB: DatabaseServer should not contain raw resource names" {
+        $resources = @($script:Inventory.SQLDB)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.DatabaseServer)) {
+                $r.DatabaseServer | Should -Not -Match $script:AzureIdPattern -Because "DatabaseServer should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "SQLDB: ElasticPoolID should be obfuscated or 'None'" {
+        $resources = @($script:Inventory.SQLDB)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.ElasticPoolID)) {
+                $r.ElasticPoolID | Should -Not -Match $script:AzureIdPattern -Because "ElasticPoolID should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "SQLMI: InstancePoolName should not contain raw resource IDs" {
+        $resources = @($script:Inventory.SQLMI)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.InstancePoolName)) {
+                $r.InstancePoolName | Should -Not -Match $script:AzureIdPattern -Because "InstancePoolName should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "SQLMIDB: ManagedInstance should be obfuscated or null" {
+        $resources = @($script:Inventory.SQLMIDB)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.ManagedInstance)) {
+                $r.ManagedInstance | Should -Not -Match $script:AzureIdPattern -Because "ManagedInstance should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "PublicIP: AssociatedResource should not contain raw resource names" {
+        $resources = @($script:Inventory.PublicIP)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.AssociatedResource) -and $r.AssociatedResource -ne 'None') {
+                $r.AssociatedResource | Should -Not -Match $script:AzureIdPattern -Because "AssociatedResource should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "VMDisk: AssociatedResource should be obfuscated or null" {
+        $resources = @($script:Inventory.VMDisk)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.AssociatedResource)) {
+                $r.AssociatedResource | Should -Not -Match $script:AzureIdPattern -Because "Disk AssociatedResource should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "ComputeSnapshots: SourceResourceId should be obfuscated or null" {
+        $resources = @($script:Inventory.ComputeSnapshots)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.SourceResourceId)) {
+                $r.SourceResourceId | Should -Not -Match $script:AzureIdPattern -Because "SourceResourceId should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "AVD: HostId should be obfuscated or null" {
+        $resources = @($script:Inventory.AVD)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.HostId)) {
+                $r.HostId | Should -Not -Match $script:AzureIdPattern -Because "AVD HostId should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "AVD: Hostname should be obfuscated or null" {
+        $resources = @($script:Inventory.AVD)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.Hostname)) {
+                $r.Hostname | Should -Not -Match $script:AzureIdPattern -Because "AVD Hostname should not contain raw Azure resource ID"
+                $r.Hostname | Should -Match $script:ObfuscationPattern -Because "AVD Hostname should be obfuscated"
+            }
+        }
+    }
+
+    It "AVD: Hostname should differ from HostId" {
+        $resources = @($script:Inventory.AVD)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.Hostname) -and ![string]::IsNullOrEmpty($r.HostId)) {
+                $r.Hostname | Should -Not -Be $r.HostId -Because "Hostname and HostId should be different obfuscated values"
+            }
+        }
+    }
+
+    It "MachineLearning: StorageAccount should be obfuscated or null" {
+        $resources = @($script:Inventory.MachineLearning)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.StorageAccount)) {
+                $r.StorageAccount | Should -Not -Match $script:AzureIdPattern -Because "ML StorageAccount should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "MachineLearning: KeyVault should be obfuscated or null" {
+        $resources = @($script:Inventory.MachineLearning)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.KeyVault)) {
+                $r.KeyVault | Should -Not -Match $script:AzureIdPattern -Because "ML KeyVault should not contain raw Azure resource ID"
+            }
+        }
+    }
+
+    It "Databricks: ManagedResourceGroup should be obfuscated or null" {
+        $resources = @($script:Inventory.Databricks)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.ManagedResourceGroup)) {
+                $r.ManagedResourceGroup | Should -BeIn @('obfuscated') -Because "Databricks ManagedResourceGroup should be obfuscated"
+            }
+        }
+    }
+
+    It "Databricks: StorageAccount should be obfuscated or null" {
+        $resources = @($script:Inventory.Databricks)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.StorageAccount)) {
+                $r.StorageAccount | Should -BeIn @('obfuscated') -Because "Databricks StorageAccount should be obfuscated"
+            }
+        }
+    }
+
+    It "Purview: FriendlyName should be obfuscated or null" {
+        $resources = @($script:Inventory.Purview)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.FriendlyName)) {
+                $r.FriendlyName | Should -BeIn @('obfuscated') -Because "Purview FriendlyName should be obfuscated"
+            }
+        }
+    }
+
+    It "Frontdoor: WebApplicationFirewall should be obfuscated or False" {
+        $resources = @($script:Inventory.FRONTDOOR)
+        foreach ($r in $resources) {
+            if ($null -ne $r -and ![string]::IsNullOrEmpty($r.WebApplicationFirewall) -and $r.WebApplicationFirewall -ne 'False') {
+                $r.WebApplicationFirewall | Should -Not -Match $script:AzureIdPattern -Because "Frontdoor WAF should not contain raw Azure resource ID"
+            }
+        }
+    }
+}
+
+# ============================================================
+# 16. Dictionary file excluded from zip
+# ============================================================
+Describe "Dictionary File Exclusion" {
+    It "Should not contain the obfuscation dictionary in the zip" {
+        $dictFiles = $script:AllFiles | Where-Object { $_.Name -like "ObfuscationDictionary_*" }
+        $dictFiles | Should -BeNullOrEmpty -Because "Dictionary file should stay local, not in the zip"
+    }
+}

--- a/Tests/OutputCompleteness.Tests.ps1
+++ b/Tests/OutputCompleteness.Tests.ps1
@@ -1,0 +1,143 @@
+# Output Completeness Tests
+# Validates the output zip contains all expected files with correct structure
+# Run with: Invoke-Pester ./Tests/OutputCompleteness.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    $zipPath = if ($env:TEST_ZIP_PATH) { $env:TEST_ZIP_PATH } else {
+        Get-ChildItem -Path $PSScriptRoot -Filter "ResourcesReport_*.zip" | 
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+    if ([string]::IsNullOrEmpty($zipPath) -or -not (Test-Path $zipPath)) {
+        throw "No test zip found. Copy a ResourcesReport_*.zip to Tests/ or set `$env:TEST_ZIP_PATH"
+    }
+    $tmpBase = if ($env:TMPDIR) { $env:TMPDIR } elseif ($env:TEMP) { $env:TEMP } else { "/tmp" }
+    $script:ExtractPath = Join-Path $tmpBase ("CompleteTest_" + [guid]::NewGuid().ToString().Substring(0,8))
+    New-Item -ItemType Directory -Path $script:ExtractPath -Force | Out-Null
+    Expand-Archive -Path $zipPath -DestinationPath $script:ExtractPath -Force
+
+    $script:AllFiles = Get-ChildItem -Path $script:ExtractPath -File
+    $invFile = Get-ChildItem -Path $script:ExtractPath -Filter "Inventory_*.json" | Select-Object -First 1
+    $script:Inventory = if ($invFile) { Get-Content $invFile.FullName -Raw | ConvertFrom-Json } else { $null }
+}
+
+AfterAll {
+    if (Test-Path $script:ExtractPath) { Remove-Item -Path $script:ExtractPath -Recurse -Force }
+}
+
+Describe "Zip File Contents" {
+    It "Should contain an Excel report file" {
+        $xlsx = $script:AllFiles | Where-Object { $_.Extension -eq '.xlsx' }
+        $xlsx | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should contain an inventory JSON file" {
+        $json = $script:AllFiles | Where-Object { $_.Name -like 'Inventory_*' }
+        $json | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should contain at least one metrics JSON file" {
+        $metrics = $script:AllFiles | Where-Object { $_.Name -like 'Metrics_*' }
+        $metrics | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should contain a consumption CSV file" {
+        $csv = $script:AllFiles | Where-Object { $_.Name -like 'Consumption_*' }
+        $csv | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should not contain any unexpected file types" {
+        $allowedExtensions = @('.xlsx', '.json', '.csv')
+        foreach ($file in $script:AllFiles) {
+            $file.Extension | Should -BeIn $allowedExtensions -Because "File '$($file.Name)' has unexpected extension"
+        }
+    }
+
+    It "Should not contain dictionary or transcript files" {
+        $leaked = $script:AllFiles | Where-Object { $_.Name -like 'ObfuscationDictionary_*' -or $_.Name -like 'Transcript_*' }
+        $leaked | Should -BeNullOrEmpty
+    }
+}
+
+Describe "Inventory JSON Structure" {
+    It "Should have a Version field" {
+        $script:Inventory.Version | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should have at least one resource type with data" {
+        $populated = $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' }
+        $populated.Count | Should -BeGreaterThan 0 -Because "At least one service should have discovered resources"
+    }
+
+    It "Every resource should have ID, Name, and Location fields" {
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_) {
+                    $_.PSObject.Properties.Name | Should -Contain 'ID' -Because "Resource in $($_.Name) should have ID"
+                    $_.PSObject.Properties.Name | Should -Contain 'Location' -Because "Resource should have Location"
+                }
+            }
+        }
+    }
+}
+
+Describe "Metrics JSON Structure" {
+    It "Every metrics file should have a Metrics array" {
+        $metricsFiles = Get-ChildItem -Path $script:ExtractPath -Filter "Metrics_*.json"
+        foreach ($mf in $metricsFiles) {
+            $data = Get-Content $mf.FullName -Raw | ConvertFrom-Json
+            $data.PSObject.Properties.Name | Should -Contain 'Metrics'
+        }
+    }
+
+    It "Each metric entry should have Service, Metric, and MetricValue fields" {
+        $metricsFiles = Get-ChildItem -Path $script:ExtractPath -Filter "Metrics_*.json"
+        foreach ($mf in $metricsFiles) {
+            $data = Get-Content $mf.FullName -Raw | ConvertFrom-Json
+            foreach ($m in @($data.Metrics)) {
+                if ($null -ne $m) {
+                    $m.PSObject.Properties.Name | Should -Contain 'Service'
+                    $m.PSObject.Properties.Name | Should -Contain 'Metric'
+                    $m.PSObject.Properties.Name | Should -Contain 'MetricValue'
+                }
+            }
+        }
+    }
+}
+
+Describe "Non-Sensitive Fields Preserved" {
+    It "VM Location should be a real Azure region (not obfuscated)" {
+        $vms = @($script:Inventory.VirtualMachines)
+        foreach ($vm in $vms) {
+            if ($null -ne $vm) {
+                $vm.Location | Should -Not -Match '^(prod|nonprod)_' -Because "Location should be a real region, not obfuscated"
+            }
+        }
+    }
+
+    It "VM Size should be a real Azure VM size" {
+        $vms = @($script:Inventory.VirtualMachines)
+        foreach ($vm in $vms) {
+            if ($null -ne $vm -and ![string]::IsNullOrEmpty($vm.Size)) {
+                $vm.Size | Should -Match '^standard_' -Because "VM Size should be a real Azure size like standard_d2s_v5"
+            }
+        }
+    }
+
+    It "VM OS should be a real OS type" {
+        $vms = @($script:Inventory.VirtualMachines)
+        foreach ($vm in $vms) {
+            if ($null -ne $vm -and ![string]::IsNullOrEmpty($vm.OS)) {
+                $vm.OS | Should -BeIn @('windows', 'linux') -Because "OS should be windows or linux"
+            }
+        }
+    }
+
+    It "Storage SKU should be a real Azure storage SKU" {
+        $storage = @($script:Inventory.StorageAcc)
+        foreach ($sa in $storage) {
+            if ($null -ne $sa -and ![string]::IsNullOrEmpty($sa.SKU)) {
+                $sa.SKU | Should -Not -Match '^(prod|nonprod)_' -Because "Storage SKU should be real, not obfuscated"
+            }
+        }
+    }
+}

--- a/Tests/ProdNonprodPrefix.Tests.ps1
+++ b/Tests/ProdNonprodPrefix.Tests.ps1
@@ -1,0 +1,78 @@
+# Prod/Nonprod Prefix Tests
+# Validates that the prod_/nonprod_ prefix logic is consistent
+# Run with: Invoke-Pester ./Tests/ProdNonprodPrefix.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    $zipPath = if ($env:TEST_ZIP_PATH) { $env:TEST_ZIP_PATH } else {
+        Get-ChildItem -Path $PSScriptRoot -Filter "ResourcesReport_*.zip" | 
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+    if ([string]::IsNullOrEmpty($zipPath) -or -not (Test-Path $zipPath)) {
+        throw "No test zip found."
+    }
+    $tmpBase = if ($env:TMPDIR) { $env:TMPDIR } elseif ($env:TEMP) { $env:TEMP } else { "/tmp" }
+    $script:ExtractPath = Join-Path $tmpBase ("PrefixTest_" + [guid]::NewGuid().ToString().Substring(0,8))
+    New-Item -ItemType Directory -Path $script:ExtractPath -Force | Out-Null
+    Expand-Archive -Path $zipPath -DestinationPath $script:ExtractPath -Force
+
+    $invFile = Get-ChildItem -Path $script:ExtractPath -Filter "Inventory_*.json" | Select-Object -First 1
+    $script:Inventory = Get-Content $invFile.FullName -Raw | ConvertFrom-Json
+
+    $script:AllResources = @()
+    $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+        @($_.Value) | ForEach-Object { if ($null -ne $_) { $script:AllResources += $_ } }
+    }
+}
+
+AfterAll {
+    if (Test-Path $script:ExtractPath) { Remove-Item -Path $script:ExtractPath -Recurse -Force }
+}
+
+Describe "Prefix Consistency Per Resource" {
+    It "ID and Name should have the same prefix for each resource" {
+        foreach ($r in $script:AllResources) {
+            # Only check ID and Name — Subscription/ResourceGroup are shared across
+            # resources and their prefix is derived from the subscription/RG name
+            # itself, so they may differ from the resource's own prefix in mixed environments.
+            $fields = @($r.ID, $r.Name) | Where-Object { ![string]::IsNullOrEmpty($_) }
+            $prefixes = $fields | ForEach-Object { if ($_ -match '^(prod|nonprod)_') { $Matches[1] } }
+            $uniquePrefixes = $prefixes | Select-Object -Unique
+            if ($uniquePrefixes.Count -gt 0) {
+                $uniquePrefixes.Count | Should -Be 1 -Because "Resource '$($r.ID)' should have consistent prefix on ID and Name (got: $($uniquePrefixes -join ', '))"
+            }
+        }
+    }
+}
+
+Describe "Prefix Format Validation" {
+    It "All obfuscated IDs should start with exactly 'prod_' or 'nonprod_'" {
+        foreach ($r in $script:AllResources) {
+            if ($null -ne $r.ID) {
+                $r.ID | Should -Match '^(prod|nonprod)_[0-9a-f]{8}-' -Because "ID should have valid prefix format"
+            }
+        }
+    }
+
+    It "No resource should have an empty prefix (just underscore + GUID)" {
+        foreach ($r in $script:AllResources) {
+            if ($null -ne $r.ID) {
+                $r.ID | Should -Not -Match '^_[0-9a-f]{8}-' -Because "ID should not start with bare underscore"
+            }
+        }
+    }
+}
+
+Describe "Consumption Prefix Consistency" {
+    It "Consumption ResourceIds should have prod_ or nonprod_ prefix" {
+        $csvFile = Get-ChildItem -Path $script:ExtractPath -Filter "Consumption_*.csv" | Select-Object -First 1
+        if ($null -eq $csvFile) { return }
+        $content = Get-Content $csvFile.FullName -ErrorAction SilentlyContinue
+        if ($null -eq $content -or $content.Count -le 1) { return }
+        $csv = Import-Csv $csvFile.FullName
+        foreach ($row in $csv) {
+            if (![string]::IsNullOrEmpty($row.ResourceId)) {
+                $row.ResourceId | Should -Match '^(prod|nonprod)_' -Because "Consumption ResourceId should have prefix"
+            }
+        }
+    }
+}

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,54 @@
+# Obfuscation Tests
+
+Pester tests to validate that the obfuscation feature works correctly and no PII leaks into output files.
+
+## Prerequisites
+
+- PowerShell 7+
+- Pester module (v5+)
+
+```powershell
+Install-Module -Name Pester -Force -Scope CurrentUser
+```
+
+## How to Run
+
+### 1. Generate a test report with obfuscation enabled
+
+```powershell
+pwsh ./ResourceInventory.ps1 -SubscriptionID <your-sub-id> -Obfuscate -Debug
+```
+
+### 2. Copy the output zip to the Tests folder
+
+```powershell
+cp /path/to/ResourcesReport_*.zip ./Tests/
+```
+
+### 3. Run the tests
+
+```powershell
+pwsh -Command "Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed"
+```
+
+Or set environment variables to avoid editing the test file:
+
+```powershell
+$env:TEST_ZIP_PATH = "./Tests/ResourcesReport_202603301824.zip"
+$env:TEST_SUBSCRIPTION_ID = "<your-subscription-id>"
+$env:TEST_USER_EMAIL = "user@example.com"
+pwsh -Command "Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed"
+```
+
+### 4. Run skip-mode tests (no Azure needed)
+
+Generate skip-mode output:
+```powershell
+pwsh ./ResourceInventory.ps1 -SubscriptionID <your-sub-id> -SkipMetrics -SkipConsumption -Obfuscate
+```
+
+Then run:
+```powershell
+$env:TEST_ZIP_PATH = "./Tests/ResourcesReport_skip.zip"
+pwsh -Command "Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed"
+```

--- a/Tests/ReferentialIntegrity.Tests.ps1
+++ b/Tests/ReferentialIntegrity.Tests.ps1
@@ -1,0 +1,129 @@
+# Referential Integrity Tests
+# Validates that cross-references between resources are consistent after obfuscation
+# Run with: Invoke-Pester ./Tests/ReferentialIntegrity.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    $zipPath = if ($env:TEST_ZIP_PATH) { $env:TEST_ZIP_PATH } else {
+        Get-ChildItem -Path $PSScriptRoot -Filter "ResourcesReport_*.zip" | 
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+    if ([string]::IsNullOrEmpty($zipPath) -or -not (Test-Path $zipPath)) {
+        throw "No test zip found. Copy a ResourcesReport_*.zip to Tests/ or set `$env:TEST_ZIP_PATH"
+    }
+    $tmpBase = if ($env:TMPDIR) { $env:TMPDIR } elseif ($env:TEMP) { $env:TEMP } else { "/tmp" }
+    $script:ExtractPath = Join-Path $tmpBase ("RefIntTest_" + [guid]::NewGuid().ToString().Substring(0,8))
+    New-Item -ItemType Directory -Path $script:ExtractPath -Force | Out-Null
+    Expand-Archive -Path $zipPath -DestinationPath $script:ExtractPath -Force
+
+    $invFile = Get-ChildItem -Path $script:ExtractPath -Filter "Inventory_*.json" | Select-Object -First 1
+    $script:Inventory = Get-Content $invFile.FullName -Raw | ConvertFrom-Json
+
+    $csvFile = Get-ChildItem -Path $script:ExtractPath -Filter "Consumption_*.csv" | Select-Object -First 1
+    $script:ConsumptionCsv = if ($csvFile) { 
+        $content = Get-Content $csvFile.FullName -ErrorAction SilentlyContinue
+        if ($null -ne $content -and $content.Count -gt 1) { Import-Csv $csvFile.FullName } else { @() }
+    } else { @() }
+
+    # Collect all IDs across all resource types
+    $script:AllIds = @()
+    $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+        @($_.Value) | ForEach-Object { if ($null -ne $_.ID) { $script:AllIds += $_.ID } }
+    }
+}
+
+AfterAll {
+    if (Test-Path $script:ExtractPath) { Remove-Item -Path $script:ExtractPath -Recurse -Force }
+}
+
+Describe "VM Disk to VM Cross-Reference" {
+    It "Every disk AssociatedResource should match a VM ID or be null" {
+        $disks = @($script:Inventory.VMDisk)
+        $vmIds = @($script:Inventory.VirtualMachines) | Where-Object { $null -ne $_ } | ForEach-Object { $_.ID }
+        foreach ($disk in $disks) {
+            if ($null -ne $disk -and ![string]::IsNullOrEmpty($disk.AssociatedResource)) {
+                $disk.AssociatedResource | Should -BeIn $vmIds -Because "Disk '$($disk.ID)' AssociatedResource should reference a known VM"
+            }
+        }
+    }
+}
+
+Describe "AVD HostId to VM Cross-Reference" {
+    It "Every AVD HostId should match a VM ID or be null" {
+        $avd = @($script:Inventory.AVD)
+        $vmIds = @($script:Inventory.VirtualMachines) | Where-Object { $null -ne $_ } | ForEach-Object { $_.ID }
+        foreach ($avdItem in $avd) {
+            if ($null -ne $avdItem -and ![string]::IsNullOrEmpty($avdItem.HostId)) {
+                $avdItem.HostId | Should -BeIn $vmIds -Because "AVD HostId should reference a known VM"
+            }
+        }
+    }
+}
+
+Describe "Obfuscated ID Uniqueness" {
+    It "Every obfuscated ID should be unique across all resources" {
+        $idCounts = $script:AllIds | Group-Object | Where-Object { $_.Count -gt 1 }
+        $idCounts | Should -BeNullOrEmpty -Because "No two resources should share the same obfuscated ID"
+    }
+}
+
+Describe "Consumption to Inventory Cross-Reference" {
+    It "Consumption ResourceIds that exist in inventory should use the same obfuscated value" {
+        if ($script:ConsumptionCsv.Count -eq 0) { return }
+        $inventoryIds = $script:AllIds
+        foreach ($row in $script:ConsumptionCsv) {
+            if (![string]::IsNullOrEmpty($row.ResourceId) -and $row.ResourceId -in $inventoryIds) {
+                # If it's in both, the ID should be identical (same dictionary mapping)
+                $row.ResourceId | Should -BeIn $inventoryIds -Because "Consumption ResourceId should match inventory ID"
+            }
+        }
+    }
+}
+
+Describe "ResourceGroup Consistency" {
+    It "Resources with the same obfuscated ResourceGroup should be grouped together" {
+        $rgGroups = @{}
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_ -and $null -ne $_.ResourceGroup) {
+                    if (-not $rgGroups.ContainsKey($_.ResourceGroup)) { $rgGroups[$_.ResourceGroup] = @() }
+                    $rgGroups[$_.ResourceGroup] += $_.ID
+                }
+            }
+        }
+        # Each RG should have at least one resource
+        foreach ($rg in $rgGroups.Keys) {
+            $rgGroups[$rg].Count | Should -BeGreaterThan 0 -Because "ResourceGroup '$rg' should have at least one resource"
+        }
+    }
+}
+
+Describe "Subscription Determinism" {
+    It "Resources sharing the same obfuscated Subscription should all have the same value" {
+        # Collect all subscription values
+        $subValues = @{}
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_ -and $null -ne $_.Subscription) {
+                    $subValues[$_.Subscription] = $true
+                }
+            }
+        }
+        # There should be fewer unique subscription values than total resources
+        # (deterministic = same real sub maps to same obfuscated sub)
+        $subValues.Keys.Count | Should -BeLessOrEqual $script:AllIds.Count -Because "Subscription values should be reused across resources in the same subscription"
+    }
+}
+
+Describe "ResourceGroup Determinism" {
+    It "Fewer unique ResourceGroup values than total resources (deterministic mapping)" {
+        $rgValues = @{}
+        $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
+            @($_.Value) | ForEach-Object {
+                if ($null -ne $_ -and $null -ne $_.ResourceGroup) {
+                    $rgValues[$_.ResourceGroup] = $true
+                }
+            }
+        }
+        $rgValues.Keys.Count | Should -BeLessOrEqual $script:AllIds.Count -Because "ResourceGroup values should be reused across resources in the same RG"
+    }
+}

--- a/Tests/test-summary.txt
+++ b/Tests/test-summary.txt
@@ -1,0 +1,125 @@
+Test Summary - Obfuscation Feature
+===================================
+Environment: macOS (PowerShell 7.6.0, Az CLI 2.83.0) + Azure Cloud Shell (PowerShell 7.5.4)
+Date: 2026-04-14
+Branch: feature/obfuscate-v2
+
+Test Runs Performed
+-------------------
+
+1. No obfuscation (backward compatibility)
+   Command: pwsh ./ResourceInventory.ps1 -SubscriptionID <sub-id> -SkipConsumption -SkipMetrics -Debug -DeviceLogin
+   Result: PASS - 57 services processed, zero errors
+   Verified: Script runs identically to upstream when obfuscation is off
+
+2. Obfuscate (tags stripped, all fields masked)
+   Command: pwsh ./ResourceInventory.ps1 -SubscriptionID <sub-id> -SkipConsumption -SkipMetrics -Obfuscate -Debug
+   Result: PASS - All IDs/Names/Subscriptions/ResourceGroups obfuscated, tags null
+
+3. Full run with metrics + consumption + obfuscation
+   Command: pwsh ./ResourceInventory.ps1 -SubscriptionID <sub-id> -Obfuscate -Debug
+   Result: PASS - 57 services, 8 metrics, 306 consumption records, all obfuscated
+   Verified: Consumption CSV 144KB with obfuscated ResourceIds
+
+4. Session auto-detect with PowerShell Az context
+   Result: PASS - Detects existing az CLI session, sets PowerShell Az context if needed
+   Verified: Consumption data flows correctly (was broken before Az context fix)
+
+Parameter Combinations Tested
+-----------------------------
+-Obfuscate                          Data obfuscated, tags stripped
+-Obfuscate -SkipMetrics             Valid empty metrics JSON produced
+-Obfuscate -SkipConsumption         Valid CSV with headers produced
+-Obfuscate (full run)               Metrics + Consumption + Obfuscation all working
+No flags (backward compat)          Script runs identically to upstream
+
+Pester Unit Tests
+-----------------
+Total: 73 tests across 5 files
+Passed: 73
+Failed: 0
+Skipped: 0
+
+Test Files:
+  Obfuscation.Tests.ps1 (44 tests)
+    - Transcript exclusion from zip
+    - Email address detection (regex scan across all output files)
+    - Home directory path detection (Unix + Windows)
+    - Azure subscription ID pattern detection (inventory, consumption, metrics)
+    - All inventory fields obfuscated (ID, Name, Subscription, ResourceGroup)
+    - Metrics obfuscation (ID, Name, Subscription, ResourceGroup)
+    - Consumption ResourceId + InstanceData ResourceUri obfuscation
+    - Consumption ReservationId obfuscation
+    - Consumption ReservationOrderId obfuscation
+    - Prefix consistency (prod_/nonprod_, no plain GUIDs)
+    - Valid metrics JSON structure
+    - Valid consumption CSV headers
+    - Tenant ID pattern detection
+    - Cross-reference fields (21 tests): ServerFarmId, Set, Tags, CreatedBy,
+      DatabaseServer, ElasticPoolID, InstancePoolName, ManagedInstance,
+      AssociatedResource (PublicIP + VMDisk), SourceResourceId, HostId, Hostname,
+      Hostname differs from HostId, MachineLearning StorageAccount/KeyVault,
+      Databricks ManagedResourceGroup/StorageAccount, Purview FriendlyName,
+      Frontdoor WebApplicationFirewall
+    - Dictionary file exclusion from zip
+
+  ReferentialIntegrity.Tests.ps1 (7 tests)
+    - VM disk AssociatedResource matches VM ID
+    - AVD HostId matches VM ID
+    - All obfuscated IDs are unique
+    - Consumption ResourceIds match inventory IDs
+    - ResourceGroup grouping consistency
+    - Subscription determinism (same real sub = same obfuscated value)
+    - ResourceGroup determinism (same real RG = same obfuscated value)
+
+  DictionaryValidation.Tests.ps1 (6 tests)
+    - Dictionary has all four maps (ResourceId, ResourceName, Subscription, ResourceGroup)
+    - Dictionary has GeneratedAt timestamp
+    - Dictionary keys are obfuscated values
+    - Dictionary values are real Azure resource IDs
+    - Every inventory ID has a dictionary entry
+    - No double-obfuscation (real IDs don't look obfuscated)
+
+  OutputCompleteness.Tests.ps1 (12 tests)
+    - Zip contains xlsx, json, csv files
+    - No unexpected file types in zip
+    - No dictionary or transcript in zip
+    - Inventory has Version field
+    - At least one resource type has data
+    - Every resource has ID, Name, Location
+    - Metrics files have Metrics array
+    - Metric entries have Service, Metric, MetricValue
+    - Non-sensitive fields preserved (Location, Size, OS, SKU not obfuscated)
+
+  ProdNonprodPrefix.Tests.ps1 (4 tests)
+    - Same prefix across all fields per resource
+    - Valid prefix format (prod_ or nonprod_ + GUID)
+    - No bare underscore prefixes
+    - Consumption ResourceIds have correct prefix
+
+Fixes Validated in This Run
+---------------------------
+P0 - Deterministic subscription/RG obfuscation (same real value = same obfuscated value)
+P0 - AVD Hostname distinct from HostId
+P0 - SQLMIDB ManagedInstance extracts parent MI ID (not database ID)
+P0 - SQLDB DatabaseServer extracts parent server ID (not database ID)
+P1 - MachineLearning cross-refs obfuscated (StorageAccount, KeyVault, AppInsight, ContainerRegistry)
+P1 - Databricks cross-refs obfuscated (ManagedResourceGroup, StorageAccount)
+P1 - AvSet VirtualMachines cross-ref obfuscated
+P1 - Frontdoor WebApplicationFirewall cross-ref obfuscated
+P1 - Purview FriendlyName obfuscated
+P2 - Word-boundary regex prevents false prefix matches (e.g. 'contest' no longer matches 'test')
+P2 - Short naming convention prefix detection (d-/t-/s- patterns)
+P2 - Fallback to 'obfuscated' when cross-ref resource not in dictionary (SQLMIDB, SQLDB, AvSet)
+P2 - ReservationId and ReservationOrderId obfuscated in consumption output
+
+Resources Discovered During Testing
+------------------------------------
+- Virtual Machines: 3 (2x Windows 11 client, 1x Ubuntu)
+- AVD Host Pools: 2 (personal type, with session hosts)
+- Log Analytics Workspaces: 1
+- Public IPs: 2
+- Storage Accounts: 2
+- VM Disks: 3
+- Consumption Records: 306 (31-day lookback)
+- Metrics: 8 (VM CPU, VM memory, storage capacity)


### PR DESCRIPTION
## Summary

Adds an `-Obfuscate` switch that masks sensitive fields in Azure Resource Inventory reports, enabling secure sharing with external parties. Includes a reverse-lookup dictionary for the customer to map obfuscated values back to real names when needed.

**Workflow:**
1. Customer runs with `-Obfuscate`
2. Script generates the obfuscated ZIP (safe to share) + a local `ObfuscationDictionary_*.json` (stays with the customer)
3. The dictionary maps `prod_abc123...` → `/subscriptions/.../resourceGroups/rg-finance-prod/...` for every obfuscated value
4. Same original value always maps to the same obfuscated GUID within a run, so pivot tables, grouping, and cross-referencing all work
5. When the receiving party asks "what is prod_abc123?", the customer looks it up in their dictionary and responds
6. The dictionary never leaves the customer's environment. The ZIP is clean.

## Changes

### Obfuscation Feature
- New `-Obfuscate` parameter masks ID, Name, Subscription, ResourceGroup across inventory, metrics, and consumption output
- Resources with dev/test/qa names (including short prefixes like `d-`/`t-`/`s-`) get `nonprod_` prefix; others get `prod_`
- Deterministic within a run — same resource always maps to same GUID, preserving referential integrity
- Deterministic subscription/RG mapping — all resources in the same real subscription or resource group share the same obfuscated value
- Tags stripped (set to null) when obfuscating
- Transcript log and dictionary excluded from ZIP when obfuscating
- Cross-reference fields obfuscated across all service modules (AVD HostId/Hostname, SQLDB DatabaseServer/ElasticPoolID, SQLMIDB ManagedInstance, AvSet VirtualMachines, MachineLearning StorageAccount/KeyVault/AppInsight/ContainerRegistry, Databricks ManagedResourceGroup/StorageAccount, Frontdoor WAF, Purview FriendlyName/CreatedBy, PublicIP AssociatedResource, VMDisk AssociatedResource, ComputeSnapshots SourceResourceId, VirtualMachines Set, AppServices ServerFarmId, SQLMI InstancePoolName)
- All dictionary lookups use ContainsKey guards with proper fallback generation
- Consumption ReservationId and ReservationOrderId obfuscated
- AVD Hostname deterministic via SHA256 hash (distinct from HostId)

### Bug Fixes
- Fix `$azcliExt` typo → `$azCliExtension` (resource-graph extension check always failed)
- Fix `Read-Host` with invalid `-ForegroundColor` parameter
- Fix az CLI version null check ordering
- Fix misleading 'Using device login' log in browser login branch
- Fix `MachineLearning.ps1` SmaResources key mismatch (`AzureML` → `MachineLearning`)
- Fix `IOTHubs.ps1` iterating undefined `$Tags` → `$data.locations`
- Fix `EvtHub.ps1` undefined `$StyleCost` reference
- Remove undefined `$Cost` references in `WrkSpace.ps1`
- Fix `AzureFirewall.ps1` inconsistent `'Resource Group'` → `'ResourceGroup'`
- Remove duplicate `vCores` column in `SQLMI.ps1`
- Fix `'Debbuging'` typo
- Write valid empty JSON `{"Metrics":[]}` when metrics skipped
- Write CSV headers when consumption skipped

### Performance
- Replace deprecated `az vm list-sizes` with `Get-AzComputeResourceSku` (6s vs 2+ min)
- Replace `Get-InstalledModule` with `Get-Module -ListAvailable` (eliminates NuGet bootstrap noise)
- Save/restore `$DebugPreference` around `Get-AzComputeResourceSku` calls

### Tests
- 73 Pester tests across 5 test files validating obfuscation correctness and PII protection
- Tests cover: transcript/dictionary exclusion, email/path/subscription/tenant leak detection, all field obfuscation, cross-reference fields, prefix consistency, deterministic sub/RG mapping, referential integrity, dictionary completeness, output structure, reservation ID masking

## Testing

See `Tests/test-summary.txt` for full details. Tested with:
- `-Obfuscate` alone
- `-Obfuscate -SkipMetrics -SkipConsumption`
- No flags (backward compatibility)
- All 57 service scripts processed without errors
- 73/73 Pester tests pass against live Azure subscription