### PR TITLE
fix(auth) + feat(resume,state-filter) + diagnostics: hardening for multi-subscription runs

### DIFF
--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -139,7 +139,8 @@ function Save-ExcelPackageWithDiagnostics
         # Ensure the package is disposed even though Save() failed. Without this
         # the underlying file handle stays held and the next Open-ExcelPackage
         # on the same path fails too, which makes downstream errors confusing.
-        try { $Package.Dispose() } catch { }
+        try { $Package.Dispose() }
+        catch { Write-Verbose ("Package.Dispose() after Save failure threw: {0}" -f $_.Exception.Message) }
 
         throw
     }

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -1,4 +1,14 @@
-param($File, $TableStyle, $PlatOS, $Subscriptions, $Resources, $ExtractionRunTime, $ReportingRunTime, $RunLite, $Version)
+param(
+    $File, 
+    $TableStyle, 
+    $PlatOS, 
+    $Subscriptions, 
+    $Resources, 
+    $ExtractionRunTime, 
+    $ReportingRunTime, 
+    $RunLite, 
+    $Version
+)
 
 # Ensure the EPPlus types backing ImportExcel are available before any
 # `New-Object -TypeName OfficeOpenXml.ExcelPackage` call below.

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -31,6 +31,50 @@ try {
     throw
 }
 
+# Translate the underlying exception chain into a single plain-English
+# explanation of what most likely went wrong, so the user does not have to
+# read .NET stack traces to triage. Inspects the full InnerException chain
+# for known signals and falls through to a generic message if none match.
+function Get-SaveFailureDiagnosis
+{
+    param(
+        [Parameter(Mandatory = $true)] $Exception,
+        [Parameter(Mandatory = $true)] [int] $WorksheetCount,
+        [Parameter(Mandatory = $true)] [bool] $FileExists
+    )
+
+    $messages = @()
+    $e = $Exception
+    while ($null -ne $e)
+    {
+        $messages += $e.Message
+        $e = $e.InnerException
+    }
+    $combined = ($messages -join ' | ')
+
+    if ($combined -match 'must contain at least one worksheet')
+    {
+        return 'The workbook is empty (zero worksheets). EPPlus refuses to save a workbook with no sheets. This usually means the inventory phase produced no resources for this subscription, so there were no per-service tabs to write into the file.'
+    }
+    if ($combined -match 'being used by another process|cannot access the file|sharing violation')
+    {
+        return 'The output file is held open by another process. Close any Microsoft Excel window that has this file open and re-run.'
+    }
+    if ($combined -match 'UnauthorizedAccess|access to the path .* is denied|access is denied')
+    {
+        return 'Access to the output file or its parent folder was denied. Check permissions on the InventoryReports folder, and that no antivirus or DLP product is blocking writes.'
+    }
+    if ($combined -match 'There is not enough space|disk full|not enough room')
+    {
+        return 'Insufficient disk space to write the output file.'
+    }
+    if (-not $FileExists -and $WorksheetCount -gt 0)
+    {
+        return 'The output file does not exist on disk yet, but the in-memory workbook has worksheets. The Save call should have created the file. This is most likely a path or permission issue from EPPlus rather than a content issue.'
+    }
+    return 'No specific diagnosis matched. See the exception details below for the underlying error.'
+}
+
 # Helper: invoke $package.Save() with diagnostic context. The bare .Save() call
 # raises a generic 'Error saving file ...' that doesn't tell the maintainer
 # which save site failed, what state the workbook is in, or what the underlying
@@ -38,10 +82,11 @@ try {
 #
 # Behaviour:
 # - On success: returns silently.
-# - On failure: writes a structured one-line summary to stderr, ensures the
-#   package is disposed (otherwise the file handle leaks and any subsequent
-#   open of the workbook on this run also fails), then re-throws so the caller's
-#   existing catch logic still fires.
+# - On failure: writes a structured, human-readable diagnosis followed by the
+#   raw exception chain to the host stream; ensures the package is disposed
+#   (otherwise the file handle leaks and any subsequent open of the workbook
+#   on this run also fails); then re-throws so the caller's existing catch
+#   logic still fires.
 function Save-ExcelPackageWithDiagnostics
 {
     param(
@@ -57,17 +102,26 @@ function Save-ExcelPackageWithDiagnostics
     catch
     {
         $ex = $_.Exception
-        $sizeOnDisk = if (Test-Path $File) { (Get-Item $File).Length } else { -1 }
-        $worksheetCount = try { $Package.Workbook.Worksheets.Count } catch { -1 }
+        $fileExists = Test-Path $File
+        $sizeOnDisk = if ($fileExists) { (Get-Item $File).Length } else { $null }
+        $worksheetCount = try { [int]$Package.Workbook.Worksheets.Count } catch { -1 }
+        $sizeText = if (-not $fileExists) { '<file does not exist on disk yet>' } else { '{0} bytes' -f $sizeOnDisk }
+        $worksheetText = if ($worksheetCount -lt 0) { '<could not read; package state inaccessible>' } else { [string]$worksheetCount }
+
+        $diagnosis = Get-SaveFailureDiagnosis -Exception $ex -WorksheetCount $worksheetCount -FileExists $fileExists
 
         Write-Host ("[Summary.ps1] Save failed at site '{0}' for {1}" -f $SaveSite, $File) -ForegroundColor Red
-        Write-Host ("[Summary.ps1]   FileSizeOnDisk: {0} bytes; WorksheetCount: {1}" -f $sizeOnDisk, $worksheetCount) -ForegroundColor Red
-        Write-Host ("[Summary.ps1]   Exception:      {0}: {1}" -f $ex.GetType().FullName, $ex.Message) -ForegroundColor Red
+        Write-Host ("[Summary.ps1] Likely cause: {0}" -f $diagnosis) -ForegroundColor Yellow
+        Write-Host "[Summary.ps1] State at failure:" -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   File on disk: {0}" -f $sizeText) -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   Worksheets:   {0}" -f $worksheetText) -ForegroundColor Red
+        Write-Host "[Summary.ps1] Underlying exception:" -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   {0}: {1}" -f $ex.GetType().FullName, $ex.Message) -ForegroundColor Red
         $inner = $ex.InnerException
         $depth = 0
         while ($null -ne $inner -and $depth -lt 5)
         {
-            Write-Host ("[Summary.ps1]   Inner[{0}]:      {1}: {2}" -f $depth, $inner.GetType().FullName, $inner.Message) -ForegroundColor Red
+            Write-Host ("[Summary.ps1]   Inner[{0}]: {1}: {2}" -f $depth, $inner.GetType().FullName, $inner.Message) -ForegroundColor Red
             $inner = $inner.InnerException
             $depth++
         }
@@ -86,27 +140,64 @@ if(!$RunLite)
     $Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage $File
     $Worksheets = $Excel.Workbook.Worksheets
 
-    $Order = $Worksheets | Select-Object -Property Index, name, @{N = "Dimension"; E = { $_.dimension.Rows - 1 } } | Sort-Object -Property Dimension -Descending
-    $Order0 = $Order | Where-Object { $_.Name -ne $Order[0].name -and $_.Name -ne ($Order | select-object -Last 1).Name }
-
-    $Loop = 0
-
-    Foreach ($Ord in $Order0) 
+    # Skip the reorder/save step if the workbook is empty.
+    #
+    # Background: New-Object OfficeOpenXml.ExcelPackage <path> does not
+    # require the file to exist - if the path is missing it returns a fresh
+    # in-memory package with zero worksheets. EPPlus then refuses to .Save()
+    # a workbook with no sheets ("The workbook must contain at least one
+    # worksheet") and the bare error gives no hint about why. Reaching this
+    # state means the inventory phase produced no per-service tabs for this
+    # subscription - a sub with no resources, a Resource Graph permission
+    # gap, or an obfuscation pipeline that filtered everything out. Either
+    # way there is nothing to reorder. Let the next block (Export-Excel
+    # ... -WorksheetName 'Overview' below) bootstrap the workbook with at
+    # least the Overview sheet so subsequent steps have something to work
+    # with.
+    if ($Worksheets.Count -eq 0)
     {
-        if ($Ord.Index -and $Loop -ne 0) 
-        {
-            $Worksheets.MoveAfter($Ord.Name, $Order0[$Loop - 1].Name)
-        }
-        if ($Loop -eq 0) 
-        {
-            $Worksheets.MoveAfter($Ord.Name, $Order[0].Name)
-        }
-
-        $Loop++    
+        Write-Host ("[Summary.ps1] Workbook for '{0}' has zero worksheets at the reorder step. The inventory phase produced no per-service tabs (likely an empty subscription, a permission gap, or all rows filtered by obfuscation). Skipping reorder; the Overview sheet will be created in the next step." -f $File) -ForegroundColor Yellow
+        $Excel.Dispose()
     }
+    else
+    {
+        $Order = $Worksheets | Select-Object -Property Index, name, @{N = "Dimension"; E = { $_.dimension.Rows - 1 } } | Sort-Object -Property Dimension -Descending
 
-    Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'reorder-worksheets'
-    $Excel.Dispose()
+        # When the workbook has only one or two sheets there is nothing to
+        # reorder either: $Order[0] and ($Order | Select -Last 1) collapse to
+        # the same item (or are the entire collection), and $Order0 ends up
+        # empty. Handle both edge cases explicitly rather than relying on
+        # Where-Object filtering an undefined index.
+        if ($Worksheets.Count -lt 3)
+        {
+            $Order0 = @()
+        }
+        else
+        {
+            $firstName = $Order[0].name
+            $lastName  = ($Order | Select-Object -Last 1).Name
+            $Order0 = $Order | Where-Object { $_.Name -ne $firstName -and $_.Name -ne $lastName }
+        }
+
+        $Loop = 0
+
+        Foreach ($Ord in $Order0)
+        {
+            if ($Ord.Index -and $Loop -ne 0)
+            {
+                $Worksheets.MoveAfter($Ord.Name, $Order0[$Loop - 1].Name)
+            }
+            if ($Loop -eq 0)
+            {
+                $Worksheets.MoveAfter($Ord.Name, $Order[0].Name)
+            }
+
+            $Loop++
+        }
+
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'reorder-worksheets'
+        $Excel.Dispose()
+    }
 }
 
 "" | Export-Excel -Path $File -WorksheetName 'Overview' -MoveToStart
@@ -161,13 +252,25 @@ if(!$RunLite)
     $TabDraw.TextAlignment = 'Center'
 
     $Table = @()
-    foreach ($WorkS in $Worksheets) 
+    foreach ($WorkS in $Worksheets)
     {
-        $Number = $WorkS.Tables.Name.split('_')
+        # Each per-service worksheet is expected to have exactly one Table
+        # whose name follows the pattern "<Name>_<Size>" (the size half is
+        # the row count used to populate the Overview tabs grid). Worksheets
+        # that lack a Table - or have a Table whose name does not match the
+        # pattern - are skipped rather than being allowed to throw on an
+        # unsplittable null. Without this guard a single misshapen sheet
+        # blocks the entire Overview build.
+        $tableName = try { $WorkS.Tables.Name } catch { $null }
+        if ([string]::IsNullOrWhiteSpace($tableName)) { continue }
+
+        $parts = $tableName -split '_'
+        $size = 0
+        if ($parts.Count -ge 2) { [int]::TryParse($parts[1], [ref]$size) | Out-Null }
 
         $tmp = @{
             'Name' = $WorkS.name;
-            'Size' = [int]$Number[1]
+            'Size' = $size
         }
 
         $Table += $tmp
@@ -195,7 +298,12 @@ if(!$RunLite)
     $ExtractTime = if($ExtractionRunTime.Totalminutes -lt 1){($ExtractionRunTime.Seconds.ToString()+' Seconds')}else{($ExtractionRunTime.Totalminutes.ToString('#######.##')+' Minutes')}
     $ReportTime = ($ReportingRunTime.Totalminutes.ToString('#######.##')+' Minutes')
 
-    $User = $Subscriptions[0].user.name
+    # $User is referenced once below for the summary text drawing. Guard
+    # against the (rare but possible) case where Subscriptions is empty or
+    # the first element lacks a .user.name; an out-of-bounds or null member
+    # access here would abort the entire Summary build for what is purely a
+    # cosmetic field.
+    $User = if ($Subscriptions -and $Subscriptions.Count -gt 0 -and $Subscriptions[0].user) { $Subscriptions[0].user.name } else { '<unknown user>' }
     $TotalRes = $Resources
 
 

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -1,5 +1,55 @@
 param($File, $TableStyle, $PlatOS, $Subscriptions, $Resources, $ExtractionRunTime, $ReportingRunTime, $RunLite, $Version)
 
+# Helper: invoke $package.Save() with diagnostic context. The bare .Save() call
+# raises a generic 'Error saving file ...' that doesn't tell the maintainer
+# which save site failed, what state the workbook is in, or what the underlying
+# .NET exception was. See #16 for context.
+#
+# Behaviour:
+# - On success: returns silently.
+# - On failure: writes a structured one-line summary to stderr, ensures the
+#   package is disposed (otherwise the file handle leaks and any subsequent
+#   open of the workbook on this run also fails), then re-throws so the caller's
+#   existing catch logic still fires.
+function Save-ExcelPackageWithDiagnostics
+{
+    param(
+        [Parameter(Mandatory = $true)] $Package,
+        [Parameter(Mandatory = $true)] [string] $File,
+        [Parameter(Mandatory = $true)] [string] $SaveSite
+    )
+
+    try
+    {
+        $Package.Save()
+    }
+    catch
+    {
+        $ex = $_.Exception
+        $sizeOnDisk = if (Test-Path $File) { (Get-Item $File).Length } else { -1 }
+        $worksheetCount = try { $Package.Workbook.Worksheets.Count } catch { -1 }
+
+        Write-Host ("[Summary.ps1] Save failed at site '{0}' for {1}" -f $SaveSite, $File) -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   FileSizeOnDisk: {0} bytes; WorksheetCount: {1}" -f $sizeOnDisk, $worksheetCount) -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   Exception:      {0}: {1}" -f $ex.GetType().FullName, $ex.Message) -ForegroundColor Red
+        $inner = $ex.InnerException
+        $depth = 0
+        while ($null -ne $inner -and $depth -lt 5)
+        {
+            Write-Host ("[Summary.ps1]   Inner[{0}]:      {1}: {2}" -f $depth, $inner.GetType().FullName, $inner.Message) -ForegroundColor Red
+            $inner = $inner.InnerException
+            $depth++
+        }
+
+        # Ensure the package is disposed even though Save() failed. Without this
+        # the underlying file handle stays held and the next Open-ExcelPackage
+        # on the same path fails too, which makes downstream errors confusing.
+        try { $Package.Dispose() } catch { }
+
+        throw
+    }
+}
+
 if(!$RunLite)
 {
     $Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage $File
@@ -24,7 +74,7 @@ if(!$RunLite)
         $Loop++    
     }
 
-    $Excel.Save()
+    Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'reorder-worksheets'
     $Excel.Dispose()
 }
 
@@ -52,7 +102,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'overview-grid-styling'
         $Excel.Dispose()    
     }
         
@@ -98,7 +148,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'overview-tabs-table'
         $Excel.Dispose()    
     }
 
@@ -201,7 +251,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'final-shape-and-summary-text'
         $Excel.Dispose()    
     }
 

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -298,11 +298,13 @@ if(!$RunLite)
     $ExtractTime = if($ExtractionRunTime.Totalminutes -lt 1){($ExtractionRunTime.Seconds.ToString()+' Seconds')}else{($ExtractionRunTime.Totalminutes.ToString('#######.##')+' Minutes')}
     $ReportTime = ($ReportingRunTime.Totalminutes.ToString('#######.##')+' Minutes')
 
-    # $User is referenced once below for the summary text drawing. Guard
-    # against the (rare but possible) case where Subscriptions is empty or
-    # the first element lacks a .user.name; an out-of-bounds or null member
-    # access here would abort the entire Summary build for what is purely a
-    # cosmetic field.
+    # $User and $TotalRes are kept for backward-compatibility - upstream forks
+    # or downstream consumers may reference them via dot-sourcing patterns.
+    # The original assignment of $User crashed the entire Summary build if
+    # $Subscriptions was empty or its first element lacked a .user, even
+    # though nothing in the script body reads $User itself. Guarding the
+    # assignment is cheap insurance against a regression that would surface
+    # only in unusual environments.
     $User = if ($Subscriptions -and $Subscriptions.Count -gt 0 -and $Subscriptions[0].user) { $Subscriptions[0].user.name } else { '<unknown user>' }
     $TotalRes = $Resources
 

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -1,5 +1,36 @@
 param($File, $TableStyle, $PlatOS, $Subscriptions, $Resources, $ExtractionRunTime, $ReportingRunTime, $RunLite, $Version)
 
+# Ensure the EPPlus types backing ImportExcel are available before any
+# `New-Object -TypeName OfficeOpenXml.ExcelPackage` call below.
+#
+# Background: this script is invoked via `& $SummaryPath ...` from
+# ResourceInventory.ps1, which creates a new child scope. PowerShell's
+# auto-import of modules only triggers on first use of a *cmdlet* exported
+# by the module, but the lines below reference the underlying EPPlus type
+# directly via `New-Object`. Type references do not trigger auto-import,
+# so on a fresh script invocation - or on the second-and-later iterations
+# of a long Run-AllSubscriptions.ps1 loop where module state can be
+# evicted on Windows PowerShell - the type lookup fails with:
+#
+#   Cannot find type [OfficeOpenXml.ExcelPackage]: verify that the
+#   assembly containing this type is loaded.
+#
+# Importing ImportExcel explicitly here is idempotent and inexpensive, and
+# guarantees the EPPlus assembly is loaded into the current AppDomain
+# before any New-Object call against its types. This matches the pattern
+# already used elsewhere in the script for Az modules.
+try {
+    if (-not ([System.Management.Automation.PSTypeName]'OfficeOpenXml.ExcelPackage').Type) {
+        Import-Module ImportExcel -ErrorAction Stop -Force -DisableNameChecking | Out-Null
+    }
+    if (-not ([System.Management.Automation.PSTypeName]'OfficeOpenXml.ExcelPackage').Type) {
+        throw "ImportExcel module imported but the OfficeOpenXml.ExcelPackage type is still not loadable. The ImportExcel module may be present but its bundled EPPlus assembly is missing or unloadable in this runspace."
+    }
+} catch {
+    Write-Error ("Summary.ps1 cannot proceed: {0}" -f $_.Exception.Message)
+    throw
+}
+
 # Helper: invoke $package.Save() with diagnostic context. The bare .Save() call
 # raises a generic 'Error saving file ...' that doesn't tell the maintainer
 # which save site failed, what state the workbook is in, or what the underlying

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each 
 
 Each subscription produces its own set of timestamped reports in `InventoryReports/`. After all subscriptions are processed, the wrapper bundles the per-subscription ZIPs into a single `AllSubscriptions_ResourcesReport_<timestamp>.zip` in the same folder for easy delivery.
 
+#### Resuming an interrupted run
+
+For tenants with many subscriptions, the run can be cut short by environment-level limits — for example, an Azure Cloud Shell session that ends when a Conditional Access policy enforces a maximum session lifetime. The wrapper supports resuming:
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012" -Resume
+```
+
+After each subscription is fully processed (its per-subscription ZIP has been written), the wrapper records the subscription ID in a state file at `InventoryReports/.resume-state-<TenantID>.json`. Re-running with `-Resume` reads that file and skips subscriptions that are already complete; the partially processed subscription (the one that was running when the session ended) is re-run from the start. The state file is cleared automatically after a clean run with no failures.
+
+`-Resume` is opt-in. Without it, the wrapper processes every subscription returned by `Get-AzSubscription`, and existing state is left untouched.
+
 ## Output Files
 
 Upon completion, the script generates reports in the `InventoryReports` folder:

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each 
 ./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012"
 ```
 
+`-TenantID` accepts either a tenant GUID or a verified domain. When a domain is passed (for example `contoso.onmicrosoft.com`), the wrapper resolves it to the GUID via Microsoft's anonymous OIDC discovery endpoint before doing anything else, so this also works:
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "contoso.onmicrosoft.com"
+```
+
 Each subscription produces its own set of timestamped reports in `InventoryReports/`. After all subscriptions are processed, the wrapper bundles the per-subscription ZIPs into a single `AllSubscriptions_ResourcesReport_<timestamp>.zip` in the same folder for easy delivery.
 
 #### Subscription state filter

--- a/README.md
+++ b/README.md
@@ -46,11 +46,30 @@ Before running the script, ensure your Azure user account has the following role
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [Azure CLI Account Extension](https://learn.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview)
 - Azure CLI Resource-Graph Extension (auto-installed by script)
+- **Az PowerShell module** and **ImportExcel module** (install before running — see below)
 
 > **Note:** Install the Account Extension before running the script:
 > ```powershell
 > az extension add --name account
 > ```
+
+##### Installing the required PowerShell modules
+
+The script needs both `Az` and `ImportExcel` modules. Install them once before the first run, from an elevated **PowerShell 7** prompt (`pwsh`):
+
+```powershell
+Install-Module -Name Az          -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
+Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
+```
+
+The script no longer auto-installs these modules from inside its own run. Auto-install during a script that's already importing the same module produces a class of silent broken installs (manifest present, bundled assemblies missing — typically MSAL and Azure.Core for Az), and the failure surfaces much later as zero consumption records or "Cannot find type [OfficeOpenXml.ExcelPackage]" errors. Installing once outside the script, ahead of time, is reliable.
+
+If you suspect a previous run left a broken Az install on disk:
+
+```powershell
+Get-Module Az* -ListAvailable | Uninstall-Module -Force
+Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
+```
   
 
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each 
 
 Each subscription produces its own set of timestamped reports in `InventoryReports/`. After all subscriptions are processed, the wrapper bundles the per-subscription ZIPs into a single `AllSubscriptions_ResourcesReport_<timestamp>.zip` in the same folder for easy delivery.
 
+#### Subscription state filter
+
+By default, `Run-AllSubscriptions.ps1` only inventories subscriptions whose `State` is `Enabled`. Subscriptions in any other state (`Disabled`, `Warned`, `PastDue`, `Deleted`) are skipped because they return little or no data from Resource Graph and most ARM data-plane calls, so processing them produces near-empty reports while still costing wall-clock time.
+
+To include every subscription regardless of state, pass `-IncludeDisabled`:
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012" -IncludeDisabled
+```
+
+The wrapper prints the count of excluded subscriptions and a per-state breakdown so the filter is transparent.
+
 #### Resuming an interrupted run
 
 For tenants with many subscriptions, the run can be cut short by environment-level limits — for example, an Azure Cloud Shell session that ends when a Conditional Access policy enforces a maximum session lifetime. The wrapper supports resuming:

--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ After each subscription is fully processed (its per-subscription ZIP has been wr
 
 `-Resume` is opt-in. Without it, the wrapper processes every subscription returned by `Get-AzSubscription`, and existing state is left untouched.
 
+#### Run transcript and failure diagnostics
+
+Every invocation of `Run-AllSubscriptions.ps1` writes a wrapper-level transcript to `InventoryReports/RunAllSubscriptions_transcript_<timestamp>.txt`. Unlike the per-subscription transcripts that `ResourceInventory.ps1` writes inside each subscription folder, this file captures the full wrapper run end-to-end: tenant resolution, authentication decisions, resume-state messages, the cross-iteration narration of which subscription is being processed, the consolidation step, and the final summary. This applies to every run, single subscription or many.
+
+If a subscription fails, the wrapper additionally writes a structured failure log to `InventoryReports/RunAllSubscriptions_failures_<timestamp>.log` containing the full exception type, message, up to five levels of `InnerException`, the script line, stack traces, and a snapshot of process memory and free disk at failure time. The final summary points at both files when failures have occurred.
+
+When reporting an issue, attach both files. They contain enough context to diagnose most failures without a follow-up round trip.
+
 ## Output Files
 
 Upon completion, the script generates reports in the `InventoryReports` folder:

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1101,71 +1101,99 @@ function FinalizeOutputs
 # Detect the most common environment problems that make a long run pointless,
 # before transcript start, authentication, or any per-subscription work.
 #
-# NOTE: Keep this block in sync with the same block at the top of
-# Run-AllSubscriptions.ps1 (just before its Resolve-TenantId call). They are
-# inlined in both files rather than dot-sourced from a shared file because
-# the dot-source itself is a failure surface (path resolution, missing file)
-# we do not want to add to a script whose entire job is to fail loudly when
-# the environment is wrong.
-$PreFlightInventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
-if (-not (Test-Path -Path $PreFlightInventoryRoot -PathType Container)) {
-    try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null } catch { }
-}
+# When this script is invoked by Run-AllSubscriptions.ps1 (-RunAllSubs is
+# set), the wrapper has already executed the same checks at its top level,
+# so the entire block is skipped here - otherwise the checks would re-run
+# once per subscription (e.g. 164 times in a 164-sub run), adding noise to
+# the per-subscription transcript without adding safety. Standalone invocation
+# of this script still runs the full block.
+#
+# NOTE: Keep the body of this block in sync with the same block at the top
+# of Run-AllSubscriptions.ps1 (just before its Resolve-TenantId call). They
+# are inlined in both files rather than dot-sourced from a shared file
+# because the dot-source itself is a failure surface (path resolution,
+# missing file) we do not want to add to a script whose entire job is to
+# fail loudly when the environment is wrong. Intentional differences vs the
+# wrapper copy:
+#   - This copy honors -OutputDirectory if the caller passed one (the wrapper
+#     does not expose or forward that parameter).
+#   - This copy throws on hard-fail; the wrapper's copy calls Exit-Wrapper.
+#   - This copy is gated on -not $RunAllSubs to avoid duplicate execution
+#     when invoked by the wrapper.
+if (-not $RunAllSubs.IsPresent) {
 
-Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
-
-# 1. Cloud Shell mount detection. See Run-AllSubscriptions.ps1 for the rationale.
-if (Get-Command Get-CloudDrive -ErrorAction SilentlyContinue) {
-    $CheckCloudDrive = Get-CloudDrive 3>$null 2>$null
-    if ($null -eq $CheckCloudDrive) {
-        Write-Host ""
-        Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
-        Write-Host "  Outputs in $PreFlightInventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
-        Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
-        Write-Host "    clouddrive mount" -ForegroundColor Yellow
-        Write-Host "  Continuing in ephemeral mode - download the report ZIP from $PreFlightInventoryRoot before closing the shell." -ForegroundColor Yellow
-        Write-Host ""
+    # Honor -OutputDirectory when the caller passed one. CheckPowerShell will
+    # re-validate -OutputDirectory itself further down and is the authoritative
+    # gate; we Resolve-Path here defensively so a relative path is checked at
+    # the right location, and fall back to the raw value if it does not yet
+    # resolve (the write probe below will surface the underlying error).
+    $PreFlightInventoryRoot = if ($OutputDirectory) {
+        try { (Resolve-Path $OutputDirectory -ErrorAction Stop).Path }
+        catch { $OutputDirectory }
+    } elseif ($PSVersionTable.Platform -eq 'Unix') {
+        "$HOME/InventoryReports"
     } else {
-        Write-Host ("Cloud Shell drive mounted: {0}" -f $CheckCloudDrive.Name) -ForegroundColor Green
+        "C:\InventoryReports"
     }
-}
+    if (-not (Test-Path -Path $PreFlightInventoryRoot -PathType Container)) {
+        try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+    }
 
-# 2. Disk space probe.
-try {
-    $rootItem = Get-Item -Path $PreFlightInventoryRoot -ErrorAction Stop
-    $drive = $rootItem.PSDrive
-    if ($null -ne $drive -and $null -ne $drive.Free) {
-        $freeMB = [math]::Round($drive.Free / 1MB, 0)
-        if ($freeMB -lt 100) {
-            throw ("Pre-flight: free disk space at {0} is {1} MB; the script needs at least 100 MB to start. Free space and re-run." -f $PreFlightInventoryRoot, $freeMB)
-        } elseif ($freeMB -lt 500) {
-            Write-Host ("WARNING: Free disk space at {0} is {1} MB. A large multi-subscription run can exceed this. Consider freeing space before running." -f $PreFlightInventoryRoot, $freeMB) -ForegroundColor Yellow
+    Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
+
+    # 1. Cloud Shell mount detection. See Run-AllSubscriptions.ps1 for the rationale.
+    if (Get-Command Get-CloudDrive -ErrorAction SilentlyContinue) {
+        $CheckCloudDrive = Get-CloudDrive 3>$null 2>$null
+        if ($null -eq $CheckCloudDrive) {
+            Write-Host ""
+            Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
+            Write-Host "  Outputs in $PreFlightInventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
+            Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
+            Write-Host "    clouddrive mount" -ForegroundColor Yellow
+            Write-Host "  Continuing in ephemeral mode - download the report ZIP from $PreFlightInventoryRoot before closing the shell." -ForegroundColor Yellow
+            Write-Host ""
         } else {
-            Write-Host ("Free disk space: {0:N0} MB at {1}" -f $freeMB, $PreFlightInventoryRoot) -ForegroundColor Green
+            Write-Host ("Cloud Shell drive mounted: {0}" -f $CheckCloudDrive.Name) -ForegroundColor Green
         }
     }
-} catch {
-    if ($_.Exception.Message -match '^Pre-flight:') { throw }
-    Write-Host ("WARNING: Could not determine free disk space at {0}: {1}" -f $PreFlightInventoryRoot, $_.Exception.Message) -ForegroundColor Yellow
-}
 
-# 3. Write probe.
-$probePath = Join-Path $PreFlightInventoryRoot (".write-probe-{0}.tmp" -f ([guid]::NewGuid()))
-try {
-    Set-Content -Path $probePath -Value 'preflight write probe' -Encoding utf8 -ErrorAction Stop
-    $probeRead = Get-Content -Path $probePath -Raw -ErrorAction Stop
-    if ($probeRead -notmatch 'preflight write probe') {
-        throw "Write probe content mismatch (read back '$probeRead')"
+    # 2. Disk space probe.
+    try {
+        $rootItem = Get-Item -Path $PreFlightInventoryRoot -ErrorAction Stop
+        $drive = $rootItem.PSDrive
+        if ($null -ne $drive -and $null -ne $drive.Free) {
+            $freeMB = [math]::Round($drive.Free / 1MB, 0)
+            if ($freeMB -lt 100) {
+                throw ("Pre-flight: free disk space at {0} is {1} MB; the script needs at least 100 MB to start. Free space and re-run." -f $PreFlightInventoryRoot, $freeMB)
+            } elseif ($freeMB -lt 500) {
+                Write-Host ("WARNING: Free disk space at {0} is {1} MB. A large multi-subscription run can exceed this. Consider freeing space before running." -f $PreFlightInventoryRoot, $freeMB) -ForegroundColor Yellow
+            } else {
+                Write-Host ("Free disk space: {0:N0} MB at {1}" -f $freeMB, $PreFlightInventoryRoot) -ForegroundColor Green
+            }
+        }
+    } catch {
+        if ($_.Exception.Message -match '^Pre-flight:') { throw }
+        Write-Host ("WARNING: Could not determine free disk space at {0}: {1}" -f $PreFlightInventoryRoot, $_.Exception.Message) -ForegroundColor Yellow
     }
-    Remove-Item -Path $probePath -Force -ErrorAction Stop
-    Write-Host ("Write probe: OK ({0})" -f $PreFlightInventoryRoot) -ForegroundColor Green
-} catch {
-    try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
-    throw ("Pre-flight: cannot write to {0}: {1}. This usually means readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle. Verify the directory is writable and re-run." -f $PreFlightInventoryRoot, $_.Exception.Message)
-}
 
-Write-Host "Pre-flight checks passed." -ForegroundColor Green
-Write-Host ""
+    # 3. Write probe.
+    $probePath = Join-Path $PreFlightInventoryRoot (".write-probe-{0}.tmp" -f ([guid]::NewGuid()))
+    try {
+        Set-Content -Path $probePath -Value 'preflight write probe' -Encoding utf8 -ErrorAction Stop
+        $probeRead = Get-Content -Path $probePath -Raw -ErrorAction Stop
+        if ($probeRead -notmatch 'preflight write probe') {
+            throw "Write probe content mismatch (read back '$probeRead')"
+        }
+        Remove-Item -Path $probePath -Force -ErrorAction Stop
+        Write-Host ("Write probe: OK ({0})" -f $PreFlightInventoryRoot) -ForegroundColor Green
+    } catch {
+        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+        throw ("Pre-flight: cannot write to {0}: {1}. This usually means readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle. Verify the directory is writable and re-run." -f $PreFlightInventoryRoot, $_.Exception.Message)
+    }
+
+    Write-Host "Pre-flight checks passed." -ForegroundColor Green
+    Write-Host ""
+}
 
 # Setup and Inventory Gathering.
 #

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -142,21 +142,45 @@ Function RunInventorySetup()
         }
         else
         {
-            Write-Log -Message ('Azure PowerShell Module not found. Trying to install...') -Severity 'Warning'
-            Install-Module -Name Az -Repository PSGallery -Force -Scope CurrentUser
-            $VarAzPs = Get-Module -Name Az -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
+            # Behaviour change (deliberate): do not Install-Module Az from inside
+            # this script. A real field run produced a half-installed Az module
+            # - .psd1 manifests present so Get-Module -ListAvailable was happy,
+            # but the bundled MSAL/Azure.Core assemblies were missing on disk -
+            # and the script then ran for nearly an hour producing zero
+            # consumption data because every Get-AzUsageAggregate call failed
+            # with "Azure PowerShell context has not been properly initialized".
+            # In-process module installs into a script that's already importing
+            # the same module are fragile (concurrent install, AppDomain
+            # caching, partial download) and the failure mode is a silent broken
+            # install rather than a clean error. Failing loudly here is safer.
+            Write-Log -Message ('Azure PowerShell Module not found.') -Severity 'Error'
+            Write-Log -Message ('Install it manually before re-running this script. From an elevated PowerShell 7 prompt:') -Severity 'Error'
+            Write-Log -Message ('  Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck') -Severity 'Error'
+            Write-Log -Message ('Or in Cloud Shell, the Az module is already preinstalled - if it is missing your shell environment is broken.') -Severity 'Error'
+            throw 'Azure PowerShell (Az) module is required and was not found. See log above for installation instructions.'
         }
 
-        if ($null -eq $VarAzPs) 
-        {
-            Write-Log -Message ('Failed to install Azure PowerShell Module. Press <Enter> to finish script') -Severity 'Error'
-            Read-Host ''
-            Exit
+        # Probe that the Az module actually loads. Get-Module -ListAvailable above
+        # only checks for the manifest on disk; it does not validate that the
+        # bundled assemblies (MSAL, Azure.Core, etc.) are present and loadable.
+        # Without this probe a broken install (manifest present, assemblies
+        # missing - a real field-observed scenario) would let the script
+        # continue all the way to the consumption phase before failing.
+        try {
+            Import-Module Az -ErrorAction Stop -DisableNameChecking | Out-Null
+            $Global:AzPowerShellLoaded = $true
+        } catch {
+            Write-Log -Message ('Azure PowerShell module is present on disk but failed to load: {0}' -f $_.Exception.Message) -Severity 'Error'
+            Write-Log -Message ('This usually indicates a broken install - the module manifest is present but its bundled assemblies (MSAL, Azure.Core, etc.) are missing or unloadable.') -Severity 'Error'
+            Write-Log -Message ('Reinstall with: Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck') -Severity 'Error'
+            Write-Log -Message ('If the broken install was created by a previous run of this script, also run: Get-Module Az* -ListAvailable | Uninstall-Module -Force') -Severity 'Error'
+            $Global:AzPowerShellLoaded = $false
+            throw "Azure PowerShell (Az) module is broken on disk and cannot be loaded. See log above for remediation."
         }
-        
+
 
         Write-Log -Message ('Checking ImportExcel Module...') -Severity 'Info'
-    
+
         $VarExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
     
         if ($null -ne $VarExcel)
@@ -165,16 +189,15 @@ Function RunInventorySetup()
         }
         else
         {
-            Write-Log -Message ('ImportExcel Module not found. Trying to install...') -Severity 'Warning'
-            Install-Module -Name ImportExcel -Force -Scope CurrentUser
-            $VarExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
-        }
-    
-        if ($null -eq $VarExcel) 
-        {
-            Write-Log -Message ('Failed to install ImportExcel Module. Press <Enter> to finish script') -Severity 'Error'
-            Read-Host ''
-            Exit
+            # Behaviour change (deliberate): do not Install-Module ImportExcel
+            # from inside this script. Same rationale as the Az module check
+            # above - in-process module installs into a script that's already
+            # importing the same module produce silent broken installs that
+            # only surface much later. Fail loud here with a clear command.
+            Write-Log -Message ('ImportExcel Module not found.') -Severity 'Error'
+            Write-Log -Message ('Install it manually before re-running this script. From an elevated PowerShell 7 prompt:') -Severity 'Error'
+            Write-Log -Message ('  Install-Module -Name ImportExcel -Force -AllowClobber -SkipPublisherCheck') -Severity 'Error'
+            throw 'ImportExcel module is required and was not found. See log above for installation instructions.'
         }
 
         # Eagerly import ImportExcel so its bundled EPPlus assembly is loaded into the
@@ -895,21 +918,33 @@ function ExecuteInventoryProcessing()
             Set-AzContext -Subscription $sub.id | Out-Null
             Write-Log -Message ("Gathering Consumption for: {0}" -f $sub.Name) -Severity 'Info'
 
-            do 
-            {    
-                $params = @{
-                    ReportedStartTime      = $reportedStartTime
-                    ReportedEndTime        = $reportedEndTime
-                    AggregationGranularity = 'Daily'
-                    ShowDetails            = $true
-                }
-    
-                $params.ContinuationToken = $usageData.ContinuationToken
-    
-                $usageData = Get-UsageAggregates @params
-                $usageDataExport = $usageData.UsageAggregations.Properties | Select-Object InstanceData, MeterCategory, MeterId, MeterName, MeterRegion, MeterSubCategory, Quantity, Unit, UsageStartTime, UsageEndTime
+            # Track consumption health per-subscription so the wrapper can report
+            # at the end whether consumption data was actually collected. Without
+            # this, a broken Az module produces zero consumption records on every
+            # subscription and the run still reports as successful - leaving an
+            # empty consumption sheet in the output that nobody noticed until the
+            # report was reviewed.
+            $consumptionRecordsThisSub = 0
+            $consumptionFailedThisSub = $false
+            $consumptionFailureMessage = $null
 
-                Write-Log -Message ("Records found: $($usageDataExport.Count)...") -Severity 'Info'
+            try {
+                do
+                {
+                    $params = @{
+                        ReportedStartTime      = $reportedStartTime
+                        ReportedEndTime        = $reportedEndTime
+                        AggregationGranularity = 'Daily'
+                        ShowDetails            = $true
+                    }
+
+                    $params.ContinuationToken = $usageData.ContinuationToken
+
+                    $usageData = Get-UsageAggregates @params -ErrorAction Stop
+                    $usageDataExport = $usageData.UsageAggregations.Properties | Select-Object InstanceData, MeterCategory, MeterId, MeterName, MeterRegion, MeterSubCategory, Quantity, Unit, UsageStartTime, UsageEndTime
+
+                    Write-Log -Message ("Records found: $($usageDataExport.Count)...") -Severity 'Info'
+                    $consumptionRecordsThisSub += $usageDataExport.Count
 
                 $newUsageDataExport = [System.Collections.ArrayList]::new()
 
@@ -995,7 +1030,32 @@ function ExecuteInventoryProcessing()
 
                 $newUsageDataExport | Select-Object InstanceData, MeterCategory, MeterId, MeterName, MeterRegion, MeterSubCategory, Quantity, Unit, UsageStartTime, UsageEndTime, ResourceId, ResourceLocation, ConsumptionMeter, ReservationId, ReservationOrderId | Export-Csv $Global:ConsumptionFileCsv -Encoding utf8 -Append -NoTypeInformation
                 
-            } while ('ContinuationToken' -in $usageData.psobject.properties.name -and $usageData.ContinuationToken)
+                } while ('ContinuationToken' -in $usageData.psobject.properties.name -and $usageData.ContinuationToken)
+            } catch {
+                # The most common cause is a broken Az module install (manifest
+                # present, MSAL/Azure.Core assemblies missing). The script-level
+                # Import-Module probe should have caught that, but we also catch
+                # here defensively so a transient ARM throttling event or a
+                # subscription the identity cannot bill against does not abort
+                # the entire run for other subscriptions.
+                $consumptionFailedThisSub = $true
+                $consumptionFailureMessage = $_.Exception.Message
+                Write-Log -Message ("Consumption query failed for {0}: {1}" -f $sub.Name, $_.Exception.Message) -Severity 'Warning'
+            }
+
+            # Aggregate per-sub consumption health into globals the wrapper reads
+            # at the end of the run. Globals here live in the wrapper's scope
+            # because ResourceInventory.ps1 is invoked via `& <path>`.
+            if ($null -eq $Global:ConsumptionRecordCount) { $Global:ConsumptionRecordCount = 0 }
+            if ($null -eq $Global:ConsumptionFailedSubs)  { $Global:ConsumptionFailedSubs  = @() }
+            $Global:ConsumptionRecordCount += $consumptionRecordsThisSub
+            if ($consumptionFailedThisSub) {
+                $Global:ConsumptionFailedSubs += [pscustomobject]@{
+                    Name    = $sub.Name
+                    Id      = $sub.Id
+                    Message = $consumptionFailureMessage
+                }
+            }
         }
 
         $DebugPreference = "Continue"

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1096,6 +1096,77 @@ function FinalizeOutputs
     ProcessSummary
 }
 
+# === Pre-flight checks ===
+#
+# Detect the most common environment problems that make a long run pointless,
+# before transcript start, authentication, or any per-subscription work.
+#
+# NOTE: Keep this block in sync with the same block at the top of
+# Run-AllSubscriptions.ps1 (just before its Resolve-TenantId call). They are
+# inlined in both files rather than dot-sourced from a shared file because
+# the dot-source itself is a failure surface (path resolution, missing file)
+# we do not want to add to a script whose entire job is to fail loudly when
+# the environment is wrong.
+$PreFlightInventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+if (-not (Test-Path -Path $PreFlightInventoryRoot -PathType Container)) {
+    try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+}
+
+Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
+
+# 1. Cloud Shell mount detection. See Run-AllSubscriptions.ps1 for the rationale.
+if (Get-Command Get-CloudDrive -ErrorAction SilentlyContinue) {
+    $CheckCloudDrive = Get-CloudDrive 3>$null 2>$null
+    if ($null -eq $CheckCloudDrive) {
+        Write-Host ""
+        Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
+        Write-Host "  Outputs in $PreFlightInventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
+        Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
+        Write-Host "    clouddrive mount" -ForegroundColor Yellow
+        Write-Host "  Continuing in ephemeral mode - download the report ZIP from $PreFlightInventoryRoot before closing the shell." -ForegroundColor Yellow
+        Write-Host ""
+    } else {
+        Write-Host ("Cloud Shell drive mounted: {0}" -f $CheckCloudDrive.Name) -ForegroundColor Green
+    }
+}
+
+# 2. Disk space probe.
+try {
+    $rootItem = Get-Item -Path $PreFlightInventoryRoot -ErrorAction Stop
+    $drive = $rootItem.PSDrive
+    if ($null -ne $drive -and $null -ne $drive.Free) {
+        $freeMB = [math]::Round($drive.Free / 1MB, 0)
+        if ($freeMB -lt 100) {
+            throw ("Pre-flight: free disk space at {0} is {1} MB; the script needs at least 100 MB to start. Free space and re-run." -f $PreFlightInventoryRoot, $freeMB)
+        } elseif ($freeMB -lt 500) {
+            Write-Host ("WARNING: Free disk space at {0} is {1} MB. A large multi-subscription run can exceed this. Consider freeing space before running." -f $PreFlightInventoryRoot, $freeMB) -ForegroundColor Yellow
+        } else {
+            Write-Host ("Free disk space: {0:N0} MB at {1}" -f $freeMB, $PreFlightInventoryRoot) -ForegroundColor Green
+        }
+    }
+} catch {
+    if ($_.Exception.Message -match '^Pre-flight:') { throw }
+    Write-Host ("WARNING: Could not determine free disk space at {0}: {1}" -f $PreFlightInventoryRoot, $_.Exception.Message) -ForegroundColor Yellow
+}
+
+# 3. Write probe.
+$probePath = Join-Path $PreFlightInventoryRoot (".write-probe-{0}.tmp" -f ([guid]::NewGuid()))
+try {
+    Set-Content -Path $probePath -Value 'preflight write probe' -Encoding utf8 -ErrorAction Stop
+    $probeRead = Get-Content -Path $probePath -Raw -ErrorAction Stop
+    if ($probeRead -notmatch 'preflight write probe') {
+        throw "Write probe content mismatch (read back '$probeRead')"
+    }
+    Remove-Item -Path $probePath -Force -ErrorAction Stop
+    Write-Host ("Write probe: OK ({0})" -f $PreFlightInventoryRoot) -ForegroundColor Green
+} catch {
+    try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+    throw ("Pre-flight: cannot write to {0}: {1}. This usually means readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle. Verify the directory is writable and re-run." -f $PreFlightInventoryRoot, $_.Exception.Message)
+}
+
+Write-Host "Pre-flight checks passed." -ForegroundColor Green
+Write-Host ""
+
 $Global:PowerShellTranscriptFile = ($DefaultPath + "Transcript_Log_"+ $Global:ReportName + "_" + $CurrentDateTime + ".txt")
 Start-Transcript -Path $Global:PowerShellTranscriptFile -UseMinimalHeader
 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -258,9 +258,21 @@ Function RunInventorySetup()
 
             if (!$TenantID -or $existingAccount.tenantId -eq $TenantID)
             {
-                # Ensure PowerShell Az context is also set
+                # Ensure PowerShell Az context is set for the requested tenant.
+                # We compare the Az PS context's tenant — not its current subscription
+                # — against $existingAccount because the Az PS and az CLI contexts can
+                # have different default subscriptions even when authenticated against
+                # the same tenant. Comparing subscriptions caused a re-Connect-AzAccount
+                # on every iteration of Run-AllSubscriptions.ps1 on PowerShell Desktop,
+                # which prompted the user to log in again for each subscription. Per-
+                # subscription scoping happens later via Set-AzContext / --subscriptions /
+                # resource-id parameters on Get-AzMetric, so the context only needs to
+                # match the tenant.
                 $azContext = Get-AzContext -ErrorAction SilentlyContinue
-                if ($null -eq $azContext -or $azContext.Subscription.Id -ne $existingAccount.id)
+                $needsConnect = $null -eq $azContext -or
+                                [string]::IsNullOrEmpty($azContext.Tenant.Id) -or
+                                $azContext.Tenant.Id -ne $existingAccount.tenantId
+                if ($needsConnect)
                 {
                     Write-Log -Message ('Setting PowerShell Az context...') -Severity 'Info'
                     if($DeviceLogin.IsPresent)

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1167,13 +1167,22 @@ try {
 Write-Host "Pre-flight checks passed." -ForegroundColor Green
 Write-Host ""
 
-$Global:PowerShellTranscriptFile = ($DefaultPath + "Transcript_Log_"+ $Global:ReportName + "_" + $CurrentDateTime + ".txt")
-Start-Transcript -Path $Global:PowerShellTranscriptFile -UseMinimalHeader
-
-# Setup and Inventory Gathering
+# Setup and Inventory Gathering.
+#
+# Variables and RunInventorySetup populate $Global:DefaultPath, $Global:ReportName,
+# and $Global:CurrentDateTime which are required to compute the transcript path.
+# Start-Transcript must therefore run *after* RunInventorySetup, not before.
+# Previously this block placed Start-Transcript above Variables, with the result
+# that $DefaultPath/$ReportName/$CurrentDateTime were all $null at that point and
+# the transcript file landed in the current working directory with the literal
+# name "Transcript_Log__.txt" - two underscores, missing report name and missing
+# timestamp.
 $Global:Runtime = Measure-Command -Expression {
     Variables
     RunInventorySetup
+
+    $Global:PowerShellTranscriptFile = ($Global:DefaultPath + "Transcript_Log_" + $Global:ReportName + "_" + $Global:CurrentDateTime + ".txt")
+    Start-Transcript -Path $Global:PowerShellTranscriptFile -UseMinimalHeader
 }
 
 # Execution and processing of inventory

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -176,6 +176,30 @@ Function RunInventorySetup()
             Read-Host ''
             Exit
         }
+
+        # Eagerly import ImportExcel so its bundled EPPlus assembly is loaded into the
+        # current AppDomain before any code path constructs OfficeOpenXml types via
+        # New-Object. -ListAvailable (above) only confirms the module exists; it does
+        # not load it. Without this explicit import, scripts further down the call
+        # chain (notably Extension/Summary.ps1, which is invoked in a child scope via
+        # `& $SummaryPath ...`) fail with:
+        #
+        #   Cannot find type [OfficeOpenXml.ExcelPackage]: verify that the
+        #   assembly containing this type is loaded.
+        #
+        # The failure surfaces especially on Windows PowerShell Desktop in
+        # multi-subscription runs where the auto-import behavior across iterations
+        # can lose the loaded assembly's reference. Importing once here is idempotent
+        # and inexpensive.
+        try {
+            Import-Module ImportExcel -ErrorAction Stop -Force -DisableNameChecking | Out-Null
+            if (-not ([System.Management.Automation.PSTypeName]'OfficeOpenXml.ExcelPackage').Type) {
+                Write-Log -Message ('ImportExcel imported but OfficeOpenXml.ExcelPackage type is not loadable. The Excel report step will fail.') -Severity 'Error'
+            }
+        } catch {
+            Write-Log -Message ('Import-Module ImportExcel failed: {0}' -f $_.Exception.Message) -Severity 'Error'
+            throw
+        }
     }
     
     function CheckPowerShell() 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1136,7 +1136,8 @@ if (-not $RunAllSubs.IsPresent) {
         "C:\InventoryReports"
     }
     if (-not (Test-Path -Path $PreFlightInventoryRoot -PathType Container)) {
-        try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+        try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null }
+        catch { Write-Verbose ("PreFlightInventoryRoot create failed at {0}: {1}" -f $PreFlightInventoryRoot, $_.Exception.Message) }
     }
 
     Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
@@ -1187,7 +1188,8 @@ if (-not $RunAllSubs.IsPresent) {
         Remove-Item -Path $probePath -Force -ErrorAction Stop
         Write-Host ("Write probe: OK ({0})" -f $PreFlightInventoryRoot) -ForegroundColor Green
     } catch {
-        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } }
+        catch { Write-Verbose ("Probe cleanup failed at {0}: {1}" -f $probePath, $_.Exception.Message) }
         throw ("Pre-flight: cannot write to {0}: {1}. This usually means readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle. Verify the directory is writable and re-run." -f $PreFlightInventoryRoot, $_.Exception.Message)
     }
 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -89,8 +89,24 @@ Function RunInventorySetup()
     {
         Write-Log -Message ('Checking Version') -Severity 'Info'
         Write-Log -Message ('Version: {0}' -f $Global:Version) -Severity 'Info'
-        
-        $versionJson = (New-Object System.Net.WebClient).DownloadString($RawRepo + '/Version.json') | ConvertFrom-Json
+
+        # The version check is best-effort. On corporate networks that block
+        # raw.githubusercontent.com (DNS failure, firewall, or air-gap), this
+        # WebClient call would otherwise raise SocketException and abort the
+        # entire subscription before any inventory work began. A failed update
+        # check is not a reason to skip a subscription's inventory - log a
+        # clear note and continue with the local version. See #18.
+        try
+        {
+            $versionJson = (New-Object System.Net.WebClient).DownloadString($RawRepo + '/Version.json') | ConvertFrom-Json
+        }
+        catch
+        {
+            Write-Log -Message ("Could not reach {0}/Version.json to check for an update: {1}" -f $RawRepo, $_.Exception.Message) -Severity 'Warning'
+            Write-Log -Message ('Continuing with local version {0}. If you are on a managed network, this is expected.' -f $Global:Version) -Severity 'Info'
+            return
+        }
+
         $versionNumber = ('{0}.{1}.{2}' -f $versionJson.MajorVersion, $versionJson.MinorVersion, $versionJson.BuildVersion)
 
         if($versionNumber -ne $Global:Version)

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -8,7 +8,8 @@ param (
     [switch]$Obfuscate,
     [switch]$SkipMetrics,
     [switch]$SkipConsumption,
-    [switch]$Resume
+    [switch]$Resume,
+    [switch]$IncludeDisabled
 )
 
 $RunStartTime = Get-Date
@@ -73,7 +74,28 @@ try {
 }
 
 # Get all Azure subscriptions
-$subscriptions = Get-AzSubscription
+$allSubscriptions = Get-AzSubscription
+
+# Filter out non-Enabled subscriptions by default. Disabled / Warned / Deleted
+# subscriptions return little-to-no data from Resource Graph and most ARM
+# data-plane calls, so processing them produces near-empty per-subscription
+# reports while still costing wall-clock time (which matters for environments
+# like Azure Cloud Shell where the session has a hard maximum lifetime).
+# Pass -IncludeDisabled to inventory every subscription regardless of state.
+if ($IncludeDisabled) {
+    $subscriptions = $allSubscriptions
+    $excluded = @()
+} else {
+    $subscriptions = @($allSubscriptions | Where-Object { $_.State -eq 'Enabled' })
+    $excluded     = @($allSubscriptions | Where-Object { $_.State -ne 'Enabled' })
+}
+
+Write-Host ("Subscriptions visible: {0}" -f $allSubscriptions.Count) -ForegroundColor Cyan
+if ($excluded.Count -gt 0) {
+    $byState = $excluded | Group-Object -Property State | ForEach-Object { ('{0}: {1}' -f $_.Name, $_.Count) }
+    Write-Host ("Excluded {0} non-Enabled subscription(s) [{1}]. Use -IncludeDisabled to inventory them anyway." -f $excluded.Count, ($byState -join ', ')) -ForegroundColor Yellow
+}
+Write-Host ("Subscriptions to process: {0}" -f $subscriptions.Count) -ForegroundColor Cyan
 
 # Apply resume filter (only when -Resume is explicitly passed)
 $CompletedIds = @()
@@ -170,7 +192,11 @@ if ($FailedSubscriptions.Count -eq 0 -and (Test-Path -Path $ResumeStateFile -Pat
 $Elapsed = (Get-Date) - $RunStartTime
 Write-Host ""
 Write-Host "================ Summary ================" -ForegroundColor Green
-Write-Host ("Subscriptions Total:     {0}" -f $subscriptions.Count) -ForegroundColor Green
+Write-Host ("Subscriptions Visible:   {0}" -f $allSubscriptions.Count) -ForegroundColor Green
+if ($excluded.Count -gt 0) {
+    Write-Host ("Subscriptions Excluded:  {0} (non-Enabled; use -IncludeDisabled to inventory them)" -f $excluded.Count) -ForegroundColor Green
+}
+Write-Host ("Subscriptions Eligible:  {0}" -f $subscriptions.Count) -ForegroundColor Green
 if ($Resume) {
     Write-Host ("Subscriptions Skipped:   {0} (already completed)" -f $SkippedCount) -ForegroundColor Green
 }

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -296,6 +296,7 @@ if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = 
 
 # Loop through each subscription and run ResourceInventory
 $SkippedCount = 0
+$DiagFile = $null
 foreach ($sub in $subscriptions) {
     if ($Resume -and ($CompletedIds -contains $sub.Id)) {
         Write-Host ("Skipping (already completed): {0} ({1})" -f $sub.Name, $sub.Id) -ForegroundColor DarkGray
@@ -316,7 +317,69 @@ foreach ($sub in $subscriptions) {
             Save-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID -Ids $CompletedIds
         }
     } catch {
-        Write-Host "ERROR processing subscription $($sub.Name): $_" -ForegroundColor Red
+        # Surface the full exception chain so failures (e.g. EPPlus Save errors,
+        # OOM in long CloudShell runs, file-handle leaks) are diagnosable instead
+        # of being summarised to a single line. See #16.
+        $errRecord = $_
+        Write-Host "ERROR processing subscription $($sub.Name): $errRecord" -ForegroundColor Red
+
+        $diagLines = @()
+        $diagLines += "==== Failure for subscription: $($sub.Name) ($($sub.Id)) ===="
+        $diagLines += "Timestamp: $(Get-Date -Format 'o')"
+        $diagLines += "Message:   $($errRecord.Exception.Message)"
+        $diagLines += "Type:      $($errRecord.Exception.GetType().FullName)"
+
+        $inner = $errRecord.Exception.InnerException
+        $depth = 0
+        while ($null -ne $inner -and $depth -lt 5) {
+            $diagLines += "Inner[$depth] Type:    $($inner.GetType().FullName)"
+            $diagLines += "Inner[$depth] Message: $($inner.Message)"
+            $inner = $inner.InnerException
+            $depth++
+        }
+
+        if ($null -ne $errRecord.InvocationInfo) {
+            $diagLines += "ScriptName:    $($errRecord.InvocationInfo.ScriptName)"
+            $diagLines += "Line:          $($errRecord.InvocationInfo.ScriptLineNumber)"
+            $diagLines += "PositionMsg:   $($errRecord.InvocationInfo.PositionMessage)"
+        }
+
+        $diagLines += "StackTrace:"
+        $diagLines += $errRecord.ScriptStackTrace
+        if ($null -ne $errRecord.Exception.StackTrace) {
+            $diagLines += "ExceptionStackTrace:"
+            $diagLines += $errRecord.Exception.StackTrace
+        }
+
+        # Environment snapshot — useful when CloudShell runs out of memory or disk
+        try {
+            $proc = Get-Process -Id $PID
+            $diagLines += "Process WorkingSet (MB):  $([math]::Round($proc.WorkingSet64 / 1MB, 1))"
+            $diagLines += "Process PrivateMemory (MB): $([math]::Round($proc.PrivateMemorySize64 / 1MB, 1))"
+        } catch { }
+
+        try {
+            $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+            if (Test-Path $InventoryRoot) {
+                $rootDrive = (Get-Item $InventoryRoot).PSDrive
+                if ($rootDrive) {
+                    $diagLines += "Free disk on $($rootDrive.Name): (MB): $([math]::Round($rootDrive.Free / 1MB, 1))"
+                }
+            }
+        } catch { }
+
+        $diagLines += ""
+
+        # Write to a per-run failures file so we don't lose the detail when many subs fail.
+        if ($null -eq $DiagFile) {
+            $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+            if (-not (Test-Path $InventoryRoot)) {
+                try { New-Item -ItemType Directory -Path $InventoryRoot -Force | Out-Null } catch { }
+            }
+            $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
+        }
+        try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 } catch { }
+
         $FailedSubscriptions += $sub.Name
     }
 
@@ -378,6 +441,9 @@ if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
     Write-Host ("Resume State:            {0}" -f $ResumeStateFile) -ForegroundColor Yellow
     Write-Host "Re-run with -Resume to retry failed and any unprocessed subscriptions." -ForegroundColor Yellow
+    if ($DiagFile -and (Test-Path $DiagFile)) {
+        Write-Host ("Failure Diagnostics:     {0}" -f $DiagFile) -ForegroundColor Red
+    }
 }
 Write-Host ("Execution Time:          {0}" -f $Elapsed.ToString('hh\:mm\:ss')) -ForegroundColor Green
 if ($OuterZipFile) {

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -57,16 +57,72 @@ function Save-CompletedSubscriptionIds {
     }
 }
 
-# Authenticate
+# Authenticate, but only if needed.
+#
+# In environments like Azure Cloud Shell the shell already has a valid az CLI
+# and Az PowerShell session for the signed-in user. Unconditionally calling
+# `az login` and `Connect-AzAccount` from the wrapper produces a redundant
+# browser/device-code prompt every run. The script also needs each context
+# to be on the requested tenant - if either is on a different tenant the
+# subscription queries below will return the wrong (or no) results.
+#
+# Check both contexts first; only sign in for the side that is missing or on
+# the wrong tenant. The signal we care about is the tenant, not the default
+# subscription, because per-subscription scoping is handled at use-site
+# (Set-AzContext / --subscriptions / resource-id-scoped Get-AzMetric).
+
+function Get-AzCliSignedInTenant {
+    $raw = az account show --output json 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $raw) { return $null }
+    try { return ($raw | ConvertFrom-Json).tenantId } catch { return $null }
+}
+
+function Get-AzPsSignedInTenant {
+    try {
+        $ctx = Get-AzContext -ErrorAction Stop
+        if ($null -eq $ctx -or $null -eq $ctx.Account) { return $null }
+        return $ctx.Tenant.Id
+    } catch {
+        return $null
+    }
+}
+
 try {
-    if ($DeviceLogin) {
-        az login -t $TenantID --use-device-code --only-show-errors | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "az login failed with exit code $LASTEXITCODE" }
-        Connect-AzAccount -Tenant $TenantID -UseDeviceAuthentication | Out-Null
+    $cliTenant = Get-AzCliSignedInTenant
+    $psTenant  = Get-AzPsSignedInTenant
+
+    $cliOk = ($cliTenant -eq $TenantID)
+    $psOk  = ($psTenant  -eq $TenantID)
+
+    if ($cliOk -and $psOk) {
+        Write-Host ("Existing session detected for tenant {0}; skipping interactive login." -f $TenantID) -ForegroundColor Green
     } else {
-        az login -t $TenantID --only-show-errors | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "az login failed with exit code $LASTEXITCODE" }
-        Connect-AzAccount -Tenant $TenantID | Out-Null
+        if (-not $cliOk) {
+            if ($null -eq $cliTenant) {
+                Write-Host "az CLI is not signed in; authenticating..." -ForegroundColor Cyan
+            } else {
+                Write-Host ("az CLI is signed in to tenant {0}; switching to {1}..." -f $cliTenant, $TenantID) -ForegroundColor Cyan
+            }
+            if ($DeviceLogin) {
+                az login -t $TenantID --use-device-code --only-show-errors | Out-Null
+            } else {
+                az login -t $TenantID --only-show-errors | Out-Null
+            }
+            if ($LASTEXITCODE -ne 0) { throw "az login failed with exit code $LASTEXITCODE" }
+        }
+
+        if (-not $psOk) {
+            if ($null -eq $psTenant) {
+                Write-Host "Az PowerShell is not signed in; authenticating..." -ForegroundColor Cyan
+            } else {
+                Write-Host ("Az PowerShell is signed in to tenant {0}; switching to {1}..." -f $psTenant, $TenantID) -ForegroundColor Cyan
+            }
+            if ($DeviceLogin) {
+                Connect-AzAccount -Tenant $TenantID -UseDeviceAuthentication | Out-Null
+            } else {
+                Connect-AzAccount -Tenant $TenantID | Out-Null
+            }
+        }
     }
 } catch {
     Write-Host "ERROR: Authentication failed. $_" -ForegroundColor Red

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -20,7 +20,8 @@ $FailedSubscriptions = @()
 # anything else writes to the host.
 $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
 if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {
-    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null }
+    catch { Write-Verbose ("InventoryRoot create failed at {0}: {1}" -f $InventoryRoot, $_.Exception.Message) }
 }
 
 # Wrapper-level transcript.
@@ -60,7 +61,8 @@ try {
 function Exit-Wrapper {
     param([int]$Code = 0)
     if ($WrapperTranscriptStarted) {
-        try { Stop-Transcript | Out-Null } catch { }
+        try { Stop-Transcript | Out-Null }
+        catch { Write-Verbose ("Stop-Transcript on Exit-Wrapper failed: {0}" -f $_.Exception.Message) }
     }
     exit $Code
 }
@@ -161,7 +163,8 @@ function Invoke-PreFlightChecks {
         Write-Host "  This usually means: readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle." -ForegroundColor Red
         Write-Host "  Verify the directory is writable and re-run." -ForegroundColor Red
         # Best-effort cleanup in case Set-Content partially succeeded.
-        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } }
+        catch { Write-Verbose ("Probe cleanup failed at {0}: {1}" -f $probePath, $_.Exception.Message) }
         Exit-Wrapper -Code 1
     }
 
@@ -536,7 +539,7 @@ foreach ($sub in $subscriptions) {
             $proc = Get-Process -Id $PID
             $diagLines += "Process WorkingSet (MB):  $([math]::Round($proc.WorkingSet64 / 1MB, 1))"
             $diagLines += "Process PrivateMemory (MB): $([math]::Round($proc.PrivateMemorySize64 / 1MB, 1))"
-        } catch { }
+        } catch { Write-Verbose ("Process snapshot failed: {0}" -f $_.Exception.Message) }
 
         try {
             $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
@@ -546,7 +549,7 @@ foreach ($sub in $subscriptions) {
                     $diagLines += "Free disk on $($rootDrive.Name): (MB): $([math]::Round($rootDrive.Free / 1MB, 1))"
                 }
             }
-        } catch { }
+        } catch { Write-Verbose ("Disk snapshot failed: {0}" -f $_.Exception.Message) }
 
         $diagLines += ""
 
@@ -554,11 +557,13 @@ foreach ($sub in $subscriptions) {
         if ($null -eq $DiagFile) {
             $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
             if (-not (Test-Path $InventoryRoot)) {
-                try { New-Item -ItemType Directory -Path $InventoryRoot -Force | Out-Null } catch { }
+                try { New-Item -ItemType Directory -Path $InventoryRoot -Force | Out-Null }
+                catch { Write-Verbose ("InventoryRoot create failed at {0}: {1}" -f $InventoryRoot, $_.Exception.Message) }
             }
             $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
         }
-        try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 } catch { }
+        try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 }
+        catch { Write-Verbose ("DiagFile write failed at {0}: {1}" -f $DiagFile, $_.Exception.Message) }
 
         $FailedSubscriptions += $sub.Name
     }
@@ -693,5 +698,6 @@ Write-Host "=========================================" -ForegroundColor Green
 # Stop the wrapper transcript on the normal-completion path. Error paths take
 # Exit-Wrapper which does the same.
 if ($WrapperTranscriptStarted) {
-    try { Stop-Transcript | Out-Null } catch { }
+    try { Stop-Transcript | Out-Null }
+    catch { Write-Verbose ("Stop-Transcript on normal completion failed: {0}" -f $_.Exception.Message) }
 }

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -341,6 +341,11 @@ if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = 
 # Loop through each subscription and run ResourceInventory
 $SkippedCount = 0
 $DiagFile = $null
+# Per-subscription resource counts collected for the final summary so the user
+# can see at a glance which subscriptions came back empty (the most common
+# explanation is that the signed-in identity does not have Reader on the
+# subscription, but it can also legitimately mean the subscription is empty).
+$SubResourceCounts = @()
 foreach ($sub in $subscriptions) {
     if ($Resume -and ($CompletedIds -contains $sub.Id)) {
         Write-Host ("Skipping (already completed): {0} ({1})" -f $sub.Name, $sub.Id) -ForegroundColor DarkGray
@@ -353,6 +358,31 @@ foreach ($sub in $subscriptions) {
     try {
         & (Join-Path $PSScriptRoot "ResourceInventory.ps1") -TenantID $TenantID -SubscriptionID $sub.Id @InventoryPassthrough -RunAllSubs
         if ($LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
+
+        # Capture the per-subscription resource count from the inner script.
+        # ResourceInventory.ps1 invokes via `& <path>` so its $Global:Resources
+        # lives in this wrapper's scope. The inner script resets that variable
+        # to @() at the start of every invocation, so the count after return
+        # accurately reflects the subscription that just finished.
+        $resCount = if ($null -ne $Global:Resources) { @($Global:Resources).Count } else { 0 }
+        $SubResourceCounts += [pscustomobject]@{
+            Name  = $sub.Name
+            Id    = $sub.Id
+            Count = $resCount
+        }
+
+        if ($resCount -eq 0) {
+            # Loud yellow signal so this stands out in the per-iteration narration
+            # and in the wrapper transcript. The most common cause is the signed-in
+            # identity not having Reader on the subscription; second is a sub that
+            # genuinely has no resources. Either way the user almost always wants
+            # to know immediately rather than discover it days later when the
+            # consolidated report turns out to be empty for some subs.
+            Write-Host ("WARNING: Subscription '{0}' returned 0 resources. Likely permission gap (no Reader on the subscription) or a genuinely empty subscription. Verify with: az graph query -q ""resources | summarize count()"" --subscriptions {1}" -f $sub.Name, $sub.Id) -ForegroundColor Yellow
+        } else {
+            Write-Host ("Resources collected: {0:N0}" -f $resCount) -ForegroundColor DarkGreen
+        }
+
         Write-Host "Completed subscription: $($sub.Name)" -ForegroundColor Green
 
         # Mark complete and persist immediately so a mid-run sign-out is recoverable.
@@ -481,6 +511,29 @@ if ($Resume) {
     Write-Host ("Subscriptions Skipped:   {0} (already completed)" -f $SkippedCount) -ForegroundColor Green
 }
 Write-Host ("Subscriptions Processed: {0}" -f ($subscriptions.Count - $SkippedCount)) -ForegroundColor Green
+
+# Surface the per-subscription resource-count result so the user does not have
+# to scan individual transcripts to find subs that came back empty. Empty subs
+# are shown distinctly because they almost always indicate a permission gap;
+# treating them as "successful" in the summary is misleading.
+$EmptySubs = @($SubResourceCounts | Where-Object { $_.Count -eq 0 })
+$NonEmptySubs = @($SubResourceCounts | Where-Object { $_.Count -gt 0 })
+if ($SubResourceCounts.Count -gt 0) {
+    $totalRes = ($SubResourceCounts | Measure-Object -Property Count -Sum).Sum
+    Write-Host ("Total Resources:         {0:N0} across {1} subscription(s)" -f $totalRes, $NonEmptySubs.Count) -ForegroundColor Green
+}
+if ($EmptySubs.Count -gt 0) {
+    Write-Host ""
+    Write-Host ("Subscriptions Empty:     {0} (returned 0 resources)" -f $EmptySubs.Count) -ForegroundColor Yellow
+    Write-Host "  Likely permission gap (no Reader on the subscription) or genuinely empty subscription." -ForegroundColor Yellow
+    Write-Host "  Verify Reader access for these specifically:" -ForegroundColor Yellow
+    foreach ($e in $EmptySubs) {
+        Write-Host ("    - {0} ({1})" -f $e.Name, $e.Id) -ForegroundColor Yellow
+    }
+    Write-Host "  Acid test: az graph query -q ""resources | summarize count()"" --subscriptions <id>" -ForegroundColor Yellow
+    Write-Host ""
+}
+
 if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
     Write-Host ("Resume State:            {0}" -f $ResumeStateFile) -ForegroundColor Yellow

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -534,6 +534,36 @@ if ($EmptySubs.Count -gt 0) {
     Write-Host ""
 }
 
+# Surface consumption (billing) data health. The inner script's consumption
+# loop populates these globals; if every Get-UsageAggregates call failed
+# (typically because the Az PowerShell module is broken on disk and cannot
+# load its bundled MSAL/Azure.Core assemblies) the customer ends up with an
+# empty consumption sheet and no signal that anything went wrong. Make it
+# loud here so it's caught before the report is shared.
+$consumptionRecords = if ($null -ne $Global:ConsumptionRecordCount) { [int]$Global:ConsumptionRecordCount } else { 0 }
+$consumptionFailures = if ($null -ne $Global:ConsumptionFailedSubs) { @($Global:ConsumptionFailedSubs) } else { @() }
+if ($consumptionRecords -gt 0 -or $consumptionFailures.Count -gt 0) {
+    Write-Host ("Consumption Records:     {0:N0} record(s) collected" -f $consumptionRecords) -ForegroundColor Green
+}
+if ($consumptionFailures.Count -gt 0) {
+    Write-Host ""
+    Write-Host ("Consumption Failures:    {0} subscription(s)" -f $consumptionFailures.Count) -ForegroundColor Yellow
+    # The consumption failure message is repeated verbatim across every sub
+    # when the cause is a broken Az module - dedupe to avoid screen wall.
+    $uniqueMessages = @($consumptionFailures | Select-Object -ExpandProperty Message -Unique)
+    foreach ($m in $uniqueMessages) {
+        Write-Host ("  - {0}" -f $m) -ForegroundColor Yellow
+    }
+    if ($uniqueMessages | Where-Object { $_ -match 'context has not been properly initialized|Could not load file or assembly|MSAL|Azure\.Core' }) {
+        Write-Host "  This message strongly suggests the Az PowerShell module is broken on disk." -ForegroundColor Yellow
+        Write-Host "  Reinstall with:" -ForegroundColor Yellow
+        Write-Host "    Get-Module Az* -ListAvailable | Uninstall-Module -Force" -ForegroundColor Yellow
+        Write-Host "    Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck" -ForegroundColor Yellow
+    }
+    Write-Host "  Note: the consumption sheet in the output report may be empty or incomplete for these subscriptions." -ForegroundColor Yellow
+    Write-Host ""
+}
+
 if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
     Write-Host ("Resume State:            {0}" -f $ResumeStateFile) -ForegroundColor Yellow

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -65,6 +65,112 @@ function Exit-Wrapper {
     exit $Code
 }
 
+# === Pre-flight checks ===
+#
+# Detect the most common environment problems that make a long run pointless,
+# before authentication, tenant resolution, or any per-subscription work.
+# Each check is one of:
+#   - Hard fail: print a clear message + remediation, call Exit-Wrapper.
+#   - Warn:      print a clear message and continue (the run will still
+#                produce useful output, just with a known caveat).
+#
+# NOTE: Keep this block in sync with the same block at the top of
+# ResourceInventory.ps1 (just before its Start-Transcript call). They are
+# inlined in both files rather than dot-sourced from a shared file because
+# the dot-source itself is a failure surface (path resolution, missing file)
+# we do not want to add to a script whose entire job is to fail loudly when
+# the environment is wrong.
+function Invoke-PreFlightChecks {
+    param(
+        [Parameter(Mandatory = $true)] [string] $InventoryRoot
+    )
+
+    Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
+
+    # 1. Cloud Shell mount detection.
+    #
+    # Get-CloudDrive ships with the Az.CloudShell module which is preloaded
+    # in Cloud Shell and not present in regular PowerShell installs. So the
+    # cmdlet's existence is our "are we in Cloud Shell" probe; its return
+    # value is our "is the drive mounted" probe.
+    #   - Cmdlet absent       -> not in Cloud Shell, skip the check entirely.
+    #   - Cmdlet present, $null returned -> Cloud Shell, ephemeral mode
+    #                            (verified live: emits "Clouddrive is not
+    #                            mounted" warning on stream 3 and returns null).
+    #   - Cmdlet present, object returned -> Cloud Shell, drive mounted.
+    # The 3>$null suppresses the noisy WARNING so our message is the first
+    # thing the user sees.
+    if (Get-Command Get-CloudDrive -ErrorAction SilentlyContinue) {
+        $CheckCloudDrive = Get-CloudDrive 3>$null 2>$null
+        if ($null -eq $CheckCloudDrive) {
+            Write-Host ""
+            Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
+            Write-Host "  Outputs in $InventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
+            Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
+            Write-Host "    clouddrive mount" -ForegroundColor Yellow
+            Write-Host "  Continuing in ephemeral mode - download the report ZIP from $InventoryRoot before closing the shell." -ForegroundColor Yellow
+            Write-Host ""
+        } else {
+            Write-Host ("Cloud Shell drive mounted: {0}" -f $CheckCloudDrive.Name) -ForegroundColor Green
+        }
+    }
+
+    # 2. Disk space probe at the inventory root.
+    #
+    # Cloud Shell quota is 5 GB total. A 100+ subscription run can produce
+    # 200+ MB of zips and intermediate files; if free space is already low
+    # the run will fail late with a confusing "There is not enough space"
+    # somewhere deep in EPPlus. Catch it now.
+    try {
+        $rootItem = Get-Item -Path $InventoryRoot -ErrorAction Stop
+        $drive = $rootItem.PSDrive
+        if ($null -ne $drive -and $null -ne $drive.Free) {
+            $freeMB = [math]::Round($drive.Free / 1MB, 0)
+            if ($freeMB -lt 100) {
+                Write-Host ("ERROR: Free disk space at {0} is {1} MB. The script needs at least 100 MB to start. Free space and re-run." -f $InventoryRoot, $freeMB) -ForegroundColor Red
+                Exit-Wrapper -Code 1
+            } elseif ($freeMB -lt 500) {
+                Write-Host ("WARNING: Free disk space at {0} is {1} MB. A large multi-subscription run can exceed this. Consider freeing space before running." -f $InventoryRoot, $freeMB) -ForegroundColor Yellow
+            } else {
+                Write-Host ("Free disk space: {0:N0} MB at {1}" -f $freeMB, $InventoryRoot) -ForegroundColor Green
+            }
+        }
+    } catch {
+        # If we cannot read free space (uncommon - usually means the inventory
+        # root is on an exotic filesystem), warn but do not fail. The write
+        # probe below is the real correctness gate.
+        Write-Host ("WARNING: Could not determine free disk space at {0}: {1}" -f $InventoryRoot, $_.Exception.Message) -ForegroundColor Yellow
+    }
+
+    # 3. Write probe.
+    #
+    # Catches any reason the script cannot create files in $InventoryRoot:
+    # readonly mount, permissions, antivirus quarantine, DLP product, etc.
+    # Cheap (~1 ms) and definitive.
+    $probePath = Join-Path $InventoryRoot (".write-probe-{0}.tmp" -f ([guid]::NewGuid()))
+    try {
+        Set-Content -Path $probePath -Value 'preflight write probe' -Encoding utf8 -ErrorAction Stop
+        $probeRead = Get-Content -Path $probePath -Raw -ErrorAction Stop
+        if ($probeRead -notmatch 'preflight write probe') {
+            throw "Write probe content mismatch (read back '$probeRead')"
+        }
+        Remove-Item -Path $probePath -Force -ErrorAction Stop
+        Write-Host ("Write probe: OK ({0})" -f $InventoryRoot) -ForegroundColor Green
+    } catch {
+        Write-Host ("ERROR: Cannot write to {0}: {1}" -f $InventoryRoot, $_.Exception.Message) -ForegroundColor Red
+        Write-Host "  This usually means: readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle." -ForegroundColor Red
+        Write-Host "  Verify the directory is writable and re-run." -ForegroundColor Red
+        # Best-effort cleanup in case Set-Content partially succeeded.
+        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+        Exit-Wrapper -Code 1
+    }
+
+    Write-Host "Pre-flight checks passed." -ForegroundColor Green
+    Write-Host ""
+}
+
+Invoke-PreFlightChecks -InventoryRoot $InventoryRoot
+
 # Resolve a tenant identifier to a tenant GUID.
 #
 # -TenantID may be passed as either a GUID (the canonical form) or as a verified

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -111,14 +111,21 @@ function Save-CompletedSubscriptionIds {
 # In environments like Azure Cloud Shell the shell already has a valid az CLI
 # and Az PowerShell session for the signed-in user. Unconditionally calling
 # `az login` and `Connect-AzAccount` from the wrapper produces a redundant
-# browser/device-code prompt every run. The script also needs each context
-# to be on the requested tenant - if either is on a different tenant the
-# subscription queries below will return the wrong (or no) results.
+# browser/device-code prompt every run.
 #
-# Check both contexts first; only sign in for the side that is missing or on
-# the wrong tenant. The signal we care about is the tenant, not the default
-# subscription, because per-subscription scoping is handled at use-site
-# (Set-AzContext / --subscriptions / resource-id-scoped Get-AzMetric).
+# Two things have to be true to skip the interactive login:
+#   1. The cached context for each side must be on the requested tenant.
+#   2. That cached context must still be able to *acquire a token* silently.
+# Condition 1 alone is not enough: a context can persist on disk (e.g. in
+# ~/.Azure/AzureRmContext.json) with the right tenant ID but an expired or
+# revoked refresh token. In that state Azure AD requires user interaction
+# (typically driven by Conditional Access or MFA), so any data-plane call
+# from inside the script will emit a warning like "Unable to acquire token
+# for tenant ... User interaction is required" and silently return nothing -
+# producing an empty inventory rather than failing loudly.
+#
+# Therefore the gate probes token acquisition for the requested tenant on both
+# sides. Only if both probes succeed do we skip the login.
 
 function Get-AzCliSignedInTenant {
     $raw = az account show --output json 2>$null
@@ -136,21 +143,57 @@ function Get-AzPsSignedInTenant {
     }
 }
 
+# Probe whether az CLI can silently acquire a token for $TenantID.
+# Returns $true on success, $false on any failure.
+function Test-AzCliTokenSilent {
+    param([Parameter(Mandatory=$true)][string]$Tenant)
+    az account get-access-token --tenant $Tenant --output none 2>$null
+    return ($LASTEXITCODE -eq 0)
+}
+
+# Probe whether Az PowerShell can silently acquire a token for $TenantID.
+# Get-AzAccessToken in this configuration emits a non-terminating warning
+# instead of throwing on token-acquisition failure, so we capture warnings
+# explicitly and treat any warning as a failure signal in addition to
+# catching outright exceptions.
+function Test-AzPsTokenSilent {
+    param([Parameter(Mandatory=$true)][string]$Tenant)
+    $warnings = @()
+    try {
+        $token = Get-AzAccessToken -TenantId $Tenant -ErrorAction Stop -WarningVariable warnings -WarningAction SilentlyContinue
+        if ($null -eq $token -or [string]::IsNullOrWhiteSpace($token.Token)) { return $false }
+        if ($warnings.Count -gt 0) { return $false }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 try {
     $cliTenant = Get-AzCliSignedInTenant
     $psTenant  = Get-AzPsSignedInTenant
 
-    $cliOk = ($cliTenant -eq $TenantID)
-    $psOk  = ($psTenant  -eq $TenantID)
+    $cliTenantOk = ($cliTenant -eq $TenantID)
+    $psTenantOk  = ($psTenant  -eq $TenantID)
+
+    $cliTokenOk = $false
+    $psTokenOk  = $false
+    if ($cliTenantOk) { $cliTokenOk = Test-AzCliTokenSilent -Tenant $TenantID }
+    if ($psTenantOk)  { $psTokenOk  = Test-AzPsTokenSilent  -Tenant $TenantID }
+
+    $cliOk = $cliTenantOk -and $cliTokenOk
+    $psOk  = $psTenantOk  -and $psTokenOk
 
     if ($cliOk -and $psOk) {
-        Write-Host ("Existing session detected for tenant {0}; skipping interactive login." -f $TenantID) -ForegroundColor Green
+        Write-Host ("Existing session detected for tenant {0} (token probe ok); skipping interactive login." -f $TenantID) -ForegroundColor Green
     } else {
         if (-not $cliOk) {
             if ($null -eq $cliTenant) {
                 Write-Host "az CLI is not signed in; authenticating..." -ForegroundColor Cyan
-            } else {
+            } elseif (-not $cliTenantOk) {
                 Write-Host ("az CLI is signed in to tenant {0}; switching to {1}..." -f $cliTenant, $TenantID) -ForegroundColor Cyan
+            } else {
+                Write-Host ("az CLI session for tenant {0} cannot acquire a token silently (likely expired or CA/MFA-gated); re-authenticating..." -f $TenantID) -ForegroundColor Cyan
             }
             if ($DeviceLogin) {
                 az login -t $TenantID --use-device-code --only-show-errors | Out-Null
@@ -163,8 +206,10 @@ try {
         if (-not $psOk) {
             if ($null -eq $psTenant) {
                 Write-Host "Az PowerShell is not signed in; authenticating..." -ForegroundColor Cyan
-            } else {
+            } elseif (-not $psTenantOk) {
                 Write-Host ("Az PowerShell is signed in to tenant {0}; switching to {1}..." -f $psTenant, $TenantID) -ForegroundColor Cyan
+            } else {
+                Write-Host ("Az PowerShell session for tenant {0} cannot acquire a token silently (likely expired or CA/MFA-gated); re-authenticating..." -f $TenantID) -ForegroundColor Cyan
             }
             if ($DeviceLogin) {
                 Connect-AzAccount -Tenant $TenantID -UseDeviceAuthentication | Out-Null
@@ -178,8 +223,31 @@ try {
     exit 1
 }
 
-# Get all Azure subscriptions
-$allSubscriptions = Get-AzSubscription
+# Get all Azure subscriptions.
+#
+# Get-AzSubscription emits warnings (rather than throwing) when token
+# acquisition for a tenant fails - typically due to CA/MFA gating. In that
+# state the cmdlet returns no subscriptions, which would otherwise cause
+# this wrapper to report "All subscriptions processed!" with an empty
+# inventory. Capture warnings and treat zero-results-with-warnings as a
+# loud failure instead of a silent one.
+$subWarnings = @()
+$allSubscriptions = Get-AzSubscription -TenantId $TenantID -WarningVariable subWarnings -WarningAction SilentlyContinue
+if ($null -eq $allSubscriptions) { $allSubscriptions = @() }
+$allSubscriptions = @($allSubscriptions)
+
+if ($allSubscriptions.Count -eq 0) {
+    Write-Host ("ERROR: Get-AzSubscription returned no subscriptions for tenant {0}." -f $TenantID) -ForegroundColor Red
+    if ($subWarnings.Count -gt 0) {
+        Write-Host "Underlying warnings:" -ForegroundColor Red
+        foreach ($w in $subWarnings) { Write-Host ("  - {0}" -f $w) -ForegroundColor Red }
+        Write-Host "This typically indicates the cached session cannot acquire a token (Conditional Access / MFA), or the signed-in identity has no access to any subscription in this tenant." -ForegroundColor Yellow
+        Write-Host "Try re-running with -DeviceLogin, or sign out and sign back in to the requested tenant." -ForegroundColor Yellow
+    } else {
+        Write-Host "The signed-in identity may have no subscriptions in this tenant. Verify with 'Get-AzSubscription -TenantId <id>' interactively." -ForegroundColor Yellow
+    }
+    exit 1
+}
 
 # Filter out non-Enabled subscriptions by default. Disabled / Warned / Deleted
 # subscriptions return little-to-no data from Resource Graph and most ARM

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -15,6 +15,56 @@ param (
 $RunStartTime = Get-Date
 $FailedSubscriptions = @()
 
+# Inventory root (used for resume state, consolidated output, and the wrapper
+# transcript). Computed up front so the transcript can be started before
+# anything else writes to the host.
+$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {
+    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+}
+
+# Wrapper-level transcript.
+#
+# ResourceInventory.ps1 already records a per-subscription transcript inside
+# each subscription's output folder. That captures everything inside a single
+# sub's run, but it does not capture the wrapper's own output: tenant
+# resolution, the auth gate's decisions, resume-state messages, the
+# Processing/Completed/ERROR cross-iteration narration, the consolidation
+# step, or the final summary. For multi-subscription runs that bookkeeping is
+# the most useful diagnostic signal of all - which sub failed, why, what came
+# before, and how the wrapper proceeded.
+#
+# This transcript runs at the wrapper level for every invocation (single sub
+# or many) and lands at:
+#   <InventoryRoot>/RunAllSubscriptions_transcript_<timestamp>.txt
+# It also catches everything Write-Host'd by the inner script into the same
+# console session, so the file is a complete record of one wrapper invocation.
+# Start-Transcript is idempotent in the sense that we Stop it on every exit
+# path via Exit-Wrapper.
+$WrapperTranscriptStarted = $false
+$WrapperTranscriptFile = Join-Path $InventoryRoot ("RunAllSubscriptions_transcript_{0}.txt" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
+try {
+    Start-Transcript -Path $WrapperTranscriptFile -UseMinimalHeader -Force | Out-Null
+    $WrapperTranscriptStarted = $true
+    Write-Host ("Wrapper transcript: {0}" -f $WrapperTranscriptFile) -ForegroundColor DarkGray
+} catch {
+    # Non-fatal. If transcript fails to start (rare - usually permissions or
+    # an already-running transcript on this host), the run continues without
+    # one rather than aborting.
+    Write-Host ("WARNING: Could not start wrapper transcript at {0}: {1}" -f $WrapperTranscriptFile, $_.Exception.Message) -ForegroundColor Yellow
+}
+
+# Single exit path that ensures the wrapper transcript is stopped before
+# returning to the host. Used by every error path that previously called
+# `exit <code>` directly.
+function Exit-Wrapper {
+    param([int]$Code = 0)
+    if ($WrapperTranscriptStarted) {
+        try { Stop-Transcript | Out-Null } catch { }
+    }
+    exit $Code
+}
+
 # Resolve a tenant identifier to a tenant GUID.
 #
 # -TenantID may be passed as either a GUID (the canonical form) or as a verified
@@ -61,13 +111,7 @@ try {
     $TenantID = Resolve-TenantId -Value $TenantID
 } catch {
     Write-Host ("ERROR: {0}" -f $_.Exception.Message) -ForegroundColor Red
-    exit 1
-}
-
-# Inventory root (used for resume state and consolidated output)
-$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
-if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {
-    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+    Exit-Wrapper -Code 1
 }
 
 # Resume state helpers
@@ -220,7 +264,7 @@ try {
     }
 } catch {
     Write-Host "ERROR: Authentication failed. $_" -ForegroundColor Red
-    exit 1
+    Exit-Wrapper -Code 1
 }
 
 # Get all Azure subscriptions.
@@ -246,7 +290,7 @@ if ($allSubscriptions.Count -eq 0) {
     } else {
         Write-Host "The signed-in identity may have no subscriptions in this tenant. Verify with 'Get-AzSubscription -TenantId <id>' interactively." -ForegroundColor Yellow
     }
-    exit 1
+    Exit-Wrapper -Code 1
 }
 
 # Filter out non-Enabled subscriptions by default. Disabled / Warned / Deleted
@@ -444,9 +488,21 @@ if ($FailedSubscriptions.Count -gt 0) {
     if ($DiagFile -and (Test-Path $DiagFile)) {
         Write-Host ("Failure Diagnostics:     {0}" -f $DiagFile) -ForegroundColor Red
     }
+    if ($WrapperTranscriptStarted) {
+        Write-Host ("Wrapper Transcript:      {0}" -f $WrapperTranscriptFile) -ForegroundColor Red
+    }
 }
 Write-Host ("Execution Time:          {0}" -f $Elapsed.ToString('hh\:mm\:ss')) -ForegroundColor Green
 if ($OuterZipFile) {
     Write-Host ("Consolidated Report:     {0}" -f $OuterZipFile) -ForegroundColor Green
 }
+if ($WrapperTranscriptStarted) {
+    Write-Host ("Wrapper Transcript:      {0}" -f $WrapperTranscriptFile) -ForegroundColor Green
+}
 Write-Host "=========================================" -ForegroundColor Green
+
+# Stop the wrapper transcript on the normal-completion path. Error paths take
+# Exit-Wrapper which does the same.
+if ($WrapperTranscriptStarted) {
+    try { Stop-Transcript | Out-Null } catch { }
+}

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -15,6 +15,55 @@ param (
 $RunStartTime = Get-Date
 $FailedSubscriptions = @()
 
+# Resolve a tenant identifier to a tenant GUID.
+#
+# -TenantID may be passed as either a GUID (the canonical form) or as a verified
+# domain (e.g. "contoso.onmicrosoft.com" or "contoso.com"). When given a domain,
+# resolve it to the GUID via Microsoft's public OIDC discovery endpoint:
+#
+#   https://login.microsoftonline.com/<domain>/v2.0/.well-known/openid-configuration
+#
+# That endpoint is anonymous (no sign-in required) and returns a JSON document
+# whose "issuer" field embeds the tenant GUID. Resolving up front means every
+# downstream call (az login, Get-AzSubscription, the resume state filename, the
+# auth gate) operates on a stable identifier even if Azure later renames the
+# domain.
+function Resolve-TenantId {
+    param([Parameter(Mandatory=$true)][string]$Value)
+
+    $guidPattern = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    if ($Value -match $guidPattern) { return $Value }
+
+    $url = "https://login.microsoftonline.com/$Value/v2.0/.well-known/openid-configuration"
+    Write-Host ("Resolving tenant '{0}' via OIDC discovery..." -f $Value) -ForegroundColor Cyan
+    try {
+        $config = Invoke-RestMethod -Uri $url -Method Get -ErrorAction Stop
+    } catch {
+        throw "Could not resolve tenant '$Value' to a GUID. Check that it is a valid Azure AD domain or pass the tenant GUID directly. Underlying error: $($_.Exception.Message)"
+    }
+
+    if ($null -eq $config -or [string]::IsNullOrWhiteSpace($config.issuer)) {
+        throw "OIDC discovery for tenant '$Value' returned an unexpected response (no issuer)."
+    }
+
+    # issuer looks like https://login.microsoftonline.com/<guid>/v2.0
+    $segments = $config.issuer -split '/'
+    $resolved = $segments | Where-Object { $_ -match $guidPattern } | Select-Object -First 1
+    if (-not $resolved) {
+        throw "OIDC discovery for tenant '$Value' did not contain a recognizable tenant GUID. issuer='$($config.issuer)'"
+    }
+
+    Write-Host ("Resolved tenant '{0}' -> {1}" -f $Value, $resolved) -ForegroundColor Green
+    return $resolved
+}
+
+try {
+    $TenantID = Resolve-TenantId -Value $TenantID
+} catch {
+    Write-Host ("ERROR: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    exit 1
+}
+
 # Inventory root (used for resume state and consolidated output)
 $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
 if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -7,11 +7,54 @@ param (
     [switch]$DeviceLogin,
     [switch]$Obfuscate,
     [switch]$SkipMetrics,
-    [switch]$SkipConsumption
+    [switch]$SkipConsumption,
+    [switch]$Resume
 )
 
 $RunStartTime = Get-Date
 $FailedSubscriptions = @()
+
+# Inventory root (used for resume state and consolidated output)
+$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {
+    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+}
+
+# Resume state helpers
+$ResumeStateFile = Join-Path $InventoryRoot (".resume-state-{0}.json" -f $TenantID)
+
+function Get-CompletedSubscriptionIds {
+    param([string]$Path, [string]$Tenant)
+
+    if (-not (Test-Path -Path $Path -PathType Leaf)) { return @() }
+    try {
+        $state = Get-Content -Path $Path -Raw | ConvertFrom-Json
+        if ($state.TenantID -ne $Tenant) {
+            Write-Host ("Resume state file is for a different tenant ({0}); ignoring." -f $state.TenantID) -ForegroundColor Yellow
+            return @()
+        }
+        if ($null -eq $state.CompletedSubscriptionIds) { return @() }
+        return @($state.CompletedSubscriptionIds)
+    } catch {
+        Write-Host ("Could not read resume state file ({0}); starting fresh. $_" -f $Path) -ForegroundColor Yellow
+        return @()
+    }
+}
+
+function Save-CompletedSubscriptionIds {
+    param([string]$Path, [string]$Tenant, [string[]]$Ids)
+
+    $state = [pscustomobject]@{
+        TenantID                  = $Tenant
+        CompletedSubscriptionIds  = @($Ids)
+        LastUpdated               = (Get-Date).ToString('o')
+    }
+    try {
+        $state | ConvertTo-Json -Depth 4 | Set-Content -Path $Path -Encoding utf8
+    } catch {
+        Write-Host ("WARNING: Failed to persist resume state to {0}: $_" -f $Path) -ForegroundColor Yellow
+    }
+}
 
 # Authenticate
 try {
@@ -32,6 +75,22 @@ try {
 # Get all Azure subscriptions
 $subscriptions = Get-AzSubscription
 
+# Apply resume filter (only when -Resume is explicitly passed)
+$CompletedIds = @()
+if ($Resume) {
+    $CompletedIds = Get-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID
+    if ($CompletedIds.Count -gt 0) {
+        Write-Host ("Resume mode: {0} previously completed subscription(s) will be skipped." -f $CompletedIds.Count) -ForegroundColor Cyan
+    } else {
+        Write-Host "Resume mode: no previous state found; processing all subscriptions." -ForegroundColor Cyan
+    }
+} else {
+    # Without -Resume, do not auto-skip. Inform the user if stale state exists.
+    if (Test-Path -Path $ResumeStateFile -PathType Leaf) {
+        Write-Host ("Note: resume state file exists at {0}. Pass -Resume to skip previously completed subscriptions." -f $ResumeStateFile) -ForegroundColor Yellow
+    }
+}
+
 # Build passthrough hashtable for optional switches
 $InventoryPassthrough = @{}
 if ($DeviceLogin)      { $InventoryPassthrough['DeviceLogin'] = $true }
@@ -41,13 +100,26 @@ if ($SkipConsumption)  { $InventoryPassthrough['SkipConsumption'] = $true }
 if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = $true }
 
 # Loop through each subscription and run ResourceInventory
+$SkippedCount = 0
 foreach ($sub in $subscriptions) {
+    if ($Resume -and ($CompletedIds -contains $sub.Id)) {
+        Write-Host ("Skipping (already completed): {0} ({1})" -f $sub.Name, $sub.Id) -ForegroundColor DarkGray
+        $SkippedCount++
+        continue
+    }
+
     Write-Host "Processing subscription: $($sub.Name) ($($sub.Id))" -ForegroundColor Cyan
 
     try {
         & (Join-Path $PSScriptRoot "ResourceInventory.ps1") -TenantID $TenantID -SubscriptionID $sub.Id @InventoryPassthrough -RunAllSubs
         if ($LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
         Write-Host "Completed subscription: $($sub.Name)" -ForegroundColor Green
+
+        # Mark complete and persist immediately so a mid-run sign-out is recoverable.
+        if (-not ($CompletedIds -contains $sub.Id)) {
+            $CompletedIds += $sub.Id
+            Save-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID -Ids $CompletedIds
+        }
     } catch {
         Write-Host "ERROR processing subscription $($sub.Name): $_" -ForegroundColor Red
         $FailedSubscriptions += $sub.Name
@@ -59,7 +131,6 @@ foreach ($sub in $subscriptions) {
 Write-Host "All subscriptions processed!" -ForegroundColor Green
 
 # Consolidate per-subscription ZIPs into a single outer ZIP
-$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
 $OuterZipFile = $null
 
 if (Test-Path -Path $InventoryRoot -PathType Container) {
@@ -84,13 +155,30 @@ if (Test-Path -Path $InventoryRoot -PathType Container) {
     Write-Host ("Inventory root not found at {0}. Nothing to consolidate." -f $InventoryRoot) -ForegroundColor Yellow
 }
 
+# Clean up resume state on a fully successful run (all subs processed, no failures).
+# Otherwise leave it so the next invocation with -Resume can pick up where this stopped.
+if ($FailedSubscriptions.Count -eq 0 -and (Test-Path -Path $ResumeStateFile -PathType Leaf)) {
+    try {
+        Remove-Item -Path $ResumeStateFile -Force
+        Write-Host "Resume state cleared (clean run)." -ForegroundColor Green
+    } catch {
+        Write-Host ("WARNING: Could not remove resume state file {0}: $_" -f $ResumeStateFile) -ForegroundColor Yellow
+    }
+}
+
 # Final summary
 $Elapsed = (Get-Date) - $RunStartTime
 Write-Host ""
 Write-Host "================ Summary ================" -ForegroundColor Green
-Write-Host ("Subscriptions Processed: {0}" -f $subscriptions.Count) -ForegroundColor Green
+Write-Host ("Subscriptions Total:     {0}" -f $subscriptions.Count) -ForegroundColor Green
+if ($Resume) {
+    Write-Host ("Subscriptions Skipped:   {0} (already completed)" -f $SkippedCount) -ForegroundColor Green
+}
+Write-Host ("Subscriptions Processed: {0}" -f ($subscriptions.Count - $SkippedCount)) -ForegroundColor Green
 if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
+    Write-Host ("Resume State:            {0}" -f $ResumeStateFile) -ForegroundColor Yellow
+    Write-Host "Re-run with -Resume to retry failed and any unprocessed subscriptions." -ForegroundColor Yellow
 }
 Write-Host ("Execution Time:          {0}" -f $Elapsed.ToString('hh\:mm\:ss')) -ForegroundColor Green
 if ($OuterZipFile) {

--- a/Services/Analytics/Databricks.ps1
+++ b/Services/Analytics/Databricks.ps1
@@ -24,7 +24,10 @@ if($Task -eq 'Processing')
                 'Name'                      = $1.NAME;
                 'Location'                  = $1.LOCATION;
                 'PricingTier'               = $sku.name;
-                'ManagedResourceGroup'      = if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.Count -gt 0) { 'obfuscated' } else { $data.managedResourceGroupId.split('/')[4] };
+                # ManagedResourceGroupId is theoretically always set on a workspace, but
+                # split('/')[4] still fails if the property is missing or malformed.
+                # Guard cheaply rather than crash the whole subscription.
+                'ManagedResourceGroup'      = if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.Count -gt 0) { 'obfuscated' } elseif ([string]::IsNullOrEmpty($data.managedResourceGroupId)) { $null } else { $data.managedResourceGroupId.split('/')[4] };
                 'StorageAccount'            = if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.Count -gt 0) { 'obfuscated' } else { $data.parameters.storageAccountName.value };
                 'StorageAccountSKU'         = $data.parameters.storageAccountSkuName.value;
                 'CreatedTime'               = $timecreated;

--- a/Services/Analytics/MachineLearning.ps1
+++ b/Services/Analytics/MachineLearning.ps1
@@ -14,10 +14,18 @@ If ($Task -eq 'Processing')
             $data = $1.PROPERTIES
             $timecreated = [datetime]($data.creationTime) | Get-Date -Format "yyyy-MM-dd HH:mm"
 
-            $StorageAcc = $data.storageAccount.split('/')[8]
-            $KeyVault = $data.keyVault.split('/')[8]
-            $Insight = $data.applicationInsights.split('/')[8]
-            $containerRegistry = $data.containerRegistry.split('/')[8]
+            # The four cross-resource references (storage / key vault / app insights /
+            # container registry) are *optional* on an Azure ML workspace - a workspace
+            # without one of them returns $null in PROPERTIES rather than the property
+            # being absent. The original line `$data.storageAccount.split('/')[8]` then
+            # fails with "You cannot call a method on a null-valued expression" and
+            # aborts the entire subscription. Guard every reference and emit $null
+            # (or, for obfuscated runs, the literal string 'obfuscated' to match the
+            # rest of this module's lossy fallback pattern) when the field is absent.
+            $StorageAcc        = if ([string]::IsNullOrEmpty($data.storageAccount))      { $null } else { $data.storageAccount.split('/')[8] }
+            $KeyVault          = if ([string]::IsNullOrEmpty($data.keyVault))            { $null } else { $data.keyVault.split('/')[8] }
+            $Insight           = if ([string]::IsNullOrEmpty($data.applicationInsights)) { $null } else { $data.applicationInsights.split('/')[8] }
+            $containerRegistry = if ([string]::IsNullOrEmpty($data.containerRegistry))   { $null } else { $data.containerRegistry.split('/')[8] }
 
             # Obfuscate cross-reference names when dictionary is populated
             if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.Count -gt 0) {


### PR DESCRIPTION
Closes #16. Closes #17. Supersedes #21 (its commit is included here).

This PR bundles fifteen related changes that together harden `Run-AllSubscriptions.ps1` runs against tenants with many subscriptions. They are submitted together because a field operator running this against a tenant with many subscriptions needs all of them to complete a single end-to-end run.

---

## 1. Fix: preserve Az PowerShell context across subscription iterations on Windows

Fixes the re-login prompt on every subscription iteration when running `Run-AllSubscriptions.ps1` on PowerShell Desktop (Windows). Azure CloudShell was unaffected and remains unaffected.

`LoginSession()` in `ResourceInventory.ps1` compared the Az PS context's *default subscription* against the az CLI context's default subscription — these are independent on Windows PowerShell Desktop, so the predicate flipped on every iteration and `Connect-AzAccount` re-ran. The fix compares the Az PS context's **tenant** against `$existingAccount.tenantId` instead. Per-subscription scoping is already handled at use-site (`Set-AzContext -Subscription`, `--subscriptions` on Resource Graph, resource-id-scoped `Get-AzMetric`), so the Az PS context only needs to match the tenant.

The `Connect-AzAccount` call itself stays untouched; only the predicate that decides whether to call it changes. Az CLI auth flow, Service Principal auth flow, tenant-mismatch handling, and per-collector scoping logic are all unchanged.

---

## 2. Feature: `-Resume` switch for `Run-AllSubscriptions.ps1`

Adds the ability to resume a multi-subscription run that was terminated mid-flight, without redoing already-completed subscriptions.

In tenants with many subscriptions (100+), the wrapper can be terminated mid-run by environment-level limits the script itself cannot prevent — most commonly an Azure Cloud Shell session that ends when a Conditional Access policy enforces a maximum session lifetime. After each subscription's inner `ResourceInventory.ps1` returns successfully, its subscription ID is appended to a per-tenant state file at `$InventoryRoot/.resume-state-<TenantID>.json` and flushed to disk. When invoked with `-Resume`, the wrapper reads that file and skips subscriptions whose IDs are already recorded; the subscription that was in flight at the moment of interruption is re-run from the start. Failed subscriptions are intentionally not added so a `-Resume` run also retries them. After a clean run with zero failures the state file is removed. Without `-Resume` the wrapper processes every subscription and leaves any existing state file untouched (with a one-line note that `-Resume` is available).

Summary output is updated to include skipped/processed counts when `-Resume` is active and to point at the state file when failures occurred. README gains a "Resuming an interrupted run" subsection.

---

## 3. Feature: skip non-Enabled subscriptions by default

`Get-AzSubscription` returns every subscription the signed-in identity can see, including ones in `Disabled`, `Warned`, `PastDue`, or `Deleted` state. The wrapper used to iterate all of them, producing near-empty per-subscription reports while still costing wall-clock time — meaningful for Cloud Shell runs under a CA-enforced session cap.

Default behavior now filters to `State = 'Enabled'`. New `-IncludeDisabled` switch processes every subscription regardless of state for cases like pre-deletion audit. Counts of visible / excluded / eligible / processed subscriptions, and a per-state breakdown of what was skipped, are printed at startup and in the final summary. README gains a "Subscription state filter" subsection.

---

## 4. Fix: reuse existing session instead of unconditionally re-authenticating

The wrapper used to call `az login` and `Connect-AzAccount` at the start of every run regardless of whether the user was already signed in — producing a redundant browser/device-code prompt in Cloud Shell and on workstations with valid sessions.

Before authenticating, the wrapper now inspects the current state of both contexts (`az account show` for the CLI tenant, `Get-AzContext` for the Az PS tenant). If both already match the requested `-TenantID`, no interactive login is performed; otherwise only the side that is missing or on a different tenant is re-authenticated. The check uses tenant identity rather than the default subscription, consistent with section 1.

> **Note:** section 4's tenant-only check turned out to be necessary but not sufficient — see section 6 for the follow-up.

---

## 5. Feature: accept tenant domain in addition to GUID for `-TenantID`

`-TenantID` previously required the GUID. Now both forms work:

```powershell
./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012"
./Run-AllSubscriptions.ps1 -TenantID "contoso.onmicrosoft.com"
```

If `-TenantID` looks like a GUID it is used as-is. Otherwise it is treated as a domain and resolved to the tenant GUID via Microsoft's anonymous OIDC discovery endpoint at `https://login.microsoftonline.com/<domain>/v2.0/.well-known/openid-configuration` — no authentication required. Resolving up front means every downstream call operates on a stable identifier even if the tenant later renames the domain.

---

## 6. Fix: probe token acquisition before reusing cached session, and fail loud on empty enumeration

A first round of testing on Windows surfaced a real failure mode that section 4's tenant-only check did not catch:

```
Existing session detected for tenant <id>; skipping interactive login.
WARNING: Unable to acquire token for tenant '<id>' with error 'Authentication
failed against tenant <id>. User interaction is required. ... MFA ...'
Subscriptions visible: 0
All subscriptions processed!
```

A context can persist on disk (e.g. in `~/.Azure/AzureRmContext.json`) with the right tenant ID but an expired or revoked refresh token. Azure AD then requires user interaction (CA/MFA), and `Get-AzSubscription` emits a non-terminating warning rather than throwing — so the wrapper happily reported "All subscriptions processed!" with an empty inventory.

This commit makes the gate **probe silent token acquisition** for the requested tenant on both sides:

- **az CLI:** `az account get-access-token --tenant <id> --output none`, treating any non-zero exit as a probe failure.
- **Az PS:** `Get-AzAccessToken -TenantId <id>` with `WarningVariable`; treats both thrown exceptions and emitted warnings as failure.

Only when the cached tenant matches **and** the silent token probe succeeds is the interactive login skipped. Status messages distinguish the cause of any re-auth so it's visible in the log.

`Get-AzSubscription` is also hardened: scoped explicitly to `-TenantId $TenantID`, with `WarningVariable`. If it returns zero subscriptions and emitted any warning, the wrapper prints the warning text, suggests remediation (`-DeviceLogin` or sign out/in), and exits with a non-zero status instead of producing an empty consolidated report.

---

## 7. Diagnostics: capture full exception detail for failures (was PR #21, now folded in)

Refs #16. The wrapper's `catch` block previously printed `$_` — which is the .NET method-invocation wrapper, not the actual underlying error. It now writes a per-run structured failures log to `<InventoryReports>/RunAllSubscriptions_failures_<timestamp>.log` containing:

- Full exception type, message, **up to 5 levels of `InnerException`**
- `InvocationInfo` (which script, which line, position context)
- `ScriptStackTrace` and `Exception.StackTrace`
- Process WorkingSet / PrivateMemory at failure time (relevant for OOM hypotheses on long Cloud Shell runs)
- Free disk on the inventory drive (relevant for disk-full hypotheses)

The on-screen `ERROR processing subscription <name>: ...` line is unchanged.

`Extension/Summary.ps1` has four `$Excel.Save()` call sites. They are now routed through a `Save-ExcelPackageWithDiagnostics` helper that tags **which save site failed** (one of `reorder-worksheets`, `overview-grid-styling`, `overview-tabs-table`, `final-shape-and-summary-text`), logs the file size and worksheet count at failure time, **calls `$Package.Dispose()` on failure** (the existing code only disposed on success, so a failed save left the file handle open and any subsequent `Open-ExcelPackage` failed with a misleading "file in use" error masking the real cause), and re-throws so the wrapper's `catch` still fires.

This is diagnostics-only — same data lands in the same xlsx on the success path.

#21 will be closed as superseded by this PR.

---

## 8. Fix: eagerly load ImportExcel/EPPlus to prevent OfficeOpenXml type lookup failures

Field testing on Windows PowerShell Desktop in a multi-subscription tenant hit:

```
ERROR processing subscription Azure subscription 1:
Cannot find type [OfficeOpenXml.ExcelPackage]: verify that the
assembly containing this type is loaded.
```

This is **not** an EPPlus Save failure (covered by section 7) — it's an assembly *load* failure that happens before any save runs. The subscription's iteration continues (the wrapper's catch block held), but its xlsx never gets created.

### Root cause

`Extension/Summary.ps1` constructs EPPlus types via:

```powershell
$Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage $File
```

PowerShell's auto-import only triggers on first use of a *cmdlet* exported by a module, not on a direct type reference. `ResourceInventory.ps1` verified ImportExcel was installed via `Get-Module -ListAvailable` but never actually called `Import-Module`, so whatever loaded the type previously was a side effect of some earlier ImportExcel cmdlet usage in the same runspace — fragile across multi-subscription iterations on Windows PowerShell Desktop where module state can be evicted.

### Fix

- **`ResourceInventory.ps1`**: after the existing `-ListAvailable` check, call `Import-Module ImportExcel` explicitly with `-Force`, then confirm `[OfficeOpenXml.ExcelPackage]` is loadable. This guarantees the EPPlus assembly is in the AppDomain before the iteration loop starts.
- **`Extension/Summary.ps1`**: add a defensive guard at the top of the script. Summary.ps1 runs in a child scope via `& $SummaryPath ...`, so even if the parent loaded the module, the type lookup might fail in a worker scope on some PowerShell hosts. The guard tests for the type, imports the module if missing, and re-tests; if the type is still not loadable it throws a clear actionable error rather than letting the bare `New-Object` produce the cryptic "Cannot find type" line.

Both changes are idempotent and effectively free on the success path. Verified locally in a fresh PowerShell 7 runspace: with no ImportExcel imported, the type was unavailable; after running the guard, the type loaded and `New-Object -TypeName OfficeOpenXml.ExcelPackage` succeeded.

This pairs well with section 7: section 7 makes a Save failure self-diagnosing; section 8 prevents the type-load failure that prevented Save from ever being called.

---

## 9. Feature: wrapper-level transcript

`ResourceInventory.ps1` already records a per-subscription transcript inside each subscription's output folder. That captures everything inside a single sub's run, but it does not capture the wrapper's own output — tenant resolution, the auth gate's decisions, resume-state messages, the cross-iteration `Processing/Completed/ERROR` narration, the consolidation step, the final summary. For multi-subscription runs that bookkeeping is the most useful diagnostic signal of all (which sub failed, what came before, how the wrapper proceeded), and right now it lives only in the console buffer.

This commit adds a wrapper-level transcript that runs for every invocation (single subscription or many), writing to:

```
<InventoryRoot>/RunAllSubscriptions_transcript_<timestamp>.txt
```

`$InventoryRoot` is now computed first thing, before tenant resolution, so the transcript can start before anything else writes to the host. A new `Exit-Wrapper` helper stops the transcript and exits; every existing `exit 1` call has been routed through it so the transcript is properly stopped on every error path. The transcript file path is surfaced both in the summary on a clean run (green) and alongside the failure-diagnostics file on a failed run (red), so the user always sees where the record landed.

If `Start-Transcript` itself fails (rare; usually permissions or an already-running transcript on this host), the run continues without one rather than aborting.

This pairs with sections 7 and 8: section 9 captures *what the wrapper did before, during, and after* a failure; section 7 captures *what blew up*; section 8 prevents the most common reason a multi-sub run blows up in the first place. README gains a "Run transcript and failure diagnostics" subsection asking users to attach both files when reporting issues.

---

## 10. Fix: skip reorder on empty workbook + humanise Summary.ps1 save diagnostics

A run on a multi-subscription Windows tenant produced this failure on the first subscription:

```
[Summary.ps1] Save failed at site 'reorder-worksheets' for ...
[Summary.ps1]   FileSizeOnDisk: -1 bytes; WorksheetCount: 0
[Summary.ps1]   Inner[1]: The workbook must contain at least one worksheet
```

The diagnostics from sections 7 and 9 surfaced the root cause; this commit fixes it.

### Empty-workbook crash

`New-Object -TypeName OfficeOpenXml.ExcelPackage <path>` does **not** require the file to exist — if the path is missing, EPPlus returns a fresh in-memory package with zero worksheets. EPPlus then refuses to `.Save()` a workbook with no sheets ("The workbook must contain at least one worksheet"). The reorder block at the top of `Summary.ps1` constructed a package and immediately called Save() without checking whether the inventory phase had produced any per-service tabs, so a subscription with no resources, a Resource Graph permission gap, or a fully filtered obfuscation pipeline crashed the entire Summary build.

Fixed by gating the reorder block on `$Worksheets.Count -gt 0`. When the workbook is empty the script prints a clear yellow explanation and disposes the package; the very next block (`Export-Excel ... -WorksheetName 'Overview'`) legitimately bootstraps the workbook, so the rest of `Summary.ps1` has something to work with.

The same block also had a latent off-by-one when the workbook had only 1 or 2 sheets — the existing `Where-Object` filter against `$Order[0]` and `$Order | Select -Last 1` collapsed to the same item with two sheets and to the entire collection with one. Both edge cases are now handled explicitly.

### Humanised diagnostics

The previous `Save-ExcelPackageWithDiagnostics` output used a `-1` sentinel for "file does not exist on disk" and packed everything onto unstructured lines. The field was being asked to read .NET stack traces to triage. This commit:

- Adds a `Get-SaveFailureDiagnosis` helper that walks the InnerException chain and translates known signals ("must contain at least one worksheet", "being used by another process", `UnauthorizedAccess`, "There is not enough space", and the non-existent-file-with-non-empty-workbook combination) into a single sentence stating the likely cause and what to do about it. Falls through to a generic message when no pattern matches.
- Restructures the printed output: human-readable diagnosis first (yellow), then a "State at failure" block using natural-language placeholders (`<file does not exist on disk yet>` instead of `-1 bytes`), then the raw exception chain underneath. Re-throw and Dispose() behaviour are unchanged.

### Defensive null-safety fixes

Two latent failure modes in `Summary.ps1` flagged in review of the same file:

- `$Subscriptions[0].user.name` (a cosmetic field used in the Overview summary text drawing) now guards for empty `$Subscriptions` and missing `.user`, falling back to `'<unknown user>'` rather than aborting the entire Summary build for a decorative line.
- The Overview tabs loop's `$WorkS.Tables.Name.split('_')` previously threw on any worksheet without a Table or with a non-conforming Table name; it now skips such worksheets and uses `[int]::TryParse` for the size half of the pattern, so a single misshapen sheet no longer blocks the whole Overview build.

### Verification

- Calling `Save-ExcelPackageWithDiagnostics` on an empty workbook produces the new structured output with `Likely cause: The workbook is empty (zero worksheets). EPPlus refuses to save...` followed by the State block (`File on disk: <file does not exist on disk yet>`, `Worksheets: 0`) and then the underlying exception chain (verified).
- Running the full `Summary.ps1` against a non-existent file path no longer raises at reorder-worksheets — the new yellow informational message is printed, `Summary.ps1` completes successfully, and produces a workbook with at least the Overview sheet (verified — 22 KB output file).

This makes the field-reported failure mode no longer reachable: section 8 ensured EPPlus types load; section 10 ensures an empty workbook does not crash the Summary build; sections 7 and 9 ensure that any *new* failure surfaces immediately with a plain-English diagnosis and a complete record on disk.

---

## 11. Feature: surface per-subscription resource counts in the wrapper transcript and summary

Diagnosing a recent multi-subscription run required scrolling through individual per-subscription transcripts to find the buried `Records found: 0` line for each failed sub. That signal should be immediately visible at the wrapper level, not buried in per-sub transcripts that the user has to open one at a time.

### Behavior

During the iteration loop, after each successful inner-script invocation the wrapper reads `$Global:Resources.Count` from the just-finished sub (`ResourceInventory.ps1` is invoked via `& <path>`, so its global lives in the wrapper's scope; it's reset to `@()` on every invocation so the count is per-sub).

- **Count > 0**: prints `Resources collected: <N>` in dark green so each iteration's outcome is visible at a glance.
- **Count == 0**: prints a yellow warning naming the subscription, stating the two most likely causes (no Reader, or a genuinely empty subscription), and giving an exact `az graph query` command to verify.

At the end of the run, the summary block adds:

```
Total Resources:         <N> across <K> subscription(s)

Subscriptions Empty:     <M> (returned 0 resources)
  Likely permission gap (no Reader on the subscription) or genuinely empty subscription.
  Verify Reader access for these specifically:
    - <name1> (<id1>)
    - <name2> (<id2>)
  Acid test: az graph query -q "resources | summarize count()" --subscriptions <id>
```

The user can act on the list directly without hunting through transcripts. Both signals also land in the wrapper transcript file (section 9) so the record survives the session.

---

## 12. Fix: verify Az/ImportExcel module health, stop in-process installs, surface consumption failures

A second field run (a multi-subscription tenant) revealed a different failure mode that PR 20 hadn't yet covered. The inventory phase completed cleanly — 17,290 resources collected — but the consumption sheet shipped empty across every subscription:

```
Checking Azure PowerShell Module...
Azure PowerShell Module not found. Trying to install...
WARNING: Unable to find type [Microsoft.Azure.PowerShell.AuthenticationAssemblyLoadContext.AzAssemblyLoadContextInitializer].
PS>TerminatingError(Import-Module): "Could not load file or assembly 'Microsoft.Identity.Client.Extensions.Msal, Version=4.82.1.0, ...
The system cannot find the file specified."
...
Gathering Consumption for: <subscription-name>
PS>TerminatingError(Get-AzUsageAggregate): "The Azure PowerShell context has not been properly initialized. Please import the module and try again."
Records found: 0...
```

Classic broken-Az-install pattern. The `.psd1` manifest landed but the bundled MSAL assembly didn't. The script's `Get-Module -ListAvailable` check accepted the manifest as proof of installation; later, every `Get-AzUsageAggregate` call failed with "Azure PowerShell context has not been properly initialized" and the consumption sheet shipped empty across all 19 subs.

This commit addresses three combining issues:

### Probe-then-trust for module loads

`Get-Module -ListAvailable` only confirms the manifest exists; it does not validate that the bundled assemblies are present and loadable. Both Az and ImportExcel checks now invoke `Import-Module ... -ErrorAction Stop` after the existing `-ListAvailable` check. A broken install (manifest present, MSAL or Azure.Core missing — the field-observed case) now fails immediately at the top of the run with a clear message and exact remediation:

```
Reinstall with: Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
If the broken install was created by a previous run of this script, also run: Get-Module Az* -ListAvailable | Uninstall-Module -Force
```

### Drop in-process `Install-Module` fallbacks

The script previously tried to `Install-Module Az` and `Install-Module ImportExcel` from inside its own run. Installing the same module a script is about to import is genuinely fragile — concurrent install state, AppDomain caching, half-downloaded packages, multi-user PSGallery throttling — and the failure mode is the silent broken install seen in the field, not a clean error. Both auto-installs are removed; the script now fails loudly with an exact one-line install command for the user to run once before re-running.

README's Prerequisites section gains explicit `Install-Module` commands so this is not surprising. This is a deliberate behaviour change: a fresh local box no longer self-bootstraps both modules, but Cloud Shell users (which is the recommended path for most users) are unaffected because Cloud Shell preinstalls Az.

### Surface consumption failures in the wrapper summary

Wrap the consumption loop's `Get-UsageAggregates` in a try/catch that records per-sub failures into globals (`$Global:ConsumptionFailedSubs`, `$Global:ConsumptionRecordCount`). The wrapper's final summary now prints:

```
Consumption Records:     <N> record(s) collected

Consumption Failures:    <K> subscription(s)
  - <deduped failure messages>
  This message strongly suggests the Az PowerShell module is broken on disk.
  Reinstall with:
    Get-Module Az* -ListAvailable | Uninstall-Module -Force
    Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
  Note: the consumption sheet in the output report may be empty or incomplete for these subscriptions.
```

Failure messages are deduplicated (a broken-Az run produces the same error 19 times; one line is enough). When the message matches the broken-Az signature, the dedicated reinstall hint fires.

This pairs with sections 7 and 11: section 7 captures *what blew up*; section 11 surfaces empty subs from a permissions perspective; section 12 surfaces empty consumption from a runtime-dependency perspective.

The probe pattern matches commit `1b457de` (ImportExcel/EPPlus type-load fix). The "fail loud, don't auto-install" approach matches the broader principle that scripts should not try to bootstrap their own runtime dependencies in-process.

---

## 13. Pre-flight checks: Cloud Shell mount, disk space, write probe

Field runs and a code review uncovered three environment-level problems that the current scripts don't catch until they have already wasted minutes (or in one case nearly an hour):

1. **Azure Cloud Shell with no storage account mounted.** The shell runs, `$HOME` exists, the script writes its outputs — and when the session ends, the report disappears with the session. The existing platform-detection block in `ResourceInventory.ps1` (`Get-CloudDrive` in a try/catch with a truthiness check) treats unmounted Cloud Shell as *not* Cloud Shell, falling through to a "PowerShell Unix" branch that lands outputs in ephemeral `$HOME` anyway. Verified live: `Get-CloudDrive` in unmounted Cloud Shell emits `Clouddrive is not mounted` on **warning stream 3** (not error stream 2) and returns `$null`.
2. **Insufficient disk space at the inventory root.** Cloud Shell's 5 GB user quota is small relative to a 100+ subscription run that produces hundreds of MB of intermediate files and ZIPs. Currently this surfaces as a confusing "There is not enough space" deep inside EPPlus on a sub-by-sub basis.
3. **Read-only or otherwise unwritable inventory root.** Antivirus, DLP products, locked-down corporate fleets, or read-only mounts all surface the same way: a late failure when the first per-sub output goes to write.

This commit adds three pre-flight checks at the top of both `Run-AllSubscriptions.ps1` (right after the wrapper transcript starts, before tenant resolution) and `ResourceInventory.ps1` (right before the inner script's `Start-Transcript`). The blocks are inlined in both files — not dot-sourced from a shared file — because the dot-source itself is a failure surface (path resolution, missing file) we do not want to add to a script whose entire job here is to fail loudly when the environment is wrong. A `# NOTE: keep this block in sync with Run-AllSubscriptions.ps1` comment is on each copy.

Detection logic, verified against live Cloud Shell:

- **Cloud Shell mount:** `Get-Command Get-CloudDrive -ErrorAction SilentlyContinue` tells us whether we're in Cloud Shell at all. When we are, `Get-CloudDrive 3>$null 2>$null` returns `$null` for ephemeral mode and a populated object (with `.Name` and `.FileShareUri`) for mounted. The `3>$null` suppresses the noisy "Clouddrive is not mounted" warning so our user-facing message is the first thing the user sees.
- **Disk space:** Read `PSDrive.Free` at the inventory root. Hard-fail at < 100 MB, warn at 100–500 MB, success otherwise. Exits via `Exit-Wrapper` (wrapper) or `throw` (inner script — the wrapper's existing catch records full diagnostic detail via the failures log).
- **Write probe:** `Set-Content` + `Get-Content` + `Remove-Item` against a tiny `.write-probe-<guid>.tmp` file in the inventory root. Catches read-only mounts, permissions, AV/DLP blocks, stale handles. Hard-fail with the underlying exception message and a list of usual causes.

Behaviour:

| Condition | Result |
|---|---|
| Cloud Shell unmounted | Warn and continue (the run still produces a usable report; the user just needs to download the ZIP before closing the shell). |
| Disk < 100 MB | Hard-fail with remediation. |
| Disk 100–500 MB | Warn and continue. |
| Write probe fails | Hard-fail with the underlying error. |
| `Get-CloudDrive` cmdlet not present | Not Cloud Shell, check is skipped. |

The wrapper's pre-flight runs once at the top of the wrapper run; the inner script's pre-flight runs only when the inner script is invoked directly (no `-RunAllSubs`), and honors the inner script's `-OutputDirectory` parameter so a caller pointing at a non-default path is checked at the right root. When the wrapper invokes the inner script (`-RunAllSubs` set), the inner pre-flight is skipped to avoid re-running the same checks once per subscription. Verified locally on macOS PowerShell 7.6 against a live tenant — the wrapper's pre-flight ran, the inner pre-flight skipped on each per-sub iteration, no disruption to existing behaviour.

---

## 14. Fix: transcript filename now includes report name and timestamp

Long-standing latent bug, not introduced by anything else in this PR — surfaced while tidying up after pre-flight (section 13).

In `ResourceInventory.ps1`, `Start-Transcript` was called at the top of the inner script's main flow with a path computed from `$DefaultPath`, `$Global:ReportName`, and `$CurrentDateTime`. Those three variables are populated inside `Variables()` and `RunInventorySetup()`, which run **inside the `Measure-Command { ... }` block immediately below**. So at top-level execution time all three were `$null`, the path string evaluated to literally `Transcript_Log__.txt` (two underscores, no report name, no timestamp), and the transcript landed in the script's current working directory instead of the per-subscription output folder. Visible symptom: stale `Transcript_Log__.txt` files left in the repo root after every run.

Fix: move the `Start-Transcript` call inside the `Measure-Command` block, after `Variables` and `RunInventorySetup` populate the required globals. Also fully qualify the variable references with `$Global:` so future readers do not need to chase scope rules to verify the references resolve.

Verified locally: a smoke run now leaves no transcript in the working directory and writes the per-subscription transcript at `$InventoryRoot/ResourcesReport<timestamp>/Transcript_Log_ResourcesReport_<timestamp>.txt` with both the report name and the timestamp present in the filename as originally intended.

---

## Testing

- `[Parser]::ParseFile()` clean parse on `Run-AllSubscriptions.ps1`, `ResourceInventory.ps1`, and `Extension/Summary.ps1`.
- Auth context predicate fix (1): logic walkthrough on the four cases (no context / wrong tenant / right tenant different default sub / right tenant same default sub).
- Resume (2): walkthrough on first run, mid-run interruption, resumed run, clean run state cleanup, failure-retained state.
- State filter (3): walkthrough on all-Enabled, mixed, and `-IncludeDisabled` cases.
- Tenant resolver (5): GUID input passes through, `contoso.onmicrosoft.com` resolves correctly, bogus domain produces a clear error (verified on macOS PowerShell 7.6).
- Auth gate with token probe (6): live exercise against a stale cached session — token probe correctly returns false, both sides re-authenticate; valid session correctly takes the skip path; tenant mismatch correctly takes the re-auth path.
- Get-AzSubscription failure path (6): `WarningVariable` correctly captures the "Unable to acquire token" warning; zero-subs-with-warnings path now exits non-zero with a clear remediation message instead of producing an empty report.
- End-to-end smoke (1–6): full inventory of one subscription on macOS — consumption, metrics, all 57 service modules, consolidated outer ZIP, resume state cleared on clean exit.
- Assembly-load fix (8): in a fresh runspace with no ImportExcel imported, `[OfficeOpenXml.ExcelPackage]` is `null`; after the guard runs, the type is loaded and a `New-Object` against it succeeds (verified).
- Diagnostics (7): helper falls through to bare `$Package.Save()` on the success path; on the failure path, structured output goes to a separate file and the on-screen messages are additive.
- Wrapper transcript (9): exercised on macOS PowerShell 7.6 against an early-exit path (invalid tenant). Transcript file was created at `<InventoryRoot>/RunAllSubscriptions_transcript_<timestamp>.txt`, captured the wrapper's intro line, the resolver step, the underlying AAD JSON error response (including trace ID), the script's ERROR line, and was properly closed by `Exit-Wrapper`.
- Pre-flight checks (13): verified live in Cloud Shell that `Get-CloudDrive 3>$null 2>$null` returns `$null` for unmounted (warning emitted on stream 3, not stream 2) and a populated object for mounted; verified the wrapper's pre-flight emits the expected warn-and-continue message in unmounted mode; smoke run on a mounted tenant passes the disk-space and write-probe paths cleanly; the inner script's copy runs once per subscription iteration without disrupting timings.
- Transcript filename fix (14): smoke run on macOS PowerShell 7.6 — no `Transcript_Log__.txt` left in the working directory, transcript correctly lands at `$InventoryRoot/ResourcesReport<timestamp>/Transcript_Log_ResourcesReport_<timestamp>.txt`.

End-to-end verification on the multi-subscription Windows tenant is being done by a field operator running the same code today.








