### PR TITLE
ci: add PSScriptAnalyzer workflow, PascalCase rule, and PowerShell style guide

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -2,7 +2,8 @@ name: PSScriptAnalyzer
 
 on:
   push:
-    branches: [main, master]
+    # Run on every branch so feature work gets immediate feedback.
+    branches: ['**']
     paths:
       - '**.ps1'
       - '**.psm1'
@@ -11,6 +12,7 @@ on:
       - '.scriptanalyzer/**'
       - '.github/workflows/psscriptanalyzer.yml'
   pull_request:
+    # PRs targeting mainline still gate on the same rules.
     branches: [main, master]
     paths:
       - '**.ps1'

--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -1,0 +1,133 @@
+name: PSScriptAnalyzer
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - '**.ps1'
+      - '**.psm1'
+      - '**.psd1'
+      - 'PSScriptAnalyzerSettings.psd1'
+      - '.scriptanalyzer/**'
+      - '.github/workflows/psscriptanalyzer.yml'
+  pull_request:
+    branches: [main, master]
+    paths:
+      - '**.ps1'
+      - '**.psm1'
+      - '**.psd1'
+      - 'PSScriptAnalyzerSettings.psd1'
+      - '.scriptanalyzer/**'
+      - '.github/workflows/psscriptanalyzer.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  analyze:
+    name: Analyze PowerShell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck
+          Get-Module PSScriptAnalyzer -ListAvailable | Select-Object Name, Version | Format-Table -AutoSize
+
+      - name: Run PSScriptAnalyzer
+        id: analyze
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Import-Module PSScriptAnalyzer
+
+          $Targets = @(
+              './Services',
+              './Extension',
+              './Tests',
+              './ResourceInventory.ps1',
+              './Run-AllSubscriptions.ps1'
+          ) | Where-Object { Test-Path $_ }
+
+          $AllResults = @()
+          foreach ($Target in $Targets)
+          {
+              $AllResults += Invoke-ScriptAnalyzer `
+                  -Path $Target `
+                  -Settings ./PSScriptAnalyzerSettings.psd1 `
+                  -Recurse `
+                  -ErrorAction Continue
+          }
+
+          $Errors        = @($AllResults | Where-Object Severity -eq 'Error')
+          $Warnings      = @($AllResults | Where-Object Severity -eq 'Warning')
+          $Informational = @($AllResults | Where-Object Severity -eq 'Information')
+
+          Write-Host "::group::Summary"
+          Write-Host ("Errors:        {0}" -f $Errors.Count)
+          Write-Host ("Warnings:      {0}" -f $Warnings.Count)
+          Write-Host ("Informational: {0}" -f $Informational.Count)
+          Write-Host "::endgroup::"
+
+          # Emit findings as GitHub annotations so they show up inline on the PR.
+          foreach ($Finding in $AllResults)
+          {
+              $Level = switch ($Finding.Severity)
+              {
+                  'Error'       { 'error' }
+                  'Warning'     { 'warning' }
+                  default       { 'notice' }
+              }
+              $Path = $Finding.ScriptPath
+              if ($Path)
+              {
+                  # Make the path repo-relative for GitHub UI linking.
+                  $Path = $Path -replace [regex]::Escape((Get-Location).Path + [IO.Path]::DirectorySeparatorChar), ''
+              }
+              $Line = $Finding.Line
+              $Col  = $Finding.Column
+              $Rule = $Finding.RuleName
+              $Msg  = ($Finding.Message -replace "`r?`n", ' ').Trim()
+              Write-Host "::$Level file=$Path,line=$Line,col=$Col,title=$Rule::$Msg"
+          }
+
+          # Write a job summary for the Actions run page.
+          $SummaryPath = $env:GITHUB_STEP_SUMMARY
+          if ($SummaryPath)
+          {
+              "# PSScriptAnalyzer results" | Out-File $SummaryPath -Append
+              "" | Out-File $SummaryPath -Append
+              "| Severity | Count |" | Out-File $SummaryPath -Append
+              "|----------|-------|" | Out-File $SummaryPath -Append
+              "| Error | $($Errors.Count) |" | Out-File $SummaryPath -Append
+              "| Warning | $($Warnings.Count) |" | Out-File $SummaryPath -Append
+              "| Information | $($Informational.Count) |" | Out-File $SummaryPath -Append
+
+              if ($AllResults.Count -gt 0)
+              {
+                  "" | Out-File $SummaryPath -Append
+                  "## Top findings" | Out-File $SummaryPath -Append
+                  "" | Out-File $SummaryPath -Append
+                  $AllResults |
+                      Group-Object RuleName |
+                      Sort-Object Count -Descending |
+                      Select-Object -First 15 |
+                      ForEach-Object { "- **$($_.Name)**: $($_.Count)" } |
+                      Out-File $SummaryPath -Append
+              }
+          }
+
+          # Fail the job on Errors only. Warnings are reported but don't block,
+          # so legacy PascalCase violations surface without breaking every PR.
+          # Flip this to `$Errors.Count + $Warnings.Count` once the warning
+          # backlog is burned down.
+          if ($Errors.Count -gt 0)
+          {
+              Write-Host "::error::PSScriptAnalyzer found $($Errors.Count) error(s)."
+              exit 1
+          }

--- a/.kiro/steering/powershell-style.md
+++ b/.kiro/steering/powershell-style.md
@@ -1,0 +1,105 @@
+---
+inclusion: fileMatch
+fileMatchPattern: '*.ps1,*.psm1,*.psd1'
+---
+
+# PowerShell Style Guide
+
+These rules apply to all `.ps1`, `.psm1`, and `.psd1` files in this repo. They
+exist both to make the code consistent and to give AI assistants a clear target
+to hit when generating or editing PowerShell.
+
+## Naming
+
+Use PascalCase for variables, function names, parameters, and module-scope state.
+
+- Variables: `$ResourceId`, `$FrontDoorType`, `$AllResources`.
+- Functions and cmdlets: `Verb-PascalCase` — `Get-Resource`, `New-ObfuscationMap`.
+- Parameters: `[Parameter()]$ResourceIdDictionary` not `$resourceIdDictionary`.
+- Hashtable keys that become output columns (Excel headers, JSON fields): keep
+  the existing PascalCase names unchanged. Renaming a key is a schema change.
+
+Exceptions — leave these alone:
+
+- PowerShell automatic variables: `$_`, `$args`, `$input`, `$PSItem`, `$this`,
+  `$MyInvocation`, `$PSBoundParameters`, etc.
+- Single-letter loop iterators that are unambiguously local: `$i`, `$j`.
+- Short positional loop variables that match surrounding code style (`$1` is
+  used pervasively in this repo; new code should prefer a meaningful name like
+  `$Resource`, but don't break existing collectors just to rename it).
+
+## Brace Style
+
+Use **Allman** (BSD) brace style — the opening brace goes on its own line,
+aligned with the keyword that opened the block. This lets the editor fold the
+body while still showing the signature.
+
+Do this:
+
+```powershell
+function Get-Something
+{
+    param(
+        [string]$Name
+    )
+
+    if ($Name)
+    {
+        foreach ($Item in $Name)
+        {
+            # ...
+        }
+    }
+}
+```
+
+Not this:
+
+```powershell
+function Get-Something {
+    param([string]$Name)
+    if ($Name) {
+        foreach ($Item in $Name) {
+            # ...
+        }
+    }
+}
+```
+
+Apply the same rule to `if` / `elseif` / `else`, `foreach`, `for`, `while`,
+`switch`, `try` / `catch` / `finally`, and script blocks passed as parameters
+where readability benefits from it. Short inline script blocks passed to
+pipeline cmdlets (`Where-Object { $_.State -eq 'Running' }`) stay one-line —
+the rule is about definitions, not every brace.
+
+## Indentation and Whitespace
+
+- Four spaces per level. No tabs.
+- One blank line between logical sections inside a function.
+- No trailing whitespace.
+
+## Verification
+
+Before declaring a PowerShell change complete:
+
+1. Parse each modified file with the PowerShell parser and confirm zero errors.
+2. If `PSScriptAnalyzerSettings.psd1` exists at the repo root, run:
+   ```
+   Invoke-ScriptAnalyzer -Path <changed files> -Settings ./PSScriptAnalyzerSettings.psd1
+   ```
+   and resolve any warnings before handing back.
+
+## Safe Refactoring Rules
+
+PowerShell variable reads are case-insensitive, so renaming `$resources` to
+`$Resources` is a local change. But some renames are **not** safe and must be
+avoided unless the user explicitly asks for a schema change:
+
+- Hashtable keys that feed exported output (Excel column names, JSON field
+  names, dictionary keys written to disk).
+- Function parameter names that other files pass by name — rename only if you
+  add `[Alias('OldName')]` to preserve the public surface.
+- Anything consumed by tests under `Tests/` by literal name.
+
+When in doubt, prefer renaming the local usage and leaving the export name
+alone.

--- a/.scriptanalyzer/CustomRules.psm1
+++ b/.scriptanalyzer/CustomRules.psm1
@@ -1,0 +1,118 @@
+# Custom PSScriptAnalyzer rules for Resource Discovery for Azure.
+# Referenced from ../PSScriptAnalyzerSettings.psd1.
+#
+# Each exported function whose name starts with `Measure-` is discovered by
+# PSScriptAnalyzer as a custom rule and run against every ScriptBlockAst.
+#
+# Notes on portability:
+# - We don't use `using namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic`
+#   at the top of the file because that requires the type to be loadable when
+#   the module is parsed. PSScriptAnalyzer loads this module in a context where
+#   that assembly isn't always resolvable at parse time, so we reference the
+#   types via fully-qualified names at runtime instead.
+# - Runtime lookup: [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]
+#   is available because PSScriptAnalyzer.dll is already loaded by the time the
+#   rule function runs.
+
+<#
+.SYNOPSIS
+    Flags variable assignments that do not start with an uppercase letter.
+
+.DESCRIPTION
+    The repo standard is PascalCase for variable names. This rule walks every
+    assignment statement and emits a diagnostic when the variable on the left
+    starts with a lowercase letter, skipping PowerShell automatic variables
+    and an allow-list of short loop iterators.
+
+    Hashtable keys, parameter defaults, and pipeline variables ($_) are not
+    reported here — only explicit `$foo = ...` assignments.
+#>
+function Measure-VariablePascalCase
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]$ScriptBlockAst
+    )
+
+    # Resolve the DiagnosticRecord type at call time — it's owned by
+    # PSScriptAnalyzer.dll, which is loaded before the rule runs.
+    $DiagnosticType = [type]'Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord'
+    if (-not $DiagnosticType)
+    {
+        # If PSScriptAnalyzer isn't loaded, silently skip.
+        return @()
+    }
+
+    # Automatic variables and common iterators we never want to flag.
+    $AllowList = @(
+        '_', 'args', 'input', 'this', 'psitem', 'myinvocation',
+        'psboundparameters', 'psscriptroot', 'pscommandpath', 'pscmdlet',
+        'host', 'home', 'pwd', 'error', 'true', 'false', 'null',
+        'i', 'j', 'k', 'x', 'y', 'z',
+        # The repo uses $1 pervasively as the foreach iterator; allow it so
+        # this rule doesn't explode on legacy collectors. New code should
+        # prefer a descriptive name.
+        '1', '2', '3'
+    )
+
+    $Results = @()
+
+    # Do not recurse into nested script blocks: PSScriptAnalyzer invokes the
+    # rule once per ScriptBlockAst, so recursing here double-counts anything
+    # inside if/foreach bodies.
+    $Assignments = $ScriptBlockAst.FindAll(
+        {
+            param($Ast)
+            $Ast -is [System.Management.Automation.Language.AssignmentStatementAst]
+        },
+        $false
+    )
+
+    foreach ($Assignment in $Assignments)
+    {
+        $Left = $Assignment.Left
+
+        # Unwrap `[type]$Var = ...` convert expressions.
+        if ($Left -is [System.Management.Automation.Language.ConvertExpressionAst])
+        {
+            $Left = $Left.Child
+        }
+
+        if ($Left -isnot [System.Management.Automation.Language.VariableExpressionAst])
+        {
+            continue
+        }
+
+        $Name = $Left.VariablePath.UserPath
+
+        if ([string]::IsNullOrEmpty($Name)) { continue }
+        if ($AllowList -contains $Name.ToLower()) { continue }
+        # Case-sensitive regex: `-match` is case-insensitive by default in
+        # PowerShell, which would accept lowercase names. `-cmatch` forces
+        # case-sensitive matching so only real PascalCase passes through.
+        if ($Name -cmatch '^[A-Z]') { continue }
+
+        $Suggested = $Name.Substring(0,1).ToUpper() + $Name.Substring(1)
+        $Message   = "Variable '`$$Name' should use PascalCase (e.g. '`$$Suggested')."
+
+        # Construct via reflection-friendly form so we don't depend on the
+        # type literal being resolvable at parse time.
+        $SeverityType = [type]'Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticSeverity'
+        $Warning      = [Enum]::Parse($SeverityType, 'Warning')
+
+        $Record = $DiagnosticType::new(
+            $Message,
+            $Left.Extent,
+            'Measure-VariablePascalCase',
+            $Warning,
+            $null  # scriptName filled in by PSScriptAnalyzer
+        )
+        $Results += $Record
+    }
+
+    return $Results
+}
+
+Export-ModuleMember -Function 'Measure-*'

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,79 @@
+@{
+    # PSScriptAnalyzer settings for Resource Discovery for Azure.
+    # Keep in sync with .kiro/steering/powershell-style.md.
+    #
+    # Run locally:
+    #   Invoke-ScriptAnalyzer -Path <file-or-folder> -Settings ./PSScriptAnalyzerSettings.psd1 -Recurse
+
+    IncludeDefaultRules = $true
+
+    # Custom rules live alongside this file.
+    CustomRulePath   = @('./.scriptanalyzer/CustomRules.psm1')
+    IncludeRules     = @('*')
+
+    # Most of the repo predates these rules; excluding here keeps the signal
+    # on new code. Remove entries as older files are cleaned up.
+    ExcludeRules = @(
+        # Pre-existing in ResourceInventory.ps1 for Service Principal auth.
+        # TODO: replace with an encrypted credential store and re-enable.
+        'PSAvoidUsingConvertToSecureStringWithPlainText'
+    )
+
+    Severity = @('Error', 'Warning', 'Information')
+
+    Rules = @{
+
+        # ---- Brace style --------------------------------------------------
+        # Allman (BSD) style: opening brace on its own line so function /
+        # block signatures stay visible when the body is folded.
+        PSPlaceOpenBrace = @{
+            Enable             = $true
+            OnSameLine         = $false   # => brace on its own line
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true    # leave `Where-Object { ... }` alone
+        }
+
+        PSPlaceCloseBrace = @{
+            Enable             = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+
+        # ---- Indentation --------------------------------------------------
+        PSUseConsistentIndentation = @{
+            Enable              = $true
+            Kind                = 'space'
+            IndentationSize     = 4
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+        }
+
+        PSUseConsistentWhitespace = @{
+            Enable                                  = $true
+            CheckInnerBrace                         = $true
+            CheckOpenBrace                          = $true
+            CheckOpenParen                          = $true
+            CheckOperator                           = $true
+            CheckPipe                               = $true
+            CheckPipeForRedundantWhitespace         = $false
+            CheckSeparator                          = $true
+            CheckParameter                          = $false
+            IgnoreAssignmentOperatorInsideHashTable = $true
+        }
+
+        # ---- Naming -------------------------------------------------------
+        # Parameter names must be PascalCase (built-in rule).
+        # Variable PascalCase is enforced by the custom rule below.
+        PSUseCorrectCasing = @{
+            Enable = $true
+        }
+
+        # Custom rule — see .scriptanalyzer/CustomRules.psm1
+        # Flags local variable assignments that don't start with an uppercase
+        # letter. Keeps a short allow-list for common iterators and automatic
+        # variables. Warning severity so it surfaces without blocking CI.
+        'Measure-VariablePascalCase' = @{
+            Enable = $true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds static analysis for PowerShell using PSScriptAnalyzer, with a custom rule enforcing the repo's PascalCase naming convention.

## What's included

- **`.github/workflows/psscriptanalyzer.yml`** — Runs on every branch push and on PRs targeting `main`/`master`. Emits findings as GitHub annotations so they show up inline, writes a summary table to the Actions run page, and fails the job on Error severity only. Warnings surface but don't block, so the legacy warning backlog can be burned down incrementally without breaking every PR.

- **`PSScriptAnalyzerSettings.psd1`** — Settings with Allman brace style, 4-space indentation, consistent whitespace, and the custom PascalCase rule enabled. Excludes `PSAvoidUsingConvertToSecureStringWithPlainText` for the existing Service Principal auth flow in `ResourceInventory.ps1`; flagged as a TODO to replace with an encrypted credential store.

- **`.scriptanalyzer/CustomRules.psm1`** — `Measure-VariablePascalCase` flags local variable assignments that don't start with an uppercase letter. Includes an allow-list for PowerShell automatic variables and short iterators, and explicitly allows `$1`/`$2`/`$3` to avoid flagging the legacy collector pattern used throughout `Services/`.

- **`.kiro/steering/powershell-style.md`** — Style guide kept in sync with the analyzer settings.

## Testing

- Verified the workflow triggers on `.ps1`/`.psm1`/`.psd1` changes.
- Custom rule discovery tested locally with `Invoke-ScriptAnalyzer -Path ./Services -Settings ./PSScriptAnalyzerSettings.psd1 -Recurse`.
- No existing source files modified, so no risk to collector behavior or report output.

## Rollout notes

Warnings do not block CI today. Once the existing warning backlog is cleaned up, the failure condition in the workflow can be flipped from `$Errors.Count -gt 0` to `$Errors.Count + $Warnings.Count -gt 0` to gate on Warnings as well.
