### PR TITLE
fix: exclude PowerShell transcript from default (non-obfuscated) zip

### DIFF
--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1087,11 +1087,17 @@ if($Obfuscate.IsPresent)
 }
 else
 {
+    # Exclude the PowerShell transcript from the zip on the default path too.
+    # The transcript captures every Write-Host/Write-Log call after Start-Transcript,
+    # which includes the authenticated account name, tenant/subscription IDs, and
+    # local file paths. Customers expect the non-obfuscated zip to contain inventory
+    # data, not their console session. The transcript stays on disk locally for debug.
     $compressionOutput = @{
-        Path = $Global:File, $Global:ConsumptionFileCsv, $Global:PowerShellTranscriptFile, $jsonWildCard
+        Path = $Global:File, $Global:ConsumptionFileCsv, $jsonWildCard
         CompressionLevel = 'Fastest'
         DestinationPath = $Global:ZipOutputFile
     }
+    Write-Log -Message ('Transcript log excluded from zip (kept locally for debug)') -Severity 'Info'
 }
 
 try 


### PR DESCRIPTION
Closes #18

## Summary

Excludes the PowerShell transcript log from the default (non-obfuscated) ZIP that customers send to AWS for review.

## Why

The transcript captures every `Write-Host` / `Write-Log` call after `Start-Transcript`, which includes:

- The authenticated account user name (typically an email)
- Tenant ID and subscription IDs
- Local file paths
- Any echoed errors that may include resource names

The obfuscated path already excluded the transcript correctly. The default path included it explicitly, leaking customer environment data on the most common code path. See #18 for details.

## What changed

`ResourceInventory.ps1` — the non-obfuscate `Compress-Archive` block no longer includes `$Global:PowerShellTranscriptFile` in `Path`. The transcript still stays on disk locally for debug, just like in the obfuscate path. A log line confirms the exclusion so customers can verify.

## Testing

- Parsed the file with `[System.Management.Automation.Language.Parser]::ParseFile()` — no syntax errors.
- Logic is symmetric with the existing obfuscate path which has been working correctly.
- No collector behavior or report content changes; only the zip manifest changes.

## Out of scope

If a debug bundle is needed for support cases in the future, attaching the transcript separately or adding an opt-in `-IncludeTranscript` switch would be a clean follow-up. Not doing it here to keep the change minimal.
