### PR TITLE
diagnostics: capture full exception detail for EPPlus Save failures (refs #16)

### DIFF
--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -1,5 +1,55 @@
 param($File, $TableStyle, $PlatOS, $Subscriptions, $Resources, $ExtractionRunTime, $ReportingRunTime, $RunLite, $Version)
 
+# Helper: invoke $package.Save() with diagnostic context. The bare .Save() call
+# raises a generic 'Error saving file ...' that doesn't tell the maintainer
+# which save site failed, what state the workbook is in, or what the underlying
+# .NET exception was. See #16 for context.
+#
+# Behaviour:
+# - On success: returns silently.
+# - On failure: writes a structured one-line summary to stderr, ensures the
+#   package is disposed (otherwise the file handle leaks and any subsequent
+#   open of the workbook on this run also fails), then re-throws so the caller's
+#   existing catch logic still fires.
+function Save-ExcelPackageWithDiagnostics
+{
+    param(
+        [Parameter(Mandatory = $true)] $Package,
+        [Parameter(Mandatory = $true)] [string] $File,
+        [Parameter(Mandatory = $true)] [string] $SaveSite
+    )
+
+    try
+    {
+        $Package.Save()
+    }
+    catch
+    {
+        $ex = $_.Exception
+        $sizeOnDisk = if (Test-Path $File) { (Get-Item $File).Length } else { -1 }
+        $worksheetCount = try { $Package.Workbook.Worksheets.Count } catch { -1 }
+
+        Write-Host ("[Summary.ps1] Save failed at site '{0}' for {1}" -f $SaveSite, $File) -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   FileSizeOnDisk: {0} bytes; WorksheetCount: {1}" -f $sizeOnDisk, $worksheetCount) -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   Exception:      {0}: {1}" -f $ex.GetType().FullName, $ex.Message) -ForegroundColor Red
+        $inner = $ex.InnerException
+        $depth = 0
+        while ($null -ne $inner -and $depth -lt 5)
+        {
+            Write-Host ("[Summary.ps1]   Inner[{0}]:      {1}: {2}" -f $depth, $inner.GetType().FullName, $inner.Message) -ForegroundColor Red
+            $inner = $inner.InnerException
+            $depth++
+        }
+
+        # Ensure the package is disposed even though Save() failed. Without this
+        # the underlying file handle stays held and the next Open-ExcelPackage
+        # on the same path fails too, which makes downstream errors confusing.
+        try { $Package.Dispose() } catch { }
+
+        throw
+    }
+}
+
 if(!$RunLite)
 {
     $Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage $File
@@ -24,7 +74,7 @@ if(!$RunLite)
         $Loop++    
     }
 
-    $Excel.Save()
+    Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'reorder-worksheets'
     $Excel.Dispose()
 }
 
@@ -52,7 +102,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'overview-grid-styling'
         $Excel.Dispose()    
     }
         
@@ -98,7 +148,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'overview-tabs-table'
         $Excel.Dispose()    
     }
 
@@ -201,7 +251,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'final-shape-and-summary-text'
         $Excel.Dispose()    
     }
 

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -41,6 +41,7 @@ if ($SkipConsumption)  { $InventoryPassthrough['SkipConsumption'] = $true }
 if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = $true }
 
 # Loop through each subscription and run ResourceInventory
+$DiagFile = $null
 foreach ($sub in $subscriptions) {
     Write-Host "Processing subscription: $($sub.Name) ($($sub.Id))" -ForegroundColor Cyan
 
@@ -49,7 +50,69 @@ foreach ($sub in $subscriptions) {
         if ($LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
         Write-Host "Completed subscription: $($sub.Name)" -ForegroundColor Green
     } catch {
-        Write-Host "ERROR processing subscription $($sub.Name): $_" -ForegroundColor Red
+        # Surface the full exception chain so failures (e.g. EPPlus Save errors,
+        # OOM in long CloudShell runs, file-handle leaks) are diagnosable instead
+        # of being summarised to a single line. See #16.
+        $errRecord = $_
+        Write-Host "ERROR processing subscription $($sub.Name): $errRecord" -ForegroundColor Red
+
+        $diagLines = @()
+        $diagLines += "==== Failure for subscription: $($sub.Name) ($($sub.Id)) ===="
+        $diagLines += "Timestamp: $(Get-Date -Format 'o')"
+        $diagLines += "Message:   $($errRecord.Exception.Message)"
+        $diagLines += "Type:      $($errRecord.Exception.GetType().FullName)"
+
+        $inner = $errRecord.Exception.InnerException
+        $depth = 0
+        while ($null -ne $inner -and $depth -lt 5) {
+            $diagLines += "Inner[$depth] Type:    $($inner.GetType().FullName)"
+            $diagLines += "Inner[$depth] Message: $($inner.Message)"
+            $inner = $inner.InnerException
+            $depth++
+        }
+
+        if ($null -ne $errRecord.InvocationInfo) {
+            $diagLines += "ScriptName:    $($errRecord.InvocationInfo.ScriptName)"
+            $diagLines += "Line:          $($errRecord.InvocationInfo.ScriptLineNumber)"
+            $diagLines += "PositionMsg:   $($errRecord.InvocationInfo.PositionMessage)"
+        }
+
+        $diagLines += "StackTrace:"
+        $diagLines += $errRecord.ScriptStackTrace
+        if ($null -ne $errRecord.Exception.StackTrace) {
+            $diagLines += "ExceptionStackTrace:"
+            $diagLines += $errRecord.Exception.StackTrace
+        }
+
+        # Environment snapshot — useful when CloudShell runs out of memory or disk
+        try {
+            $proc = Get-Process -Id $PID
+            $diagLines += "Process WorkingSet (MB):  $([math]::Round($proc.WorkingSet64 / 1MB, 1))"
+            $diagLines += "Process PrivateMemory (MB): $([math]::Round($proc.PrivateMemorySize64 / 1MB, 1))"
+        } catch { }
+
+        try {
+            $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+            if (Test-Path $InventoryRoot) {
+                $rootDrive = (Get-Item $InventoryRoot).PSDrive
+                if ($rootDrive) {
+                    $diagLines += "Free disk on $($rootDrive.Name): (MB): $([math]::Round($rootDrive.Free / 1MB, 1))"
+                }
+            }
+        } catch { }
+
+        $diagLines += ""
+
+        # Write to a per-run failures file so we don't lose the detail when many subs fail.
+        if ($null -eq $DiagFile) {
+            $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+            if (-not (Test-Path $InventoryRoot)) {
+                try { New-Item -ItemType Directory -Path $InventoryRoot -Force | Out-Null } catch { }
+            }
+            $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
+        }
+        try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 } catch { }
+
         $FailedSubscriptions += $sub.Name
     }
 
@@ -91,6 +154,9 @@ Write-Host "================ Summary ================" -ForegroundColor Green
 Write-Host ("Subscriptions Processed: {0}" -f $subscriptions.Count) -ForegroundColor Green
 if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
+    if ($DiagFile -and (Test-Path $DiagFile)) {
+        Write-Host ("Failure Diagnostics:     {0}" -f $DiagFile) -ForegroundColor Red
+    }
 }
 Write-Host ("Execution Time:          {0}" -f $Elapsed.ToString('hh\:mm\:ss')) -ForegroundColor Green
 if ($OuterZipFile) {


### PR DESCRIPTION
Refs #16 (does **not** close — see "What this PR is" below).

## What this PR is

Diagnostics-only. No behaviour change. The next time a customer hits the EPPlus Save error described in #16, the failure log will tell us exactly what's failing — at which save site, with which inner exception, with how much memory and disk available — instead of the current opaque `Exception calling "Save" with "0" argument(s)` line.

This is a *prerequisite* for fixing #16, not a fix itself. The actual root cause for #16 is unknown today — possible candidates are:

- EPPlus running into Excel's 1,048,576 row limit
- CloudShell memory exhaustion across long-running multi-sub iterations
- CloudShell home-directory disk exhaustion
- File handle leak from a previous failed Save → Dispose path

Without an inner exception or a memory/disk snapshot at failure time, picking a "fix" is guessing. This PR makes the next reproduction self-diagnosing.

## What changed

### `Run-AllSubscriptions.ps1`

The wrapper's `catch` block previously printed `$_` — which is the .NET method-invocation wrapper, not the actual EPPlus error. It now writes a per-run structured failures log to `<InventoryReports>/RunAllSubscriptions_failures_<timestamp>.log` containing:

- Full exception type, message, **up to 5 levels of `InnerException`**
- `InvocationInfo` (which script, which line, position context)
- `ScriptStackTrace` and `Exception.StackTrace`
- Process WorkingSet / PrivateMemory at failure time (relevant for OOM hypotheses)
- Free disk on the inventory drive (relevant for disk-full hypotheses)

The on-screen `ERROR processing subscription <name>: ...` line is unchanged, so anything the maintainer or user expected to see still appears.

### `Extension/Summary.ps1`

There are four `$Excel.Save()` call sites in `Summary.ps1`. They are now routed through a helper `Save-ExcelPackageWithDiagnostics` that:

- Tags **which save site failed** — one of `reorder-worksheets`, `overview-grid-styling`, `overview-tabs-table`, `final-shape-and-summary-text`. Right now there's no way to tell from the error which of the four it was.
- Logs the file size on disk and worksheet count at failure time.
- **Calls `$Package.Dispose()` on failure.** This was a real latent issue: the existing code calls `.Dispose()` *after* `.Save()`, so a failed save left the file handle open. Subsequent `Open-ExcelPackage` calls (which exist later in the same script) would then fail with a misleading "file in use" error that masked the real cause.
- Re-throws so the wrapper's `catch` still fires and processes the next subscription.

## What this PR is NOT

- Not a behavioural change to the report content. The same data lands in the same xlsx.
- Not a fix for #16. The Save still fails when whatever underlying condition is in play.
- Not a perf regression — the helper only adds work on the failure path.
- Not a public API change. `Save-ExcelPackageWithDiagnostics` is internal to `Summary.ps1`.

## Testing

- `[Parser]::ParseFile` clean on all touched files.
- The helper falls through to `$Package.Save()` on the success path, so no observable difference in the happy case.
- On the failure path, the structured output goes to a separate file and the on-screen messages are *additive* — nothing existing is removed or rephrased.

## Follow-up

Once a customer (Vishwanath or anyone else with a 100+ sub tenant) reproduces #16 against this code and shares the new failures log, a targeted fix can be written in a single follow-up PR. That PR will close #16 properly.
