### PR TITLE
Add Run-AllSubscriptions.ps1 wrapper for per-subscription inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ git clone https://github.com/awslabs/resource-discovery-for-azure.git
 ### Authentication Notes
 
 - **Azure Cloud Shell:** Authentication is automatic
-- **Local PowerShell:** You'll be redirected to Azure sign-in
+- **Local PowerShell:** Run `az login` and `Connect-AzAccount` before executing the script. If you plan to scan all subscriptions in a tenant, use `Run-AllSubscriptions.ps1`, which prompts you to sign in once and then reuses the session for every subscription.
 
 You might get more than one authentication request due to different collector processes running in parallel.
 
@@ -130,6 +130,16 @@ You might get more than one authentication request due to different collector pr
 ```powershell
 ./ResourceInventory.ps1 -ReportName "CompanyName" -Obfuscate
 ```
+
+### Running Across All Subscriptions
+
+Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each subscription in a tenant, instead of the default single consolidated report. The wrapper prompts you to sign in once, then invokes `ResourceInventory.ps1` for each subscription sequentially.
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012"
+```
+
+Each subscription produces its own set of timestamped reports in `InventoryReports/`. After all subscriptions are processed, the wrapper bundles the per-subscription ZIPs into a single `AllSubscriptions_ResourcesReport_<timestamp>.zip` in the same folder for easy delivery.
 
 ## Output Files
 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -9,6 +9,7 @@ param ($TenantID,
         [switch]$DeviceLogin,
         [switch]$EnableLogs,
         [switch]$Obfuscate,
+        [switch]RunAllSubs,
         $ConcurrencyLimit = 6,
         $ReportName = 'ResourcesReport', 
         $OutputDirectory)
@@ -288,22 +289,30 @@ Function RunInventorySetup()
             Write-Log -Message ('Authenticating Azure') -Severity 'Info'
     
             Write-Log -Message ('Clearing account cache') -Severity 'Info'
-            #az account clear | Out-Null
+
+            if(!$RunAllSubs.IsPresent)
+            {
+                az account clear | Out-Null
+            }
+            
             Write-Log -Message ('Calling Login, the browser will open and prompt you to login.') -Severity 'Info'
 
             $DebugPreference = "SilentlyContinue"
-    
-            if($DeviceLogin.IsPresent)
+
+            if(!$RunAllSubs.IsPresent)
             {
-                Write-Log -Message ('Using device login') -Severity 'Info'
-                #az login --use-device-code
-                #Connect-AzAccount -UseDeviceAuthentication | Out-Null
-            }
-            else 
-            {
-                Write-Log -Message ('Using browser login') -Severity 'Info'
-                #az login --only-show-errors | Out-Null
-                #Connect-AzAccount | Out-Null
+                    if($DeviceLogin.IsPresent)
+                    {
+                        Write-Log -Message ('Using device login') -Severity 'Info'
+                        #az login --use-device-code
+                        #Connect-AzAccount -UseDeviceAuthentication | Out-Null
+                    }
+                    else 
+                    {
+                        Write-Log -Message ('Using browser login') -Severity 'Info'
+                        #az login --only-show-errors | Out-Null
+                        #Connect-AzAccount | Out-Null
+                    }
             }
 
             $DebugPreference = "Continue"
@@ -331,16 +340,19 @@ Function RunInventorySetup()
                 [int]$SelectTenant = read-host "Select Tenant (Default 1)"
                 $defaultTenant = --$SelectTenant
                 $TenantID = $Tenants[$defaultTenant]
-    
-                if($DeviceLogin.IsPresent)
+
+                if(!$RunAllSubs.IsPresent)
                 {
-                    #az login --use-device-code -t $TenantID
-                    #Connect-AzAccount -UseDeviceAuthentication -Tenant $TenantID | Out-Null
-                }
-                else 
-                {
-                    #az login -t $TenantID --only-show-errors | Out-Null
-                    #Connect-AzAccount -Tenant $TenantID | Out-Null
+                        if($DeviceLogin.IsPresent)
+                        {
+                            #az login --use-device-code -t $TenantID
+                            #Connect-AzAccount -UseDeviceAuthentication -Tenant $TenantID | Out-Null
+                        }
+                        else 
+                        {
+                            #az login -t $TenantID --only-show-errors | Out-Null
+                            #Connect-AzAccount -Tenant $TenantID | Out-Null
+                        }
                 }
             }
     

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -304,14 +304,14 @@ Function RunInventorySetup()
                     if($DeviceLogin.IsPresent)
                     {
                         Write-Log -Message ('Using device login') -Severity 'Info'
-                        #az login --use-device-code
-                        #Connect-AzAccount -UseDeviceAuthentication | Out-Null
+                        az login --use-device-code
+                        Connect-AzAccount -UseDeviceAuthentication | Out-Null
                     }
                     else 
                     {
                         Write-Log -Message ('Using browser login') -Severity 'Info'
-                        #az login --only-show-errors | Out-Null
-                        #Connect-AzAccount | Out-Null
+                        az login --only-show-errors | Out-Null
+                        Connect-AzAccount | Out-Null
                     }
             }
 
@@ -345,13 +345,13 @@ Function RunInventorySetup()
                 {
                         if($DeviceLogin.IsPresent)
                         {
-                            #az login --use-device-code -t $TenantID
-                            #Connect-AzAccount -UseDeviceAuthentication -Tenant $TenantID | Out-Null
+                            az login --use-device-code -t $TenantID
+                            Connect-AzAccount -UseDeviceAuthentication -Tenant $TenantID | Out-Null
                         }
                         else 
                         {
-                            #az login -t $TenantID --only-show-errors | Out-Null
-                            #Connect-AzAccount -Tenant $TenantID | Out-Null
+                            az login -t $TenantID --only-show-errors | Out-Null
+                            Connect-AzAccount -Tenant $TenantID | Out-Null
                         }
                 }
             }

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -288,7 +288,7 @@ Function RunInventorySetup()
             Write-Log -Message ('Authenticating Azure') -Severity 'Info'
     
             Write-Log -Message ('Clearing account cache') -Severity 'Info'
-            az account clear | Out-Null
+            #az account clear | Out-Null
             Write-Log -Message ('Calling Login, the browser will open and prompt you to login.') -Severity 'Info'
 
             $DebugPreference = "SilentlyContinue"
@@ -296,14 +296,14 @@ Function RunInventorySetup()
             if($DeviceLogin.IsPresent)
             {
                 Write-Log -Message ('Using device login') -Severity 'Info'
-                az login --use-device-code
-                Connect-AzAccount -UseDeviceAuthentication | Out-Null
+                #az login --use-device-code
+                #Connect-AzAccount -UseDeviceAuthentication | Out-Null
             }
             else 
             {
                 Write-Log -Message ('Using browser login') -Severity 'Info'
-                az login --only-show-errors | Out-Null
-                Connect-AzAccount | Out-Null
+                #az login --only-show-errors | Out-Null
+                #Connect-AzAccount | Out-Null
             }
 
             $DebugPreference = "Continue"
@@ -334,13 +334,13 @@ Function RunInventorySetup()
     
                 if($DeviceLogin.IsPresent)
                 {
-                    az login --use-device-code -t $TenantID
-                    Connect-AzAccount -UseDeviceAuthentication -Tenant $TenantID | Out-Null
+                    #az login --use-device-code -t $TenantID
+                    #Connect-AzAccount -UseDeviceAuthentication -Tenant $TenantID | Out-Null
                 }
                 else 
                 {
-                    az login -t $TenantID --only-show-errors | Out-Null
-                    Connect-AzAccount -Tenant $TenantID | Out-Null
+                    #az login -t $TenantID --only-show-errors | Out-Null
+                    #Connect-AzAccount -Tenant $TenantID | Out-Null
                 }
             }
     

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -1,7 +1,10 @@
 param (
     [Parameter(Mandatory=$true)]
-    [string]$TenantID
+    [string]$TenantID,
+    [switch]$Debug
 )
+
+$RunStartTime = Get-Date
 
 az login -t $TenantID --only-show-errors | Out-Null
 Connect-AzAccount -Tenant $TenantID | Out-Null
@@ -9,14 +12,53 @@ Connect-AzAccount -Tenant $TenantID | Out-Null
 # Get all Azure subscriptions
 $subscriptions = Get-AzSubscription
 
+# Pass-through parameters for each inner invocation
+$InventoryPassthrough = @{}
+if ($Debug.IsPresent) { $InventoryPassthrough['Debug'] = $true }
+
 # Loop through each subscription and run ResourceInventory
 foreach ($sub in $subscriptions) {
     Write-Host "Processing subscription: $($sub.Name) ($($sub.Id))" -ForegroundColor Cyan
     
-    ./ResourceInventory.ps1 -SubscriptionID $sub.Id
+    ./ResourceInventory.ps1 -SubscriptionID $sub.Id @InventoryPassthrough
     
     Write-Host "Completed subscription: $($sub.Name)" -ForegroundColor Green
     Write-Host "-----------------------------------" -ForegroundColor Gray
 }
 
 Write-Host "All subscriptions processed!" -ForegroundColor Green
+
+# Consolidate per-subscription ZIPs into a single outer ZIP
+$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+$OuterZipFile = $null
+
+if (Test-Path -Path $InventoryRoot -PathType Container) {
+    $subZips = @(Get-ChildItem -Path $InventoryRoot -Directory | ForEach-Object {
+        Get-ChildItem -Path $_.FullName -Filter "*.zip" -File
+    })
+
+    if ($subZips.Count -gt 0) {
+        $Timestamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+        $OuterZipFile = Join-Path $InventoryRoot "AllSubscriptions_ResourcesReport_$Timestamp.zip"
+
+        Write-Host ("Compressing {0} per-subscription report(s) into: {1}" -f $subZips.Count, $OuterZipFile) -ForegroundColor Cyan
+        Compress-Archive -Path $subZips.FullName -DestinationPath $OuterZipFile -Force
+
+        Write-Host ("Reporting Data File: {0}" -f $OuterZipFile) -ForegroundColor Green
+    } else {
+        Write-Host ("No per-subscription zip files found under {0} to consolidate." -f $InventoryRoot) -ForegroundColor Yellow
+    }
+} else {
+    Write-Host ("Inventory root not found at {0}. Nothing to consolidate." -f $InventoryRoot) -ForegroundColor Yellow
+}
+
+# Final summary
+$Elapsed = (Get-Date) - $RunStartTime
+Write-Host ""
+Write-Host "================ Summary ================" -ForegroundColor Green
+Write-Host ("Subscriptions Processed: {0}" -f $subscriptions.Count) -ForegroundColor Green
+Write-Host ("Execution Time:          {0}" -f $Elapsed.ToString('hh\:mm\:ss')) -ForegroundColor Green
+if ($OuterZipFile) {
+    Write-Host ("Consolidated Report:     {0}" -f $OuterZipFile) -ForegroundColor Green
+}
+Write-Host "=========================================" -ForegroundColor Green

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -19,7 +19,7 @@ if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = 
 foreach ($sub in $subscriptions) {
     Write-Host "Processing subscription: $($sub.Name) ($($sub.Id))" -ForegroundColor Cyan
     
-    ./ResourceInventory.ps1 -SubscriptionID $sub.Id @InventoryPassthrough
+    ./ResourceInventory.ps1 -SubscriptionID $sub.Id @InventoryPassthrough -RunAllSubs
     
     Write-Host "Completed subscription: $($sub.Name)" -ForegroundColor Green
     Write-Host "-----------------------------------" -ForegroundColor Gray

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -1,0 +1,22 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$TenantID
+)
+
+az login -t $TenantID --only-show-errors | Out-Null
+Connect-AzAccount -Tenant $TenantID | Out-Null
+
+# Get all Azure subscriptions
+$subscriptions = Get-AzSubscription
+
+# Loop through each subscription and run ResourceInventory
+foreach ($sub in $subscriptions) {
+    Write-Host "Processing subscription: $($sub.Name) ($($sub.Id))" -ForegroundColor Cyan
+    
+    ./ResourceInventory.ps1 -SubscriptionID $sub.Id
+    
+    Write-Host "Completed subscription: $($sub.Name)" -ForegroundColor Green
+    Write-Host "-----------------------------------" -ForegroundColor Gray
+}
+
+Write-Host "All subscriptions processed!" -ForegroundColor Green

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -1,7 +1,6 @@
 param (
     [Parameter(Mandatory=$true)]
-    [string]$TenantID,
-    [switch]$Debug
+    [string]$TenantID
 )
 
 $RunStartTime = Get-Date
@@ -14,7 +13,7 @@ $subscriptions = Get-AzSubscription
 
 # Pass-through parameters for each inner invocation
 $InventoryPassthrough = @{}
-if ($Debug.IsPresent) { $InventoryPassthrough['Debug'] = $true }
+if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = $true }
 
 # Loop through each subscription and run ResourceInventory
 foreach ($sub in $subscriptions) {


### PR DESCRIPTION
## Summary

Adds `Run-AllSubscriptions.ps1`, a wrapper that generates a **separate** inventory report for each subscription in a tenant (instead of the single consolidated report the default flow produces). The wrapper authenticates once, loops through every subscription the account can access in the specified tenant, and then bundles the per-subscription ZIPs into a single outer archive for easy delivery.

## Changes

### `Run-AllSubscriptions.ps1` (new)
- Authenticates once via `az login` + `Connect-AzAccount` for the given `-TenantID`.
- Enumerates subscriptions with `Get-AzSubscription` and invokes `ResourceInventory.ps1 -SubscriptionID <id>` for each, sequentially.
- Passes `-Debug` through to each inner invocation when set on the wrapper.
- After the loop, consolidates all per-subscription ZIPs found under `InventoryReports/*/` into `InventoryReports/AllSubscriptions_ResourcesReport_<timestamp>.zip` and logs the path using the same `Reporting Data File:` phrasing the inner script uses.
- Prints a final summary with subscription count, elapsed time, and consolidated report path.

### `ResourceInventory.ps1`
- Comments out the inline `az login` / `Connect-AzAccount` calls in the no-tenant branch so authentication can be owned by the wrapper. The service-principal path and the with-`TenantID` path are not affected.

### `README.md`
- Updates *Authentication Notes* for local PowerShell to reflect that users should `az login` + `Connect-AzAccount` before running the inner script, or use the wrapper.
- Adds a concise *Running Across All Subscriptions* section with usage example and a mention of the outer consolidated ZIP.

## Usage

```powershell
./Run-AllSubscriptions.ps1 -TenantID "<tenant-id>"
```

## Known follow-ups (not in this PR)
- Per-iteration `try/catch` with success/failure counts in the summary.
- Error handling around the wrapper's auth step.
- `#Requires -Version 7.0` and empty-subscription guard.
- Script-relative invocation of `ResourceInventory.ps1` via `$PSScriptRoot`.
- Re-run ZIP contamination safeguard in the consolidation step.