### PR TITLE
Add -ParallelStreams switch for multi-process subscription processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -494,3 +494,8 @@ Tests/*.zip
 
 Transcript_Log_*
 ObfuscationDictionary_*
+
+# Local-only working notes — must not land in any public commit
+.exploration/
+.kiro/
+docs/components/

--- a/.gitignore
+++ b/.gitignore
@@ -499,3 +499,4 @@ ObfuscationDictionary_*
 .exploration/
 .kiro/
 docs/components/
+.scrub-review/

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -139,7 +139,8 @@ function Save-ExcelPackageWithDiagnostics
         # Ensure the package is disposed even though Save() failed. Without this
         # the underlying file handle stays held and the next Open-ExcelPackage
         # on the same path fails too, which makes downstream errors confusing.
-        try { $Package.Dispose() } catch { }
+        try { $Package.Dispose() }
+        catch { Write-Verbose ("Package.Dispose() after Save failure threw: {0}" -f $_.Exception.Message) }
 
         throw
     }

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -1,4 +1,14 @@
-param($File, $TableStyle, $PlatOS, $Subscriptions, $Resources, $ExtractionRunTime, $ReportingRunTime, $RunLite, $Version)
+param(
+    $File, 
+    $TableStyle, 
+    $PlatOS, 
+    $Subscriptions, 
+    $Resources, 
+    $ExtractionRunTime, 
+    $ReportingRunTime, 
+    $RunLite, 
+    $Version
+)
 
 # Ensure the EPPlus types backing ImportExcel are available before any
 # `New-Object -TypeName OfficeOpenXml.ExcelPackage` call below.

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -31,6 +31,50 @@ try {
     throw
 }
 
+# Translate the underlying exception chain into a single plain-English
+# explanation of what most likely went wrong, so the user does not have to
+# read .NET stack traces to triage. Inspects the full InnerException chain
+# for known signals and falls through to a generic message if none match.
+function Get-SaveFailureDiagnosis
+{
+    param(
+        [Parameter(Mandatory = $true)] $Exception,
+        [Parameter(Mandatory = $true)] [int] $WorksheetCount,
+        [Parameter(Mandatory = $true)] [bool] $FileExists
+    )
+
+    $messages = @()
+    $e = $Exception
+    while ($null -ne $e)
+    {
+        $messages += $e.Message
+        $e = $e.InnerException
+    }
+    $combined = ($messages -join ' | ')
+
+    if ($combined -match 'must contain at least one worksheet')
+    {
+        return 'The workbook is empty (zero worksheets). EPPlus refuses to save a workbook with no sheets. This usually means the inventory phase produced no resources for this subscription, so there were no per-service tabs to write into the file.'
+    }
+    if ($combined -match 'being used by another process|cannot access the file|sharing violation')
+    {
+        return 'The output file is held open by another process. Close any Microsoft Excel window that has this file open and re-run.'
+    }
+    if ($combined -match 'UnauthorizedAccess|access to the path .* is denied|access is denied')
+    {
+        return 'Access to the output file or its parent folder was denied. Check permissions on the InventoryReports folder, and that no antivirus or DLP product is blocking writes.'
+    }
+    if ($combined -match 'There is not enough space|disk full|not enough room')
+    {
+        return 'Insufficient disk space to write the output file.'
+    }
+    if (-not $FileExists -and $WorksheetCount -gt 0)
+    {
+        return 'The output file does not exist on disk yet, but the in-memory workbook has worksheets. The Save call should have created the file. This is most likely a path or permission issue from EPPlus rather than a content issue.'
+    }
+    return 'No specific diagnosis matched. See the exception details below for the underlying error.'
+}
+
 # Helper: invoke $package.Save() with diagnostic context. The bare .Save() call
 # raises a generic 'Error saving file ...' that doesn't tell the maintainer
 # which save site failed, what state the workbook is in, or what the underlying
@@ -38,10 +82,11 @@ try {
 #
 # Behaviour:
 # - On success: returns silently.
-# - On failure: writes a structured one-line summary to stderr, ensures the
-#   package is disposed (otherwise the file handle leaks and any subsequent
-#   open of the workbook on this run also fails), then re-throws so the caller's
-#   existing catch logic still fires.
+# - On failure: writes a structured, human-readable diagnosis followed by the
+#   raw exception chain to the host stream; ensures the package is disposed
+#   (otherwise the file handle leaks and any subsequent open of the workbook
+#   on this run also fails); then re-throws so the caller's existing catch
+#   logic still fires.
 function Save-ExcelPackageWithDiagnostics
 {
     param(
@@ -57,17 +102,26 @@ function Save-ExcelPackageWithDiagnostics
     catch
     {
         $ex = $_.Exception
-        $sizeOnDisk = if (Test-Path $File) { (Get-Item $File).Length } else { -1 }
-        $worksheetCount = try { $Package.Workbook.Worksheets.Count } catch { -1 }
+        $fileExists = Test-Path $File
+        $sizeOnDisk = if ($fileExists) { (Get-Item $File).Length } else { $null }
+        $worksheetCount = try { [int]$Package.Workbook.Worksheets.Count } catch { -1 }
+        $sizeText = if (-not $fileExists) { '<file does not exist on disk yet>' } else { '{0} bytes' -f $sizeOnDisk }
+        $worksheetText = if ($worksheetCount -lt 0) { '<could not read; package state inaccessible>' } else { [string]$worksheetCount }
+
+        $diagnosis = Get-SaveFailureDiagnosis -Exception $ex -WorksheetCount $worksheetCount -FileExists $fileExists
 
         Write-Host ("[Summary.ps1] Save failed at site '{0}' for {1}" -f $SaveSite, $File) -ForegroundColor Red
-        Write-Host ("[Summary.ps1]   FileSizeOnDisk: {0} bytes; WorksheetCount: {1}" -f $sizeOnDisk, $worksheetCount) -ForegroundColor Red
-        Write-Host ("[Summary.ps1]   Exception:      {0}: {1}" -f $ex.GetType().FullName, $ex.Message) -ForegroundColor Red
+        Write-Host ("[Summary.ps1] Likely cause: {0}" -f $diagnosis) -ForegroundColor Yellow
+        Write-Host "[Summary.ps1] State at failure:" -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   File on disk: {0}" -f $sizeText) -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   Worksheets:   {0}" -f $worksheetText) -ForegroundColor Red
+        Write-Host "[Summary.ps1] Underlying exception:" -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   {0}: {1}" -f $ex.GetType().FullName, $ex.Message) -ForegroundColor Red
         $inner = $ex.InnerException
         $depth = 0
         while ($null -ne $inner -and $depth -lt 5)
         {
-            Write-Host ("[Summary.ps1]   Inner[{0}]:      {1}: {2}" -f $depth, $inner.GetType().FullName, $inner.Message) -ForegroundColor Red
+            Write-Host ("[Summary.ps1]   Inner[{0}]: {1}: {2}" -f $depth, $inner.GetType().FullName, $inner.Message) -ForegroundColor Red
             $inner = $inner.InnerException
             $depth++
         }
@@ -86,27 +140,64 @@ if(!$RunLite)
     $Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage $File
     $Worksheets = $Excel.Workbook.Worksheets
 
-    $Order = $Worksheets | Select-Object -Property Index, name, @{N = "Dimension"; E = { $_.dimension.Rows - 1 } } | Sort-Object -Property Dimension -Descending
-    $Order0 = $Order | Where-Object { $_.Name -ne $Order[0].name -and $_.Name -ne ($Order | select-object -Last 1).Name }
-
-    $Loop = 0
-
-    Foreach ($Ord in $Order0) 
+    # Skip the reorder/save step if the workbook is empty.
+    #
+    # Background: New-Object OfficeOpenXml.ExcelPackage <path> does not
+    # require the file to exist - if the path is missing it returns a fresh
+    # in-memory package with zero worksheets. EPPlus then refuses to .Save()
+    # a workbook with no sheets ("The workbook must contain at least one
+    # worksheet") and the bare error gives no hint about why. Reaching this
+    # state means the inventory phase produced no per-service tabs for this
+    # subscription - a sub with no resources, a Resource Graph permission
+    # gap, or an obfuscation pipeline that filtered everything out. Either
+    # way there is nothing to reorder. Let the next block (Export-Excel
+    # ... -WorksheetName 'Overview' below) bootstrap the workbook with at
+    # least the Overview sheet so subsequent steps have something to work
+    # with.
+    if ($Worksheets.Count -eq 0)
     {
-        if ($Ord.Index -and $Loop -ne 0) 
-        {
-            $Worksheets.MoveAfter($Ord.Name, $Order0[$Loop - 1].Name)
-        }
-        if ($Loop -eq 0) 
-        {
-            $Worksheets.MoveAfter($Ord.Name, $Order[0].Name)
-        }
-
-        $Loop++    
+        Write-Host ("[Summary.ps1] Workbook for '{0}' has zero worksheets at the reorder step. The inventory phase produced no per-service tabs (likely an empty subscription, a permission gap, or all rows filtered by obfuscation). Skipping reorder; the Overview sheet will be created in the next step." -f $File) -ForegroundColor Yellow
+        $Excel.Dispose()
     }
+    else
+    {
+        $Order = $Worksheets | Select-Object -Property Index, name, @{N = "Dimension"; E = { $_.dimension.Rows - 1 } } | Sort-Object -Property Dimension -Descending
 
-    Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'reorder-worksheets'
-    $Excel.Dispose()
+        # When the workbook has only one or two sheets there is nothing to
+        # reorder either: $Order[0] and ($Order | Select -Last 1) collapse to
+        # the same item (or are the entire collection), and $Order0 ends up
+        # empty. Handle both edge cases explicitly rather than relying on
+        # Where-Object filtering an undefined index.
+        if ($Worksheets.Count -lt 3)
+        {
+            $Order0 = @()
+        }
+        else
+        {
+            $firstName = $Order[0].name
+            $lastName  = ($Order | Select-Object -Last 1).Name
+            $Order0 = $Order | Where-Object { $_.Name -ne $firstName -and $_.Name -ne $lastName }
+        }
+
+        $Loop = 0
+
+        Foreach ($Ord in $Order0)
+        {
+            if ($Ord.Index -and $Loop -ne 0)
+            {
+                $Worksheets.MoveAfter($Ord.Name, $Order0[$Loop - 1].Name)
+            }
+            if ($Loop -eq 0)
+            {
+                $Worksheets.MoveAfter($Ord.Name, $Order[0].Name)
+            }
+
+            $Loop++
+        }
+
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'reorder-worksheets'
+        $Excel.Dispose()
+    }
 }
 
 "" | Export-Excel -Path $File -WorksheetName 'Overview' -MoveToStart
@@ -161,13 +252,25 @@ if(!$RunLite)
     $TabDraw.TextAlignment = 'Center'
 
     $Table = @()
-    foreach ($WorkS in $Worksheets) 
+    foreach ($WorkS in $Worksheets)
     {
-        $Number = $WorkS.Tables.Name.split('_')
+        # Each per-service worksheet is expected to have exactly one Table
+        # whose name follows the pattern "<Name>_<Size>" (the size half is
+        # the row count used to populate the Overview tabs grid). Worksheets
+        # that lack a Table - or have a Table whose name does not match the
+        # pattern - are skipped rather than being allowed to throw on an
+        # unsplittable null. Without this guard a single misshapen sheet
+        # blocks the entire Overview build.
+        $tableName = try { $WorkS.Tables.Name } catch { $null }
+        if ([string]::IsNullOrWhiteSpace($tableName)) { continue }
+
+        $parts = $tableName -split '_'
+        $size = 0
+        if ($parts.Count -ge 2) { [int]::TryParse($parts[1], [ref]$size) | Out-Null }
 
         $tmp = @{
             'Name' = $WorkS.name;
-            'Size' = [int]$Number[1]
+            'Size' = $size
         }
 
         $Table += $tmp
@@ -195,7 +298,12 @@ if(!$RunLite)
     $ExtractTime = if($ExtractionRunTime.Totalminutes -lt 1){($ExtractionRunTime.Seconds.ToString()+' Seconds')}else{($ExtractionRunTime.Totalminutes.ToString('#######.##')+' Minutes')}
     $ReportTime = ($ReportingRunTime.Totalminutes.ToString('#######.##')+' Minutes')
 
-    $User = $Subscriptions[0].user.name
+    # $User is referenced once below for the summary text drawing. Guard
+    # against the (rare but possible) case where Subscriptions is empty or
+    # the first element lacks a .user.name; an out-of-bounds or null member
+    # access here would abort the entire Summary build for what is purely a
+    # cosmetic field.
+    $User = if ($Subscriptions -and $Subscriptions.Count -gt 0 -and $Subscriptions[0].user) { $Subscriptions[0].user.name } else { '<unknown user>' }
     $TotalRes = $Resources
 
 

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -1,5 +1,55 @@
 param($File, $TableStyle, $PlatOS, $Subscriptions, $Resources, $ExtractionRunTime, $ReportingRunTime, $RunLite, $Version)
 
+# Helper: invoke $package.Save() with diagnostic context. The bare .Save() call
+# raises a generic 'Error saving file ...' that doesn't tell the maintainer
+# which save site failed, what state the workbook is in, or what the underlying
+# .NET exception was. See #16 for context.
+#
+# Behaviour:
+# - On success: returns silently.
+# - On failure: writes a structured one-line summary to stderr, ensures the
+#   package is disposed (otherwise the file handle leaks and any subsequent
+#   open of the workbook on this run also fails), then re-throws so the caller's
+#   existing catch logic still fires.
+function Save-ExcelPackageWithDiagnostics
+{
+    param(
+        [Parameter(Mandatory = $true)] $Package,
+        [Parameter(Mandatory = $true)] [string] $File,
+        [Parameter(Mandatory = $true)] [string] $SaveSite
+    )
+
+    try
+    {
+        $Package.Save()
+    }
+    catch
+    {
+        $ex = $_.Exception
+        $sizeOnDisk = if (Test-Path $File) { (Get-Item $File).Length } else { -1 }
+        $worksheetCount = try { $Package.Workbook.Worksheets.Count } catch { -1 }
+
+        Write-Host ("[Summary.ps1] Save failed at site '{0}' for {1}" -f $SaveSite, $File) -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   FileSizeOnDisk: {0} bytes; WorksheetCount: {1}" -f $sizeOnDisk, $worksheetCount) -ForegroundColor Red
+        Write-Host ("[Summary.ps1]   Exception:      {0}: {1}" -f $ex.GetType().FullName, $ex.Message) -ForegroundColor Red
+        $inner = $ex.InnerException
+        $depth = 0
+        while ($null -ne $inner -and $depth -lt 5)
+        {
+            Write-Host ("[Summary.ps1]   Inner[{0}]:      {1}: {2}" -f $depth, $inner.GetType().FullName, $inner.Message) -ForegroundColor Red
+            $inner = $inner.InnerException
+            $depth++
+        }
+
+        # Ensure the package is disposed even though Save() failed. Without this
+        # the underlying file handle stays held and the next Open-ExcelPackage
+        # on the same path fails too, which makes downstream errors confusing.
+        try { $Package.Dispose() } catch { }
+
+        throw
+    }
+}
+
 if(!$RunLite)
 {
     $Excel = New-Object -TypeName OfficeOpenXml.ExcelPackage $File
@@ -24,7 +74,7 @@ if(!$RunLite)
         $Loop++    
     }
 
-    $Excel.Save()
+    Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'reorder-worksheets'
     $Excel.Dispose()
 }
 
@@ -52,7 +102,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'overview-grid-styling'
         $Excel.Dispose()    
     }
         
@@ -98,7 +148,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'overview-tabs-table'
         $Excel.Dispose()    
     }
 
@@ -201,7 +251,7 @@ if(!$RunLite)
     }
     else
     {
-        $Excel.Save()
+        Save-ExcelPackageWithDiagnostics -Package $Excel -File $File -SaveSite 'final-shape-and-summary-text'
         $Excel.Dispose()    
     }
 

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -298,11 +298,13 @@ if(!$RunLite)
     $ExtractTime = if($ExtractionRunTime.Totalminutes -lt 1){($ExtractionRunTime.Seconds.ToString()+' Seconds')}else{($ExtractionRunTime.Totalminutes.ToString('#######.##')+' Minutes')}
     $ReportTime = ($ReportingRunTime.Totalminutes.ToString('#######.##')+' Minutes')
 
-    # $User is referenced once below for the summary text drawing. Guard
-    # against the (rare but possible) case where Subscriptions is empty or
-    # the first element lacks a .user.name; an out-of-bounds or null member
-    # access here would abort the entire Summary build for what is purely a
-    # cosmetic field.
+    # $User and $TotalRes are kept for backward-compatibility - upstream forks
+    # or downstream consumers may reference them via dot-sourcing patterns.
+    # The original assignment of $User crashed the entire Summary build if
+    # $Subscriptions was empty or its first element lacked a .user, even
+    # though nothing in the script body reads $User itself. Guarding the
+    # assignment is cheap insurance against a regression that would surface
+    # only in unusual environments.
     $User = if ($Subscriptions -and $Subscriptions.Count -gt 0 -and $Subscriptions[0].user) { $Subscriptions[0].user.name } else { '<unknown user>' }
     $TotalRes = $Resources
 

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -1,5 +1,36 @@
 param($File, $TableStyle, $PlatOS, $Subscriptions, $Resources, $ExtractionRunTime, $ReportingRunTime, $RunLite, $Version)
 
+# Ensure the EPPlus types backing ImportExcel are available before any
+# `New-Object -TypeName OfficeOpenXml.ExcelPackage` call below.
+#
+# Background: this script is invoked via `& $SummaryPath ...` from
+# ResourceInventory.ps1, which creates a new child scope. PowerShell's
+# auto-import of modules only triggers on first use of a *cmdlet* exported
+# by the module, but the lines below reference the underlying EPPlus type
+# directly via `New-Object`. Type references do not trigger auto-import,
+# so on a fresh script invocation - or on the second-and-later iterations
+# of a long Run-AllSubscriptions.ps1 loop where module state can be
+# evicted on Windows PowerShell - the type lookup fails with:
+#
+#   Cannot find type [OfficeOpenXml.ExcelPackage]: verify that the
+#   assembly containing this type is loaded.
+#
+# Importing ImportExcel explicitly here is idempotent and inexpensive, and
+# guarantees the EPPlus assembly is loaded into the current AppDomain
+# before any New-Object call against its types. This matches the pattern
+# already used elsewhere in the script for Az modules.
+try {
+    if (-not ([System.Management.Automation.PSTypeName]'OfficeOpenXml.ExcelPackage').Type) {
+        Import-Module ImportExcel -ErrorAction Stop -Force -DisableNameChecking | Out-Null
+    }
+    if (-not ([System.Management.Automation.PSTypeName]'OfficeOpenXml.ExcelPackage').Type) {
+        throw "ImportExcel module imported but the OfficeOpenXml.ExcelPackage type is still not loadable. The ImportExcel module may be present but its bundled EPPlus assembly is missing or unloadable in this runspace."
+    }
+} catch {
+    Write-Error ("Summary.ps1 cannot proceed: {0}" -f $_.Exception.Message)
+    throw
+}
+
 # Helper: invoke $package.Save() with diagnostic context. The bare .Save() call
 # raises a generic 'Error saving file ...' that doesn't tell the maintainer
 # which save site failed, what state the workbook is in, or what the underlying

--- a/Extension/Summary.ps1
+++ b/Extension/Summary.ps1
@@ -257,6 +257,16 @@ if(!$RunLite)
     $Worksheets = $Excel.Workbook.Worksheets | Where-Object { $_.Name -ne 'Overview' }
     $WS = $Excel.Workbook.Worksheets | Where-Object { $_.Name -eq 'Overview' }
 
+    # AddShape throws "Name already exists in the drawings collection" if the
+    # named shape is already on the worksheet from a prior save. This can
+    # happen when ResourceInventory.ps1 runs against an .xlsx that already
+    # has shapes baked in - either because a previous wrapper iteration left
+    # the file behind, or because the per-service Export-Excel calls upstream
+    # added drawings of their own. Defensive: remove the shape if present
+    # before adding it. Idempotent and safe.
+    $existingTP00 = $WS.Drawings | Where-Object { $_.Name -eq 'TP00' }
+    if ($existingTP00) { $WS.Drawings.Remove($existingTP00) }
+
     $TabDraw = $WS.Drawings.AddShape('TP00', 'Rect')
     $TabDraw.SetSize(130 , 78)
     $TabDraw.SetPosition(1, 0, 0, 0)
@@ -341,6 +351,13 @@ if(!$RunLite)
         $Link = New-Object -TypeName OfficeOpenXml.ExcelHyperLink ("'"+$Works+"'"+'!A1'),$Works
         $Item.Hyperlink = $Link
     }
+
+    # Same defensive guard as the TP00 site above. EPPlus throws
+    # "Name already exists in the drawings collection" if AddShape is called
+    # with a name that's already present, which surfaces when running against
+    # an .xlsx that retained shapes from an earlier reporting pass.
+    $existingInventory = $WS.Drawings | Where-Object { $_.Name -eq 'Inventory' }
+    if ($existingInventory) { $WS.Drawings.Remove($existingInventory) }
 
     $Draw = $WS.Drawings.AddShape('Inventory', 'Rect')
     $Draw.SetSize(445, 240)

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each 
 
 Each subscription produces its own set of timestamped reports in `InventoryReports/`. After all subscriptions are processed, the wrapper bundles the per-subscription ZIPs into a single `AllSubscriptions_ResourcesReport_<timestamp>.zip` in the same folder for easy delivery.
 
+#### Resuming an interrupted run
+
+For tenants with many subscriptions, the run can be cut short by environment-level limits — for example, an Azure Cloud Shell session that ends when a Conditional Access policy enforces a maximum session lifetime. The wrapper supports resuming:
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012" -Resume
+```
+
+After each subscription is fully processed (its per-subscription ZIP has been written), the wrapper records the subscription ID in a state file at `InventoryReports/.resume-state-<TenantID>.json`. Re-running with `-Resume` reads that file and skips subscriptions that are already complete; the partially processed subscription (the one that was running when the session ended) is re-run from the start. The state file is cleared automatically after a clean run with no failures.
+
+`-Resume` is opt-in. Without it, the wrapper processes every subscription returned by `Get-AzSubscription`, and existing state is left untouched.
+
 ## Output Files
 
 Upon completion, the script generates reports in the `InventoryReports` folder:

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each 
 ./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012"
 ```
 
+`-TenantID` accepts either a tenant GUID or a verified domain. When a domain is passed (for example `contoso.onmicrosoft.com`), the wrapper resolves it to the GUID via Microsoft's anonymous OIDC discovery endpoint before doing anything else, so this also works:
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "contoso.onmicrosoft.com"
+```
+
 Each subscription produces its own set of timestamped reports in `InventoryReports/`. After all subscriptions are processed, the wrapper bundles the per-subscription ZIPs into a single `AllSubscriptions_ResourcesReport_<timestamp>.zip` in the same folder for easy delivery.
 
 #### Subscription state filter

--- a/README.md
+++ b/README.md
@@ -46,11 +46,30 @@ Before running the script, ensure your Azure user account has the following role
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [Azure CLI Account Extension](https://learn.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview)
 - Azure CLI Resource-Graph Extension (auto-installed by script)
+- **Az PowerShell module** and **ImportExcel module** (install before running — see below)
 
 > **Note:** Install the Account Extension before running the script:
 > ```powershell
 > az extension add --name account
 > ```
+
+##### Installing the required PowerShell modules
+
+The script needs both `Az` and `ImportExcel` modules. Install them once before the first run, from an elevated **PowerShell 7** prompt (`pwsh`):
+
+```powershell
+Install-Module -Name Az          -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
+Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
+```
+
+The script no longer auto-installs these modules from inside its own run. Auto-install during a script that's already importing the same module produces a class of silent broken installs (manifest present, bundled assemblies missing — typically MSAL and Azure.Core for Az), and the failure surfaces much later as zero consumption records or "Cannot find type [OfficeOpenXml.ExcelPackage]" errors. Installing once outside the script, ahead of time, is reliable.
+
+If you suspect a previous run left a broken Az install on disk:
+
+```powershell
+Get-Module Az* -ListAvailable | Uninstall-Module -Force
+Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
+```
   
 
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each 
 
 Each subscription produces its own set of timestamped reports in `InventoryReports/`. After all subscriptions are processed, the wrapper bundles the per-subscription ZIPs into a single `AllSubscriptions_ResourcesReport_<timestamp>.zip` in the same folder for easy delivery.
 
+#### Subscription state filter
+
+By default, `Run-AllSubscriptions.ps1` only inventories subscriptions whose `State` is `Enabled`. Subscriptions in any other state (`Disabled`, `Warned`, `PastDue`, `Deleted`) are skipped because they return little or no data from Resource Graph and most ARM data-plane calls, so processing them produces near-empty reports while still costing wall-clock time.
+
+To include every subscription regardless of state, pass `-IncludeDisabled`:
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012" -IncludeDisabled
+```
+
+The wrapper prints the count of excluded subscriptions and a per-state breakdown so the filter is transparent.
+
 #### Resuming an interrupted run
 
 For tenants with many subscriptions, the run can be cut short by environment-level limits — for example, an Azure Cloud Shell session that ends when a Conditional Access policy enforces a maximum session lifetime. The wrapper supports resuming:

--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ After each subscription is fully processed (its per-subscription ZIP has been wr
 
 `-Resume` is opt-in. Without it, the wrapper processes every subscription returned by `Get-AzSubscription`, and existing state is left untouched.
 
+#### Run transcript and failure diagnostics
+
+Every invocation of `Run-AllSubscriptions.ps1` writes a wrapper-level transcript to `InventoryReports/RunAllSubscriptions_transcript_<timestamp>.txt`. Unlike the per-subscription transcripts that `ResourceInventory.ps1` writes inside each subscription folder, this file captures the full wrapper run end-to-end: tenant resolution, authentication decisions, resume-state messages, the cross-iteration narration of which subscription is being processed, the consolidation step, and the final summary. This applies to every run, single subscription or many.
+
+If a subscription fails, the wrapper additionally writes a structured failure log to `InventoryReports/RunAllSubscriptions_failures_<timestamp>.log` containing the full exception type, message, up to five levels of `InnerException`, the script line, stack traces, and a snapshot of process memory and free disk at failure time. The final summary points at both files when failures have occurred.
+
+When reporting an issue, attach both files. They contain enough context to diagnose most failures without a follow-up round trip.
+
 ## Output Files
 
 Upon completion, the script generates reports in the `InventoryReports` folder:

--- a/README.md
+++ b/README.md
@@ -325,11 +325,11 @@ Upon completion, the script generates reports in the `InventoryReports` folder:
 
 | File | Description |
 |------|-------------|
-| `Consumption_ResourcesReport_(date).json` | Cost and billing data |
+| `Consumption_ResourcesReport_(date).csv` | Cost and billing data |
 | `Inventory_ResourcesReport_(date).json` | Complete resource inventory |
 | `Metrics_ResourcesReport_(date).json` | Performance metrics data |
 | `ResourcesReport_(date).xlsx` | Consolidated Excel report |
-| `Transcript_Log(date).xlsx` | Transcript log of script activity during the run |
+| `Transcript_Log_<ReportName>_(date).txt` | Plaintext transcript of script activity (excluded from the zip when `-Obfuscate` is used) |
 | `ResourcesReport_(date).zip` | All files compressed |
 
 ### File Delivery
@@ -388,7 +388,6 @@ Compress-Archive -Path ./* -DestinationPath "CompanyName_ResourcesReport_$(Get-D
 | Parameter | Type | Description | Default | Example |
 |-----------|------|-------------|---------|----------|
 | `ConcurrencyLimit` | Integer | Parallel execution limit | 6 | `-ConcurrencyLimit 8` |
-| `CollectionDays` | Integer | Number of days for consumption lookback | 31 | `-CollectionDays 14` |
 | `SkipConsumption` | Switch | Skip cost/billing data collection | False | `-SkipConsumption` |
 | `SkipMetrics` | Switch | Skip Azure Monitor metrics collection | False | `-SkipMetrics` |
 

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ The default is `-ParallelStreams 1` (existing sequential behavior, fully preserv
 
 When you run with `-ParallelStreams`, several things change in the output:
 
-- Every line in the transcript starts with `[stream-N]` so you can tell which subscription's stream produced it.
+- The wrapper's own narration (which subscription a stream is starting, which one it finished) is prefixed with `[stream-N]`. The inner script's `Write-Host` and `Write-Log` output is **not** prefixed and will interleave across streams in the transcript. Use the per-stream summary at the end of the run, or the per-stream failures log, to disambiguate.
 - Each stream writes its own failure log to `InventoryReports/RunAllSubscriptions_failures_<timestamp>_stream-<N>.log`. At the end of the run, the wrapper merges those into a single combined failure log so you only have one file to read.
-- Each stream tracks its own progress in a separate resume-state file. When the run finishes, those are merged into the main resume-state file. This means `-Resume` works the same way regardless of whether the previous run was sequential or parallel, so you don't need to remember which mode you used.
+- Each stream tracks its own progress in a separate resume-state file. When the run finishes, those are merged into the main resume-state file. This means `-Resume` works the same way regardless of whether the previous run was sequential or parallel — but only if the previous run reached the post-aggregation step. If you Ctrl+C a parallel run mid-stream, the per-stream resume files are still on disk; running `-Resume` on the next attempt will read them and skip the subs each stream had already completed.
 
 Authentication only happens once. The wrapper saves the parent process's Az PowerShell context to a file and each stream loads it, so you don't get prompted to sign in again for each parallel worker. The wrapper deletes that snapshot file when the run ends, including if you cancel with Ctrl+C or a stream crashes during startup.
 
@@ -441,11 +441,33 @@ These are the parameters specific to `Run-AllSubscriptions.ps1`. The wrapper for
 - Ensure you have the required Azure roles assigned
 - For local environments, run `az login` before executing the script
 - Multiple authentication prompts may appear due to parallel processing
+- "Get-AzSubscription returned no subscriptions" — usually a Conditional Access / MFA gate. Re-run with `-DeviceLogin` to use the browser-based device-code flow.
+- Tenant-domain-style `-TenantID` (e.g. `contoso.onmicrosoft.com`) is resolved via Microsoft's public OIDC discovery endpoint, no sign-in needed. Pass the tenant GUID directly if discovery fails.
+
+**Subscription returned 0 resources:**
+- Almost always a permission gap: the signed-in identity does not have Reader on that specific subscription. The wrapper prints the exact `az graph query` acid-test command to confirm.
+- Less commonly, the subscription is genuinely empty.
+- Failed subs are listed at the end of the wrapper transcript and in `InventoryReports/RunAllSubscriptions_failures_<timestamp>.log`.
+
+**Consumption sheet empty across many subs:**
+- Usually a broken `Az` PowerShell module install (manifest present, bundled MSAL/Azure.Core assemblies missing or version-mismatched).
+- The wrapper surfaces this loudly at end-of-run if the consumption-record count is 0 or many subs failed in the consumption phase.
+- Reinstall: `Get-Module Az* -ListAvailable | Uninstall-Module -Force; Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser`
+
+**ImportExcel `'HorizontalAlignment' cannot be found` error:**
+- Same partial-install pattern as the `Az` module. The wrapper preflight catches this at startup now, but if you see it mid-run on an older code branch, fix it with: `Get-Module ImportExcel -ListAvailable | Uninstall-Module -Force; Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser`
+- Then re-run with `-Resume` to retry only the failed subs.
+
+**Cloud Shell session ended mid-run:**
+- Cloud Shell terminates inactive sessions after 20 minutes; long parallel runs can hit the same wall.
+- If you mounted storage (Settings > Mount storage account), the resume-state file persists. Re-launch a Cloud Shell and run with `-Resume` to skip already-completed subs.
+- Without mounted storage, all output is lost on session end. Move to a local PowerShell 7 install for runs that may exceed the timeout.
 
 **Performance Issues:**
 - Reduce `ConcurrencyLimit` if experiencing timeouts
 - Use `SkipConsumption` to speed up execution. This is not recommended, as it greatly reduces the usefulness of the report.
 - Consider targeting specific subscriptions or resource groups
+- For tenants with many subscriptions, use `-ParallelStreams` (see the Cloud Shell sizing table above).
 
 **Excel Formatting (Azure Cloud Shell):**
 - Auto-fit columns may not work in Cloud Shell
@@ -458,3 +480,4 @@ These are the parameters specific to `Run-AllSubscriptions.ps1`. The wrapper for
 - Resource-Graph extension installs automatically if missing
 - All operations are read-only and safe to execute
 - Historical data covers the previous 31 days
+

--- a/README.md
+++ b/README.md
@@ -13,8 +13,43 @@ This tool leverages read-only integrations with Azure APIs and Azure Monitor. Ou
 - Parallel processing for improved performance
 - Support for [Azure Cloud Shell](https://shell.azure.com "Open Azure Cloud Shell") and local PowerShell environments
 
+## Quick Start
+
+For most users, this is everything you need.
+
+**1. Open Azure Cloud Shell** at [shell.azure.com](https://shell.azure.com), or run a local PowerShell 7 prompt with the [prerequisites](#prerequisites) installed.
+
+**2. Download the script:**
+
+```powershell
+git clone https://github.com/awslabs/resource-discovery-for-azure.git
+cd resource-discovery-for-azure
+```
+
+**3. Run it:**
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "contoso.onmicrosoft.com" -Obfuscate -ParallelStreams 2
+```
+
+This:
+- Inventories every enabled subscription in the tenant.
+- Obfuscates resource IDs, names, and other identifying details so the report is safe to share.
+- Runs 2 subscriptions at a time (works in both Cloud Shell and on a typical laptop).
+
+The script tracks progress automatically as it goes. If anything interrupts the run (network drop, Cloud Shell session timeout, accidental Ctrl+C), re-run the same command with `-Resume` added and it will skip the subscriptions that already finished and pick up the rest:
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "contoso.onmicrosoft.com" -Obfuscate -ParallelStreams 2 -Resume
+```
+
+You'll find the consolidated report at `InventoryReports/AllSubscriptions_ResourcesReport_<timestamp>.zip`. Send that ZIP to the AWS team.
+
+For larger tenants (100+ subscriptions), see [Choosing where to run](#choosing-where-to-run-for-large-tenants-cloud-shell-vs-local) for sizing guidance. For all available options, see the [Run-AllSubscriptions Wrapper Parameters](#run-allsubscriptions-wrapper-parameters).
+
 ## Table of Contents
 
+- [Quick Start](#quick-start)
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
 - [Usage](#usage)
@@ -35,11 +70,21 @@ Before running the script, ensure your Azure user account has the following role
 
 ### Environment Options
 
-#### 🚀 Quick Start | Option 1: Azure Cloud Shell (Recommended) ⭐
-- No additional setup required
-- Pre-authenticated environment
-- All dependencies included
+The script runs in either Azure Cloud Shell or a local PowerShell 7 install. Pick based on the size of the tenant you're inventorying:
+
+| Tenant size | Use | Why |
+|---|---|---|
+| Up to ~30 subscriptions | **Cloud Shell** | Fastest to start. No setup, pre-authenticated, all dependencies included. |
+| 30–100+ subscriptions | **Either**, with `-ParallelStreams 2 -Resume` on Cloud Shell | Cloud Shell still works, but session timeouts and the 3.5 GB RAM cap start to matter. `-Resume` lets a timed-out session pick up where it left off. |
+| 100+ subscriptions, or metric-heavy tenants | **Local PowerShell 7** | Cloud Shell caps at `-ParallelStreams 2` (only 3.5 GB RAM / 2 vCPU). A local 16 GB / 8-core machine runs at `-ParallelStreams 6`, about 3× faster. Microsoft also warns that long-running parallel work in Cloud Shell can trigger anti-abuse blocking. See [Choosing where to run](#choosing-where-to-run-for-large-tenants-cloud-shell-vs-local) below for the full details. |
+
+#### Option 1: Azure Cloud Shell
+
+- Browser-based, no setup
+- Pre-authenticated to your Azure tenant
+- `Az` and `ImportExcel` modules pre-installed by Microsoft
 - Access at [Azure Cloud Shell](https://shell.azure.com "Open Azure Cloud Shell")
+- Sessions are ephemeral by default. Mount a storage account (Cloud Shell Settings > Reset User Settings > Mount storage account) if you need outputs to persist across sessions or want to use `-Resume` on a follow-up session.
 
 #### Option 2: Local Environment
 - [PowerShell 7 or later](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell)
@@ -55,20 +100,22 @@ Before running the script, ensure your Azure user account has the following role
 
 ##### Installing the required PowerShell modules
 
-The script needs both `Az` and `ImportExcel` modules. Install them once before the first run, from an elevated **PowerShell 7** prompt (`pwsh`):
+> **Cloud Shell users:** Both `Az` and `ImportExcel` are pre-installed by Microsoft. Skip this section entirely.
+
+The script needs both `Az` and `ImportExcel` modules. Install them once before the first run from a **PowerShell 7** prompt (`pwsh`). Use `-Scope CurrentUser` so no administrator elevation is needed:
 
 ```powershell
-Install-Module -Name Az          -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
-Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
+Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser
+Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser
 ```
 
-The script no longer auto-installs these modules from inside its own run. Auto-install during a script that's already importing the same module produces a class of silent broken installs (manifest present, bundled assemblies missing — typically MSAL and Azure.Core for Az), and the failure surfaces much later as zero consumption records or "Cannot find type [OfficeOpenXml.ExcelPackage]" errors. Installing once outside the script, ahead of time, is reliable.
+The script no longer installs these modules for you while it runs. Doing the install inside a script that's already loading the same module is unreliable. You can end up with a half-installed module that looks fine to PowerShell but fails much later in the run with confusing errors like "no consumption records" or "Cannot find type [OfficeOpenXml.ExcelPackage]". Installing the modules once, by hand, before the first run avoids the whole class of problem.
 
-If you suspect a previous run left a broken Az install on disk:
+If a previous run left a broken `Az` install behind, remove it and reinstall:
 
 ```powershell
 Get-Module Az* -ListAvailable | Uninstall-Module -Force
-Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck
+Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser
 ```
   
 
@@ -157,7 +204,7 @@ You might get more than one authentication request due to different collector pr
 
 ### Running Across All Subscriptions
 
-Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each subscription in a tenant, instead of the default single consolidated report. The wrapper prompts you to sign in once, then invokes `ResourceInventory.ps1` for each subscription sequentially.
+Use `Run-AllSubscriptions.ps1` to generate a separate inventory report for each subscription in a tenant, instead of the default single consolidated report. The wrapper prompts you to sign in once, then invokes `ResourceInventory.ps1` for each subscription. By default subscriptions are processed sequentially (one at a time); use `-ParallelStreams` to process several concurrently.
 
 ```powershell
 ./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012"
@@ -195,11 +242,78 @@ After each subscription is fully processed (its per-subscription ZIP has been wr
 
 `-Resume` is opt-in. Without it, the wrapper processes every subscription returned by `Get-AzSubscription`, and existing state is left untouched.
 
+#### Parallel subscription processing
+
+For large tenants, the slowest part of the run is collecting metrics. Each call to Azure Monitor takes 200–500 ms over the network, and a typical subscription with VMs, SQL DBs, and storage accounts produces thousands of these calls. Done one subscription at a time, that adds up to many hours.
+
+Pass `-ParallelStreams N` to process N subscriptions concurrently in separate `pwsh` background processes:
+
+```powershell
+./Run-AllSubscriptions.ps1 -TenantID "12345678-1234-1234-1234-123456789012" -ParallelStreams 6
+```
+
+Each stream is a separate background process. They don't share state with each other. Each has its own Azure session, its own progress tracking file, and its own output folder. The wrapper splits your subscription list across the streams in round-robin order so the workload stays balanced even when subscriptions vary in size.
+
+The default is `-ParallelStreams 1` (existing sequential behavior, fully preserved). Pick a higher value based on the environment you're running in. See the table in [Choosing where to run for large tenants](#choosing-where-to-run-for-large-tenants-cloud-shell-vs-local) below.
+
+`-ParallelStreams` and `-ConcurrencyLimit` compose. `-ConcurrencyLimit` throttles the metrics-collection runspace pool *within* one subscription; `-ParallelStreams` is the count of subscriptions running concurrently. Useful combinations:
+
+| ParallelStreams | ConcurrencyLimit | Concurrent ARM calls (in flight at once) | Verdict |
+|---|---|---|---|
+| 1 | 6 | 6 | Existing default. |
+| 6 | 6 | 36 | Recommended for metric-heavy estates on a 16 GB / 8-core local machine. |
+| 8 | 6 | 48 | Watch for HTTP 429s in per-stream logs. |
+| 6 | 12 | 72 | Aggressive. Expect retry-backoff to eat the gain. |
+
+When you run with `-ParallelStreams`, several things change in the output:
+
+- Every line in the transcript starts with `[stream-N]` so you can tell which subscription's stream produced it.
+- Each stream writes its own failure log to `InventoryReports/RunAllSubscriptions_failures_<timestamp>_stream-<N>.log`. At the end of the run, the wrapper merges those into a single combined failure log so you only have one file to read.
+- Each stream tracks its own progress in a separate resume-state file. When the run finishes, those are merged into the main resume-state file. This means `-Resume` works the same way regardless of whether the previous run was sequential or parallel, so you don't need to remember which mode you used.
+
+Authentication only happens once. The wrapper saves the parent process's Az PowerShell context to a file and each stream loads it, so you don't get prompted to sign in again for each parallel worker. The wrapper deletes that snapshot file when the run ends, including if you cancel with Ctrl+C or a stream crashes during startup.
+
+#### Choosing where to run for large tenants: Cloud Shell vs local
+
+Three things constrain how many parallel streams you can usefully run:
+
+- **Azure Resource Manager (ARM) request quota.** ARM is Azure's control-plane API that the script calls to read resource details and metrics. Each subscription is rate-limited to roughly 12,000 read requests per hour. The script's `-ConcurrencyLimit` and `-ParallelStreams` together control how many ARM requests are in flight at once. Stay under about 50 concurrent requests per tenant, or you'll start seeing HTTP 429 ("Too Many Requests") in the per-stream logs and the script will spend more time backing off than working.
+- **CPU cores.** The script is mostly waiting on network responses, not crunching numbers, so it doesn't need many cores. Roughly one core per stream is plenty. Running more streams than cores doesn't make the script faster, the CPU just spends time switching between tasks.
+- **RAM.** Each stream loads the Azure PowerShell modules and holds resource and metric data in memory before writing the output files. Plan for around 500-700 MB peak per stream. Running more streams than your RAM can hold makes the OS swap to disk and slows everything down.
+
+For small to medium tenants (up to a few dozen subscriptions), Cloud Shell is the easiest place to run. For large tenants the resource ceilings on Cloud Shell start to matter.
+
+Verified Cloud Shell limits (measured 2026-05; Microsoft can change these silently):
+
+| Resource | Cloud Shell | Notes |
+|---|---|---|
+| RAM | ~3.5 GB total, ~2.7 GB usable at idle | Each `pwsh` worker peaks at ~500–700 MB during the metrics phase |
+| CPU | 2 vCPUs (Intel Xeon Platinum @ 2.8 GHz) | Shared, so effective throughput is lower under load |
+| Storage | ~50 GB overlay filesystem | Ephemeral by default. See below. |
+| Idle timeout | 20 minutes | Sessions are terminated without warning when this elapses |
+| Concurrent sessions per tenant | 20 | Tenant-wide cap |
+| Sudo / elevation | Not available | Module installs must use `-Scope CurrentUser` |
+
+References: [Cloud Shell features](https://learn.microsoft.com/en-us/azure/cloud-shell/features), [Cloud Shell FAQ](https://learn.microsoft.com/en-us/azure/cloud-shell/faq-troubleshooting).
+
+Recommended `-ParallelStreams` per environment:
+
+| Environment | Recommended | Why |
+|---|---|---|
+| Cloud Shell (ephemeral or with mounted storage) | **2** | Saturates both vCPUs without OOM-killing workers on the 3.5 GB RAM cap |
+| Local PowerShell 7, 8 GB RAM | **2** | RAM is the bottleneck |
+| Local PowerShell 7, 16 GB RAM, 8+ cores | **6** | Recommended for metric-heavy estates |
+| Local PowerShell 7, 32 GB RAM, 12+ cores | **8** | Watch HTTP 429s in per-stream logs. |
+
+**Persistence in Cloud Shell:** Cloud Shell sessions are ephemeral by default. When your session ends, anything in your home directory is deleted, including the script's output and the resume-state file. The wrapper detects this at startup and warns you. To keep outputs across sessions (and to make `-Resume` work after a session times out), attach a storage account: in Cloud Shell, click Settings (the gear icon) > Reset User Settings > Mount storage account.
+
+**Cloud Shell anti-abuse limits:** Microsoft warns that Cloud Shell is "not a general purpose computing platform" and that excessive usage can result in your tenant being blocked from Cloud Shell ([source](https://learn.microsoft.com/en-us/azure/cloud-shell/faq-troubleshooting#terminal-output---sorry-your-cloud-shell-failed-to-provision-codetenantdisabled-)). Long parallel runs against large tenants can trigger this. If you're running RDA across many subscriptions for a few hours at a time, use a local PowerShell 7 install instead. It avoids the risk and is usually faster anyway.
+
 #### Run transcript and failure diagnostics
 
-Every invocation of `Run-AllSubscriptions.ps1` writes a wrapper-level transcript to `InventoryReports/RunAllSubscriptions_transcript_<timestamp>.txt`. Unlike the per-subscription transcripts that `ResourceInventory.ps1` writes inside each subscription folder, this file captures the full wrapper run end-to-end: tenant resolution, authentication decisions, resume-state messages, the cross-iteration narration of which subscription is being processed, the consolidation step, and the final summary. This applies to every run, single subscription or many.
+Every time you run `Run-AllSubscriptions.ps1`, it writes a transcript of the whole run to `InventoryReports/RunAllSubscriptions_transcript_<timestamp>.txt`. This is different from the per-subscription transcripts that the inner script `ResourceInventory.ps1` writes inside each subscription folder. The wrapper transcript covers the run end-to-end: which tenant was resolved, how authentication was handled, any resume-state messages, which subscription is being processed at each step, the final consolidation, and the run summary. You get this file every run, whether you process one subscription or many.
 
-If a subscription fails, the wrapper additionally writes a structured failure log to `InventoryReports/RunAllSubscriptions_failures_<timestamp>.log` containing the full exception type, message, up to five levels of `InnerException`, the script line, stack traces, and a snapshot of process memory and free disk at failure time. The final summary points at both files when failures have occurred.
+If a subscription fails, the wrapper also writes a structured failure log to `InventoryReports/RunAllSubscriptions_failures_<timestamp>.log`. This file captures the full exception type, the error message, up to five levels of inner exceptions, the script line number, the stack trace, and a snapshot of how much memory and free disk space the machine had when the failure happened. The final summary points at both files when failures occur.
 
 When reporting an issue, attach both files. They contain enough context to diagnose most failures without a follow-up round trip.
 
@@ -297,6 +411,22 @@ Compress-Archive -Path ./* -DestinationPath "CompanyName_ResourcesReport_$(Get-D
 | Parameter | Type | Description | Example |
 |-----------|------|-------------|----------|
 | `Debug` | Switch | Enable debug mode output | `-Debug` |
+
+### Run-AllSubscriptions Wrapper Parameters
+
+These are the parameters specific to `Run-AllSubscriptions.ps1`. The wrapper forwards `-DeviceLogin`, `-Obfuscate`, `-SkipMetrics`, `-SkipConsumption`, and `-ConcurrencyLimit` to the inner `ResourceInventory.ps1`, so they behave the same in both contexts.
+
+| Parameter | Type | Description | Default | Example |
+|-----------|------|-------------|---------|---------|
+| `TenantID` | String | **Required.** Azure tenant GUID or verified domain. The wrapper resolves a domain to its GUID via OIDC discovery before authenticating. | — | `-TenantID "contoso.onmicrosoft.com"` |
+| `Resume` | Switch | Skip subscriptions already completed in a prior run. Reads from `InventoryReports/.resume-state-<TenantID>.json`. State is cleared automatically after a clean run. | False | `-Resume` |
+| `IncludeDisabled` | Switch | Include subscriptions whose state is not `Enabled` (e.g. `Disabled`, `Warned`, `PastDue`). By default these are skipped because they return little or no data. | False | `-IncludeDisabled` |
+| `ParallelStreams` | Integer | Number of subscriptions to process concurrently. `1` (default) is the existing sequential behavior. See [Parallel subscription processing](#parallel-subscription-processing) for sizing guidance. | 1 | `-ParallelStreams 6` |
+| `ConcurrencyLimit` | Integer | Forwarded to the inner script's metrics-collection throttle. Controls how many `Get-AzMetric` calls run in parallel within one subscription. | 6 | `-ConcurrencyLimit 12` |
+| `Obfuscate` | Switch | Forwarded. Replace resource IDs, names, subscriptions, resource groups, and tags with masked values. | False | `-Obfuscate` |
+| `SkipMetrics` | Switch | Forwarded. Skip Azure Monitor metrics collection. | False | `-SkipMetrics` |
+| `SkipConsumption` | Switch | Forwarded. Skip cost/billing data collection. | False | `-SkipConsumption` |
+| `DeviceLogin` | Switch | Forwarded. Use device-code authentication (browser flow with a code). | False | `-DeviceLogin` |
 
 ## Troubleshooting
 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1101,71 +1101,99 @@ function FinalizeOutputs
 # Detect the most common environment problems that make a long run pointless,
 # before transcript start, authentication, or any per-subscription work.
 #
-# NOTE: Keep this block in sync with the same block at the top of
-# Run-AllSubscriptions.ps1 (just before its Resolve-TenantId call). They are
-# inlined in both files rather than dot-sourced from a shared file because
-# the dot-source itself is a failure surface (path resolution, missing file)
-# we do not want to add to a script whose entire job is to fail loudly when
-# the environment is wrong.
-$PreFlightInventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
-if (-not (Test-Path -Path $PreFlightInventoryRoot -PathType Container)) {
-    try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null } catch { }
-}
+# When this script is invoked by Run-AllSubscriptions.ps1 (-RunAllSubs is
+# set), the wrapper has already executed the same checks at its top level,
+# so the entire block is skipped here - otherwise the checks would re-run
+# once per subscription (e.g. 164 times in a 164-sub run), adding noise to
+# the per-subscription transcript without adding safety. Standalone invocation
+# of this script still runs the full block.
+#
+# NOTE: Keep the body of this block in sync with the same block at the top
+# of Run-AllSubscriptions.ps1 (just before its Resolve-TenantId call). They
+# are inlined in both files rather than dot-sourced from a shared file
+# because the dot-source itself is a failure surface (path resolution,
+# missing file) we do not want to add to a script whose entire job is to
+# fail loudly when the environment is wrong. Intentional differences vs the
+# wrapper copy:
+#   - This copy honors -OutputDirectory if the caller passed one (the wrapper
+#     does not expose or forward that parameter).
+#   - This copy throws on hard-fail; the wrapper's copy calls Exit-Wrapper.
+#   - This copy is gated on -not $RunAllSubs to avoid duplicate execution
+#     when invoked by the wrapper.
+if (-not $RunAllSubs.IsPresent) {
 
-Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
-
-# 1. Cloud Shell mount detection. See Run-AllSubscriptions.ps1 for the rationale.
-if (Get-Command Get-CloudDrive -ErrorAction SilentlyContinue) {
-    $CheckCloudDrive = Get-CloudDrive 3>$null 2>$null
-    if ($null -eq $CheckCloudDrive) {
-        Write-Host ""
-        Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
-        Write-Host "  Outputs in $PreFlightInventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
-        Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
-        Write-Host "    clouddrive mount" -ForegroundColor Yellow
-        Write-Host "  Continuing in ephemeral mode - download the report ZIP from $PreFlightInventoryRoot before closing the shell." -ForegroundColor Yellow
-        Write-Host ""
+    # Honor -OutputDirectory when the caller passed one. CheckPowerShell will
+    # re-validate -OutputDirectory itself further down and is the authoritative
+    # gate; we Resolve-Path here defensively so a relative path is checked at
+    # the right location, and fall back to the raw value if it does not yet
+    # resolve (the write probe below will surface the underlying error).
+    $PreFlightInventoryRoot = if ($OutputDirectory) {
+        try { (Resolve-Path $OutputDirectory -ErrorAction Stop).Path }
+        catch { $OutputDirectory }
+    } elseif ($PSVersionTable.Platform -eq 'Unix') {
+        "$HOME/InventoryReports"
     } else {
-        Write-Host ("Cloud Shell drive mounted: {0}" -f $CheckCloudDrive.Name) -ForegroundColor Green
+        "C:\InventoryReports"
     }
-}
+    if (-not (Test-Path -Path $PreFlightInventoryRoot -PathType Container)) {
+        try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+    }
 
-# 2. Disk space probe.
-try {
-    $rootItem = Get-Item -Path $PreFlightInventoryRoot -ErrorAction Stop
-    $drive = $rootItem.PSDrive
-    if ($null -ne $drive -and $null -ne $drive.Free) {
-        $freeMB = [math]::Round($drive.Free / 1MB, 0)
-        if ($freeMB -lt 100) {
-            throw ("Pre-flight: free disk space at {0} is {1} MB; the script needs at least 100 MB to start. Free space and re-run." -f $PreFlightInventoryRoot, $freeMB)
-        } elseif ($freeMB -lt 500) {
-            Write-Host ("WARNING: Free disk space at {0} is {1} MB. A large multi-subscription run can exceed this. Consider freeing space before running." -f $PreFlightInventoryRoot, $freeMB) -ForegroundColor Yellow
+    Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
+
+    # 1. Cloud Shell mount detection. See Run-AllSubscriptions.ps1 for the rationale.
+    if (Get-Command Get-CloudDrive -ErrorAction SilentlyContinue) {
+        $CheckCloudDrive = Get-CloudDrive 3>$null 2>$null
+        if ($null -eq $CheckCloudDrive) {
+            Write-Host ""
+            Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
+            Write-Host "  Outputs in $PreFlightInventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
+            Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
+            Write-Host "    clouddrive mount" -ForegroundColor Yellow
+            Write-Host "  Continuing in ephemeral mode - download the report ZIP from $PreFlightInventoryRoot before closing the shell." -ForegroundColor Yellow
+            Write-Host ""
         } else {
-            Write-Host ("Free disk space: {0:N0} MB at {1}" -f $freeMB, $PreFlightInventoryRoot) -ForegroundColor Green
+            Write-Host ("Cloud Shell drive mounted: {0}" -f $CheckCloudDrive.Name) -ForegroundColor Green
         }
     }
-} catch {
-    if ($_.Exception.Message -match '^Pre-flight:') { throw }
-    Write-Host ("WARNING: Could not determine free disk space at {0}: {1}" -f $PreFlightInventoryRoot, $_.Exception.Message) -ForegroundColor Yellow
-}
 
-# 3. Write probe.
-$probePath = Join-Path $PreFlightInventoryRoot (".write-probe-{0}.tmp" -f ([guid]::NewGuid()))
-try {
-    Set-Content -Path $probePath -Value 'preflight write probe' -Encoding utf8 -ErrorAction Stop
-    $probeRead = Get-Content -Path $probePath -Raw -ErrorAction Stop
-    if ($probeRead -notmatch 'preflight write probe') {
-        throw "Write probe content mismatch (read back '$probeRead')"
+    # 2. Disk space probe.
+    try {
+        $rootItem = Get-Item -Path $PreFlightInventoryRoot -ErrorAction Stop
+        $drive = $rootItem.PSDrive
+        if ($null -ne $drive -and $null -ne $drive.Free) {
+            $freeMB = [math]::Round($drive.Free / 1MB, 0)
+            if ($freeMB -lt 100) {
+                throw ("Pre-flight: free disk space at {0} is {1} MB; the script needs at least 100 MB to start. Free space and re-run." -f $PreFlightInventoryRoot, $freeMB)
+            } elseif ($freeMB -lt 500) {
+                Write-Host ("WARNING: Free disk space at {0} is {1} MB. A large multi-subscription run can exceed this. Consider freeing space before running." -f $PreFlightInventoryRoot, $freeMB) -ForegroundColor Yellow
+            } else {
+                Write-Host ("Free disk space: {0:N0} MB at {1}" -f $freeMB, $PreFlightInventoryRoot) -ForegroundColor Green
+            }
+        }
+    } catch {
+        if ($_.Exception.Message -match '^Pre-flight:') { throw }
+        Write-Host ("WARNING: Could not determine free disk space at {0}: {1}" -f $PreFlightInventoryRoot, $_.Exception.Message) -ForegroundColor Yellow
     }
-    Remove-Item -Path $probePath -Force -ErrorAction Stop
-    Write-Host ("Write probe: OK ({0})" -f $PreFlightInventoryRoot) -ForegroundColor Green
-} catch {
-    try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
-    throw ("Pre-flight: cannot write to {0}: {1}. This usually means readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle. Verify the directory is writable and re-run." -f $PreFlightInventoryRoot, $_.Exception.Message)
-}
 
-Write-Host "Pre-flight checks passed." -ForegroundColor Green
-Write-Host ""
+    # 3. Write probe.
+    $probePath = Join-Path $PreFlightInventoryRoot (".write-probe-{0}.tmp" -f ([guid]::NewGuid()))
+    try {
+        Set-Content -Path $probePath -Value 'preflight write probe' -Encoding utf8 -ErrorAction Stop
+        $probeRead = Get-Content -Path $probePath -Raw -ErrorAction Stop
+        if ($probeRead -notmatch 'preflight write probe') {
+            throw "Write probe content mismatch (read back '$probeRead')"
+        }
+        Remove-Item -Path $probePath -Force -ErrorAction Stop
+        Write-Host ("Write probe: OK ({0})" -f $PreFlightInventoryRoot) -ForegroundColor Green
+    } catch {
+        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+        throw ("Pre-flight: cannot write to {0}: {1}. This usually means readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle. Verify the directory is writable and re-run." -f $PreFlightInventoryRoot, $_.Exception.Message)
+    }
+
+    Write-Host "Pre-flight checks passed." -ForegroundColor Green
+    Write-Host ""
+}
 
 # Setup and Inventory Gathering.
 #

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -142,21 +142,45 @@ Function RunInventorySetup()
         }
         else
         {
-            Write-Log -Message ('Azure PowerShell Module not found. Trying to install...') -Severity 'Warning'
-            Install-Module -Name Az -Repository PSGallery -Force -Scope CurrentUser
-            $VarAzPs = Get-Module -Name Az -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
+            # Behaviour change (deliberate): do not Install-Module Az from inside
+            # this script. A real field run produced a half-installed Az module
+            # - .psd1 manifests present so Get-Module -ListAvailable was happy,
+            # but the bundled MSAL/Azure.Core assemblies were missing on disk -
+            # and the script then ran for nearly an hour producing zero
+            # consumption data because every Get-AzUsageAggregate call failed
+            # with "Azure PowerShell context has not been properly initialized".
+            # In-process module installs into a script that's already importing
+            # the same module are fragile (concurrent install, AppDomain
+            # caching, partial download) and the failure mode is a silent broken
+            # install rather than a clean error. Failing loudly here is safer.
+            Write-Log -Message ('Azure PowerShell Module not found.') -Severity 'Error'
+            Write-Log -Message ('Install it manually before re-running this script. From an elevated PowerShell 7 prompt:') -Severity 'Error'
+            Write-Log -Message ('  Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck') -Severity 'Error'
+            Write-Log -Message ('Or in Cloud Shell, the Az module is already preinstalled - if it is missing your shell environment is broken.') -Severity 'Error'
+            throw 'Azure PowerShell (Az) module is required and was not found. See log above for installation instructions.'
         }
 
-        if ($null -eq $VarAzPs) 
-        {
-            Write-Log -Message ('Failed to install Azure PowerShell Module. Press <Enter> to finish script') -Severity 'Error'
-            Read-Host ''
-            Exit
+        # Probe that the Az module actually loads. Get-Module -ListAvailable above
+        # only checks for the manifest on disk; it does not validate that the
+        # bundled assemblies (MSAL, Azure.Core, etc.) are present and loadable.
+        # Without this probe a broken install (manifest present, assemblies
+        # missing - a real field-observed scenario) would let the script
+        # continue all the way to the consumption phase before failing.
+        try {
+            Import-Module Az -ErrorAction Stop -DisableNameChecking | Out-Null
+            $Global:AzPowerShellLoaded = $true
+        } catch {
+            Write-Log -Message ('Azure PowerShell module is present on disk but failed to load: {0}' -f $_.Exception.Message) -Severity 'Error'
+            Write-Log -Message ('This usually indicates a broken install - the module manifest is present but its bundled assemblies (MSAL, Azure.Core, etc.) are missing or unloadable.') -Severity 'Error'
+            Write-Log -Message ('Reinstall with: Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck') -Severity 'Error'
+            Write-Log -Message ('If the broken install was created by a previous run of this script, also run: Get-Module Az* -ListAvailable | Uninstall-Module -Force') -Severity 'Error'
+            $Global:AzPowerShellLoaded = $false
+            throw "Azure PowerShell (Az) module is broken on disk and cannot be loaded. See log above for remediation."
         }
-        
+
 
         Write-Log -Message ('Checking ImportExcel Module...') -Severity 'Info'
-    
+
         $VarExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
     
         if ($null -ne $VarExcel)
@@ -165,16 +189,15 @@ Function RunInventorySetup()
         }
         else
         {
-            Write-Log -Message ('ImportExcel Module not found. Trying to install...') -Severity 'Warning'
-            Install-Module -Name ImportExcel -Force -Scope CurrentUser
-            $VarExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction SilentlyContinue | Select-Object -First 1
-        }
-    
-        if ($null -eq $VarExcel) 
-        {
-            Write-Log -Message ('Failed to install ImportExcel Module. Press <Enter> to finish script') -Severity 'Error'
-            Read-Host ''
-            Exit
+            # Behaviour change (deliberate): do not Install-Module ImportExcel
+            # from inside this script. Same rationale as the Az module check
+            # above - in-process module installs into a script that's already
+            # importing the same module produce silent broken installs that
+            # only surface much later. Fail loud here with a clear command.
+            Write-Log -Message ('ImportExcel Module not found.') -Severity 'Error'
+            Write-Log -Message ('Install it manually before re-running this script. From an elevated PowerShell 7 prompt:') -Severity 'Error'
+            Write-Log -Message ('  Install-Module -Name ImportExcel -Force -AllowClobber -SkipPublisherCheck') -Severity 'Error'
+            throw 'ImportExcel module is required and was not found. See log above for installation instructions.'
         }
 
         # Eagerly import ImportExcel so its bundled EPPlus assembly is loaded into the
@@ -895,21 +918,33 @@ function ExecuteInventoryProcessing()
             Set-AzContext -Subscription $sub.id | Out-Null
             Write-Log -Message ("Gathering Consumption for: {0}" -f $sub.Name) -Severity 'Info'
 
-            do 
-            {    
-                $params = @{
-                    ReportedStartTime      = $reportedStartTime
-                    ReportedEndTime        = $reportedEndTime
-                    AggregationGranularity = 'Daily'
-                    ShowDetails            = $true
-                }
-    
-                $params.ContinuationToken = $usageData.ContinuationToken
-    
-                $usageData = Get-UsageAggregates @params
-                $usageDataExport = $usageData.UsageAggregations.Properties | Select-Object InstanceData, MeterCategory, MeterId, MeterName, MeterRegion, MeterSubCategory, Quantity, Unit, UsageStartTime, UsageEndTime
+            # Track consumption health per-subscription so the wrapper can report
+            # at the end whether consumption data was actually collected. Without
+            # this, a broken Az module produces zero consumption records on every
+            # subscription and the run still reports as successful - leaving an
+            # empty consumption sheet in the output that nobody noticed until the
+            # report was reviewed.
+            $consumptionRecordsThisSub = 0
+            $consumptionFailedThisSub = $false
+            $consumptionFailureMessage = $null
 
-                Write-Log -Message ("Records found: $($usageDataExport.Count)...") -Severity 'Info'
+            try {
+                do
+                {
+                    $params = @{
+                        ReportedStartTime      = $reportedStartTime
+                        ReportedEndTime        = $reportedEndTime
+                        AggregationGranularity = 'Daily'
+                        ShowDetails            = $true
+                    }
+
+                    $params.ContinuationToken = $usageData.ContinuationToken
+
+                    $usageData = Get-UsageAggregates @params -ErrorAction Stop
+                    $usageDataExport = $usageData.UsageAggregations.Properties | Select-Object InstanceData, MeterCategory, MeterId, MeterName, MeterRegion, MeterSubCategory, Quantity, Unit, UsageStartTime, UsageEndTime
+
+                    Write-Log -Message ("Records found: $($usageDataExport.Count)...") -Severity 'Info'
+                    $consumptionRecordsThisSub += $usageDataExport.Count
 
                 $newUsageDataExport = [System.Collections.ArrayList]::new()
 
@@ -995,7 +1030,32 @@ function ExecuteInventoryProcessing()
 
                 $newUsageDataExport | Select-Object InstanceData, MeterCategory, MeterId, MeterName, MeterRegion, MeterSubCategory, Quantity, Unit, UsageStartTime, UsageEndTime, ResourceId, ResourceLocation, ConsumptionMeter, ReservationId, ReservationOrderId | Export-Csv $Global:ConsumptionFileCsv -Encoding utf8 -Append -NoTypeInformation
                 
-            } while ('ContinuationToken' -in $usageData.psobject.properties.name -and $usageData.ContinuationToken)
+                } while ('ContinuationToken' -in $usageData.psobject.properties.name -and $usageData.ContinuationToken)
+            } catch {
+                # The most common cause is a broken Az module install (manifest
+                # present, MSAL/Azure.Core assemblies missing). The script-level
+                # Import-Module probe should have caught that, but we also catch
+                # here defensively so a transient ARM throttling event or a
+                # subscription the identity cannot bill against does not abort
+                # the entire run for other subscriptions.
+                $consumptionFailedThisSub = $true
+                $consumptionFailureMessage = $_.Exception.Message
+                Write-Log -Message ("Consumption query failed for {0}: {1}" -f $sub.Name, $_.Exception.Message) -Severity 'Warning'
+            }
+
+            # Aggregate per-sub consumption health into globals the wrapper reads
+            # at the end of the run. Globals here live in the wrapper's scope
+            # because ResourceInventory.ps1 is invoked via `& <path>`.
+            if ($null -eq $Global:ConsumptionRecordCount) { $Global:ConsumptionRecordCount = 0 }
+            if ($null -eq $Global:ConsumptionFailedSubs)  { $Global:ConsumptionFailedSubs  = @() }
+            $Global:ConsumptionRecordCount += $consumptionRecordsThisSub
+            if ($consumptionFailedThisSub) {
+                $Global:ConsumptionFailedSubs += [pscustomobject]@{
+                    Name    = $sub.Name
+                    Id      = $sub.Id
+                    Message = $consumptionFailureMessage
+                }
+            }
         }
 
         $DebugPreference = "Continue"

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1096,6 +1096,77 @@ function FinalizeOutputs
     ProcessSummary
 }
 
+# === Pre-flight checks ===
+#
+# Detect the most common environment problems that make a long run pointless,
+# before transcript start, authentication, or any per-subscription work.
+#
+# NOTE: Keep this block in sync with the same block at the top of
+# Run-AllSubscriptions.ps1 (just before its Resolve-TenantId call). They are
+# inlined in both files rather than dot-sourced from a shared file because
+# the dot-source itself is a failure surface (path resolution, missing file)
+# we do not want to add to a script whose entire job is to fail loudly when
+# the environment is wrong.
+$PreFlightInventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+if (-not (Test-Path -Path $PreFlightInventoryRoot -PathType Container)) {
+    try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+}
+
+Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
+
+# 1. Cloud Shell mount detection. See Run-AllSubscriptions.ps1 for the rationale.
+if (Get-Command Get-CloudDrive -ErrorAction SilentlyContinue) {
+    $CheckCloudDrive = Get-CloudDrive 3>$null 2>$null
+    if ($null -eq $CheckCloudDrive) {
+        Write-Host ""
+        Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
+        Write-Host "  Outputs in $PreFlightInventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
+        Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
+        Write-Host "    clouddrive mount" -ForegroundColor Yellow
+        Write-Host "  Continuing in ephemeral mode - download the report ZIP from $PreFlightInventoryRoot before closing the shell." -ForegroundColor Yellow
+        Write-Host ""
+    } else {
+        Write-Host ("Cloud Shell drive mounted: {0}" -f $CheckCloudDrive.Name) -ForegroundColor Green
+    }
+}
+
+# 2. Disk space probe.
+try {
+    $rootItem = Get-Item -Path $PreFlightInventoryRoot -ErrorAction Stop
+    $drive = $rootItem.PSDrive
+    if ($null -ne $drive -and $null -ne $drive.Free) {
+        $freeMB = [math]::Round($drive.Free / 1MB, 0)
+        if ($freeMB -lt 100) {
+            throw ("Pre-flight: free disk space at {0} is {1} MB; the script needs at least 100 MB to start. Free space and re-run." -f $PreFlightInventoryRoot, $freeMB)
+        } elseif ($freeMB -lt 500) {
+            Write-Host ("WARNING: Free disk space at {0} is {1} MB. A large multi-subscription run can exceed this. Consider freeing space before running." -f $PreFlightInventoryRoot, $freeMB) -ForegroundColor Yellow
+        } else {
+            Write-Host ("Free disk space: {0:N0} MB at {1}" -f $freeMB, $PreFlightInventoryRoot) -ForegroundColor Green
+        }
+    }
+} catch {
+    if ($_.Exception.Message -match '^Pre-flight:') { throw }
+    Write-Host ("WARNING: Could not determine free disk space at {0}: {1}" -f $PreFlightInventoryRoot, $_.Exception.Message) -ForegroundColor Yellow
+}
+
+# 3. Write probe.
+$probePath = Join-Path $PreFlightInventoryRoot (".write-probe-{0}.tmp" -f ([guid]::NewGuid()))
+try {
+    Set-Content -Path $probePath -Value 'preflight write probe' -Encoding utf8 -ErrorAction Stop
+    $probeRead = Get-Content -Path $probePath -Raw -ErrorAction Stop
+    if ($probeRead -notmatch 'preflight write probe') {
+        throw "Write probe content mismatch (read back '$probeRead')"
+    }
+    Remove-Item -Path $probePath -Force -ErrorAction Stop
+    Write-Host ("Write probe: OK ({0})" -f $PreFlightInventoryRoot) -ForegroundColor Green
+} catch {
+    try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+    throw ("Pre-flight: cannot write to {0}: {1}. This usually means readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle. Verify the directory is writable and re-run." -f $PreFlightInventoryRoot, $_.Exception.Message)
+}
+
+Write-Host "Pre-flight checks passed." -ForegroundColor Green
+Write-Host ""
+
 $Global:PowerShellTranscriptFile = ($DefaultPath + "Transcript_Log_"+ $Global:ReportName + "_" + $CurrentDateTime + ".txt")
 Start-Transcript -Path $Global:PowerShellTranscriptFile -UseMinimalHeader
 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -258,9 +258,21 @@ Function RunInventorySetup()
 
             if (!$TenantID -or $existingAccount.tenantId -eq $TenantID)
             {
-                # Ensure PowerShell Az context is also set
+                # Ensure PowerShell Az context is set for the requested tenant.
+                # We compare the Az PS context's tenant — not its current subscription
+                # — against $existingAccount because the Az PS and az CLI contexts can
+                # have different default subscriptions even when authenticated against
+                # the same tenant. Comparing subscriptions caused a re-Connect-AzAccount
+                # on every iteration of Run-AllSubscriptions.ps1 on PowerShell Desktop,
+                # which prompted the user to log in again for each subscription. Per-
+                # subscription scoping happens later via Set-AzContext / --subscriptions /
+                # resource-id parameters on Get-AzMetric, so the context only needs to
+                # match the tenant.
                 $azContext = Get-AzContext -ErrorAction SilentlyContinue
-                if ($null -eq $azContext -or $azContext.Subscription.Id -ne $existingAccount.id)
+                $needsConnect = $null -eq $azContext -or
+                                [string]::IsNullOrEmpty($azContext.Tenant.Id) -or
+                                $azContext.Tenant.Id -ne $existingAccount.tenantId
+                if ($needsConnect)
                 {
                     Write-Log -Message ('Setting PowerShell Az context...') -Severity 'Info'
                     if($DeviceLogin.IsPresent)

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1167,13 +1167,22 @@ try {
 Write-Host "Pre-flight checks passed." -ForegroundColor Green
 Write-Host ""
 
-$Global:PowerShellTranscriptFile = ($DefaultPath + "Transcript_Log_"+ $Global:ReportName + "_" + $CurrentDateTime + ".txt")
-Start-Transcript -Path $Global:PowerShellTranscriptFile -UseMinimalHeader
-
-# Setup and Inventory Gathering
+# Setup and Inventory Gathering.
+#
+# Variables and RunInventorySetup populate $Global:DefaultPath, $Global:ReportName,
+# and $Global:CurrentDateTime which are required to compute the transcript path.
+# Start-Transcript must therefore run *after* RunInventorySetup, not before.
+# Previously this block placed Start-Transcript above Variables, with the result
+# that $DefaultPath/$ReportName/$CurrentDateTime were all $null at that point and
+# the transcript file landed in the current working directory with the literal
+# name "Transcript_Log__.txt" - two underscores, missing report name and missing
+# timestamp.
 $Global:Runtime = Measure-Command -Expression {
     Variables
     RunInventorySetup
+
+    $Global:PowerShellTranscriptFile = ($Global:DefaultPath + "Transcript_Log_" + $Global:ReportName + "_" + $Global:CurrentDateTime + ".txt")
+    Start-Transcript -Path $Global:PowerShellTranscriptFile -UseMinimalHeader
 }
 
 # Execution and processing of inventory

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -176,6 +176,30 @@ Function RunInventorySetup()
             Read-Host ''
             Exit
         }
+
+        # Eagerly import ImportExcel so its bundled EPPlus assembly is loaded into the
+        # current AppDomain before any code path constructs OfficeOpenXml types via
+        # New-Object. -ListAvailable (above) only confirms the module exists; it does
+        # not load it. Without this explicit import, scripts further down the call
+        # chain (notably Extension/Summary.ps1, which is invoked in a child scope via
+        # `& $SummaryPath ...`) fail with:
+        #
+        #   Cannot find type [OfficeOpenXml.ExcelPackage]: verify that the
+        #   assembly containing this type is loaded.
+        #
+        # The failure surfaces especially on Windows PowerShell Desktop in
+        # multi-subscription runs where the auto-import behavior across iterations
+        # can lose the loaded assembly's reference. Importing once here is idempotent
+        # and inexpensive.
+        try {
+            Import-Module ImportExcel -ErrorAction Stop -Force -DisableNameChecking | Out-Null
+            if (-not ([System.Management.Automation.PSTypeName]'OfficeOpenXml.ExcelPackage').Type) {
+                Write-Log -Message ('ImportExcel imported but OfficeOpenXml.ExcelPackage type is not loadable. The Excel report step will fail.') -Severity 'Error'
+            }
+        } catch {
+            Write-Log -Message ('Import-Module ImportExcel failed: {0}' -f $_.Exception.Message) -Severity 'Error'
+            throw
+        }
     }
     
     function CheckPowerShell() 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1136,7 +1136,8 @@ if (-not $RunAllSubs.IsPresent) {
         "C:\InventoryReports"
     }
     if (-not (Test-Path -Path $PreFlightInventoryRoot -PathType Container)) {
-        try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+        try { New-Item -Path $PreFlightInventoryRoot -ItemType Directory -Force | Out-Null }
+        catch { Write-Verbose ("PreFlightInventoryRoot create failed at {0}: {1}" -f $PreFlightInventoryRoot, $_.Exception.Message) }
     }
 
     Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
@@ -1187,7 +1188,8 @@ if (-not $RunAllSubs.IsPresent) {
         Remove-Item -Path $probePath -Force -ErrorAction Stop
         Write-Host ("Write probe: OK ({0})" -f $PreFlightInventoryRoot) -ForegroundColor Green
     } catch {
-        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } }
+        catch { Write-Verbose ("Probe cleanup failed at {0}: {1}" -f $probePath, $_.Exception.Message) }
         throw ("Pre-flight: cannot write to {0}: {1}. This usually means readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle. Verify the directory is writable and re-run." -f $PreFlightInventoryRoot, $_.Exception.Message)
     }
 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -89,8 +89,24 @@ Function RunInventorySetup()
     {
         Write-Log -Message ('Checking Version') -Severity 'Info'
         Write-Log -Message ('Version: {0}' -f $Global:Version) -Severity 'Info'
-        
-        $versionJson = (New-Object System.Net.WebClient).DownloadString($RawRepo + '/Version.json') | ConvertFrom-Json
+
+        # The version check is best-effort. On corporate networks that block
+        # raw.githubusercontent.com (DNS failure, firewall, or air-gap), this
+        # WebClient call would otherwise raise SocketException and abort the
+        # entire subscription before any inventory work began. A failed update
+        # check is not a reason to skip a subscription's inventory - log a
+        # clear note and continue with the local version. See #18.
+        try
+        {
+            $versionJson = (New-Object System.Net.WebClient).DownloadString($RawRepo + '/Version.json') | ConvertFrom-Json
+        }
+        catch
+        {
+            Write-Log -Message ("Could not reach {0}/Version.json to check for an update: {1}" -f $RawRepo, $_.Exception.Message) -Severity 'Warning'
+            Write-Log -Message ('Continuing with local version {0}. If you are on a managed network, this is expected.' -f $Global:Version) -Severity 'Info'
+            return
+        }
+
         $versionNumber = ('{0}.{1}.{2}' -f $versionJson.MajorVersion, $versionJson.MinorVersion, $versionJson.BuildVersion)
 
         if($versionNumber -ne $Global:Version)

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -1298,10 +1298,49 @@ if($SkipMetrics.IsPresent)
 {
     @{ Metrics = @() } | ConvertTo-Json -depth 5 -compress | Out-File $Global:MetricsJsonFile -Encoding utf8
 }
+else
+{
+    # Subscriptions with zero metric-eligible resources never enter the
+    # batched-write loop in Extension/Metrics.ps1, so no Metrics_*.json is
+    # produced for them. Downstream consumers that expect *every* per-sub
+    # bundle to contain a Metrics JSON (dashboard ingestion, the
+    # ParallelStreamsAggregation tests) reject the bundle when the file is
+    # missing. Detect that case and emit an empty-but-valid Metrics JSON
+    # at the canonical $Global:MetricsJsonFile path so the bundle is always
+    # structurally complete. Use Get-ChildItem with a wildcard because the
+    # batched writer suffixes filenames with "_<rangeIdx>.json".
+    $metricsPattern = ('Metrics_{0}_{1}*.json' -f $Global:ReportName, $CurrentDateTime)
+    $metricsAny = @(Get-ChildItem -Path $DefaultPath -Filter $metricsPattern -ErrorAction SilentlyContinue)
+    if ($metricsAny.Count -eq 0)
+    {
+        @{ Metrics = @() } | ConvertTo-Json -depth 5 -compress | Out-File $Global:MetricsJsonFile -Encoding utf8
+    }
+}
 
 $consumptionCreated = Test-Path -Path $Global:ConsumptionFileCsv
 
-if($SkipConsumption.IsPresent -or !$consumptionCreated)
+# A subscription with zero billing records produces an empty (0-byte) CSV
+# rather than a header-only one, because Export-Csv -Append with no input
+# objects writes nothing. Treat 0-byte files as "not created" so the safety
+# net below emits the header. Without this, downstream consumers that parse
+# the CSV by header (dashboard ingestion, the Pester tests) fail on the
+# empty file and reject the entire per-sub bundle.
+$consumptionEmpty = $false
+if ($consumptionCreated)
+{
+    try
+    {
+        $consumptionEmpty = ((Get-Item -Path $Global:ConsumptionFileCsv -ErrorAction Stop).Length -eq 0)
+    }
+    catch
+    {
+        # Treat unreadable as not-created so the header gets written; safer than
+        # leaving an unparseable file in the bundle.
+        $consumptionEmpty = $true
+    }
+}
+
+if($SkipConsumption.IsPresent -or !$consumptionCreated -or $consumptionEmpty)
 {
     "InstanceData,MeterCategory,MeterId,MeterName,MeterRegion,MeterSubCategory,Quantity,Unit,UsageStartTime,UsageEndTime,ResourceId,ResourceLocation,ConsumptionMeter,ReservationId,ReservationOrderId" | Out-File $Global:ConsumptionFileCsv -Encoding utf8
 }

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -279,7 +279,12 @@ Function RunInventorySetup()
         # second worker's Compress-Archive fails with "archive file already
         # exists". The format change is invisible to every downstream consumer:
         # all glob filters use `*` wildcards over the timestamp segment.
-        $Global:CurrentDateTime = (get-date -Format "yyyyMMddHHmmssfff")
+        # Append a 4-char per-process discriminator to the timestamp. Two
+        # worker processes that hit the same millisecond still produce
+        # different folder names. Discriminator is hex-only and length-stable
+        # so the existing `*<timestamp>*` glob filters keep matching.
+        $procDiscriminator = ('{0:x4}' -f ($PID -band 0xffff))
+        $Global:CurrentDateTime = ((get-date -Format "yyyyMMddHHmmssfff") + $procDiscriminator)
         $Global:FolderName = $Global:ReportName + $CurrentDateTime
         
         if ($cloudShell) 

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -235,6 +235,29 @@ Function RunInventorySetup()
             if (-not ([System.Management.Automation.PSTypeName]'OfficeOpenXml.ExcelPackage').Type) {
                 Write-Log -Message ('ImportExcel imported but OfficeOpenXml.ExcelPackage type is not loadable. The Excel report step will fail.') -Severity 'Error'
             }
+
+            # New-ExcelStyle health probe.
+            #
+            # On a partially-installed ImportExcel (manifest present but bundled
+            # EPPlus assemblies missing or version-mismatched), New-ExcelStyle
+            # returns $null instead of an OfficeOpenXml.Style.ExcelStyle. That
+            # $null then flows into ~30 collectors under Services\* and crashes
+            # deep inside Set-ExcelRange.ps1 with a confusing 'HorizontalAlignment
+            # cannot be found' error - long after the user has waited through
+            # resource enumeration. Catch it here with one actionable message.
+            # See ARI issue #17 for upstream context.
+            $rdaStyleProbe = $null
+            try { $rdaStyleProbe = New-ExcelStyle -HorizontalAlignment Center -AutoSize -NumberFormat 0 -ErrorAction Stop }
+            catch { Write-Log -Message ('New-ExcelStyle probe threw: {0}' -f $_.Exception.Message) -Severity 'Error' }
+            $rdaStyleProbeOk = $false
+            if ($null -ne $rdaStyleProbe) {
+                try { $rdaStyleProbeOk = ($rdaStyleProbe['HorizontalAlignment'] -eq 'Center') }
+                catch { $rdaStyleProbeOk = $false }
+            }
+            if (-not $rdaStyleProbeOk) {
+                Write-Log -Message ('ImportExcel module is in a broken state - New-ExcelStyle returned an unusable object. This usually means manifest is present but bundled EPPlus assemblies are missing or version-mismatched. Reinstall with: Get-Module ImportExcel -ListAvailable | Uninstall-Module -Force; Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser') -Severity 'Error'
+                throw 'ImportExcel preflight failed - reinstall the module and re-run.'
+            }
         } catch {
             Write-Log -Message ('Import-Module ImportExcel failed: {0}' -f $_.Exception.Message) -Severity 'Error'
             throw

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -865,7 +865,13 @@ function ExecuteInventoryProcessing()
             }
 
             $Global:SmaResources | Add-Member -MemberType NoteProperty -Name $ModName -Value NotSet
-            $Global:SmaResources.$ModName = $result
+            # Wrap with @() so the JSON serializer always emits an array, even
+            # when the collector returns exactly one resource. Without this,
+            # PowerShell unwraps a single-element pipeline result into a scalar
+            # PSCustomObject, ConvertTo-Json emits {...} instead of [{...}],
+            # and downstream parsers that iterate the resource type as an
+            # array silently see zero rows.
+            $Global:SmaResources.$ModName = @($result)
 
             $result = $null
             [System.GC]::Collect()

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -248,7 +248,15 @@ Function RunInventorySetup()
         $Global:PlatformOS = 'PowerShell Desktop'
         $cloudShell = try{Get-CloudDrive}catch{}
 
-        $Global:CurrentDateTime = (get-date -Format "yyyyMMddHHmmss")
+        # Millisecond precision is required when multiple inner-script invocations
+        # can start in the same second (the parallel-streams orchestration in
+        # Run-AllSubscriptions.ps1 fans out N child processes that all run this
+        # init block concurrently). Without it, two workers compute the same
+        # $Global:CurrentDateTime, point at the same per-sub folder, and the
+        # second worker's Compress-Archive fails with "archive file already
+        # exists". The format change is invisible to every downstream consumer:
+        # all glob filters use `*` wildcards over the timestamp segment.
+        $Global:CurrentDateTime = (get-date -Format "yyyyMMddHHmmssfff")
         $Global:FolderName = $Global:ReportName + $CurrentDateTime
         
         if ($cloudShell) 

--- a/Run-AllSubscriptions.Stream.ps1
+++ b/Run-AllSubscriptions.Stream.ps1
@@ -1,0 +1,282 @@
+#Requires -Version 7.0
+
+# Run-AllSubscriptions.Stream.ps1
+#
+# Worker script invoked by Run-AllSubscriptions.ps1 when -ParallelStreams > 1.
+# Each instance of this worker:
+#   - Runs as a separate `pwsh` background job (fresh process, fresh AppDomain).
+#   - Owns its own slice of the subscription list.
+#   - Owns its own resume-state file (.resume-state-<TenantID>-stream-<N>.json),
+#     so the streams cannot race on a shared file.
+#   - Imports an Az PowerShell context from a shared snapshot file written by
+#     the parent wrapper, so authentication is not re-prompted per stream.
+#   - Calls ResourceInventory.ps1 once per subscription in its slice.
+#   - Emits structured progress lines to stdout (prefixed [stream-N]) so the
+#     parent wrapper can collate output across streams.
+#   - Writes a per-stream JSON summary at the end so the parent can aggregate
+#     resource counts, consumption results, and failures into the final
+#     wrapper-level summary.
+#
+# This script is intentionally self-contained (no dot-source from the parent)
+# because Start-Job runs the script block in a fresh runspace where parent
+# functions and variables are not in scope. The wrapper passes everything via
+# explicit parameters.
+
+param (
+    [Parameter(Mandatory=$true)] [string]   $TenantID,
+    [Parameter(Mandatory=$true)] [string]   $StreamId,
+    [Parameter(Mandatory=$true)] [string]   $InventoryRoot,
+    [Parameter(Mandatory=$true)] [string]   $ScriptRoot,
+    [Parameter(Mandatory=$true)] [string]   $AzContextPath,
+    [Parameter(Mandatory=$true)] [string]   $StreamSummaryPath,
+    [Parameter(Mandatory=$true)] [string]   $StreamFailuresPath,
+    # SubscriptionIds / SubscriptionNames are intentionally NOT Mandatory.
+    # PowerShell rejects empty arrays passed to Mandatory [string[]] params,
+    # which would hard-fail the worker before any logging runs. The parent
+    # currently guarantees non-empty slices via [Math]::Min(StreamCount, subs)
+    # but a future change to the slicing logic should not silently break the
+    # worker's binding. Default to @() and guard the body explicitly.
+    [string[]] $SubscriptionIds   = @(),
+    [string[]] $SubscriptionNames = @(),
+
+    [switch] $Resume,
+    [switch] $DeviceLogin,
+    [switch] $Obfuscate,
+    [switch] $SkipMetrics,
+    [switch] $SkipConsumption,
+    [int]    $ConcurrencyLimit = 6
+)
+
+# Tag used to prefix all stdout lines so the parent wrapper can demultiplex
+# interleaved output across streams.
+$Tag = "[stream-$StreamId]"
+
+function Write-Stream {
+    param([string]$Message, [string]$Color = 'Gray')
+    Write-Host ("{0} {1}" -f $Tag, $Message) -ForegroundColor $Color
+}
+
+# Empty slice = nothing to do. Write a minimal "ok with zero subs" summary so
+# the parent's aggregation step (which expects a summary file from every
+# stream) does not flag this as a missing-summary failure, and exit cleanly.
+if ($SubscriptionIds.Count -eq 0) {
+    Write-Stream "no subscriptions in slice; exiting cleanly" 'Yellow'
+    @{
+        StreamId              = $StreamId
+        Tenant                = $TenantID
+        Status                = 'ok'
+        SubsProcessed         = 0
+        Completed             = @()
+        Failed                = @()
+        ResourceCounts        = @()
+        ConsumptionRecords    = 0
+        ConsumptionFailedSubs = @()
+    } | ConvertTo-Json -Depth 5 | Set-Content -Path $StreamSummaryPath -Encoding utf8
+    exit 0
+}
+
+Write-Stream ("starting; subs in slice: {0}" -f $SubscriptionIds.Count) 'Cyan'
+
+# ---- Az context import -------------------------------------------------------
+#
+# The parent wrapper called Save-AzContext on its already-authenticated session
+# and passed us the path. Importing it gives this child process a working Az
+# context without prompting for sign-in. Import-AzContext is idempotent.
+try {
+    Import-Module Az.Accounts -ErrorAction Stop -Force | Out-Null
+    Import-AzContext -Path $AzContextPath -ErrorAction Stop | Out-Null
+    Write-Stream "Az context imported from shared snapshot" 'Green'
+} catch {
+    Write-Stream ("FATAL: could not import Az context from {0}: {1}" -f $AzContextPath, $_.Exception.Message) 'Red'
+    # Write a minimum stream summary so the parent doesn't think the stream
+    # disappeared silently.
+    @{
+        StreamId      = $StreamId
+        Tenant        = $TenantID
+        Status        = 'failed-to-start'
+        Reason        = $_.Exception.Message
+        Completed     = @()
+        Failed        = @($SubscriptionIds | ForEach-Object {
+            [pscustomobject]@{ Id = $_; Reason = 'stream did not start: Az context import failed' }
+        })
+        ResourceCounts = @()
+    } | ConvertTo-Json -Depth 5 | Set-Content -Path $StreamSummaryPath -Encoding utf8
+    exit 1
+}
+
+# ---- Per-stream resume state -------------------------------------------------
+#
+# Each stream owns a separate file. No races, no locking, simple semantics.
+$StreamStateFile = Join-Path $InventoryRoot (".resume-state-{0}-stream-{1}.json" -f $TenantID, $StreamId)
+
+function Read-StreamState {
+    param([string]$Path)
+    if (-not (Test-Path -Path $Path -PathType Leaf)) { return @() }
+    try {
+        $obj = Get-Content -Path $Path -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $obj.Completed) { return @() }
+        return @($obj.Completed)
+    } catch {
+        Write-Stream ("WARNING: could not read stream state at {0}: {1}" -f $Path, $_.Exception.Message) 'Yellow'
+        return @()
+    }
+}
+
+function Write-StreamState {
+    param([string]$Path, [string[]]$Completed)
+    try {
+        @{ Tenant = $TenantID; StreamId = $StreamId; Completed = $Completed } |
+            ConvertTo-Json -Depth 4 | Set-Content -Path $Path -Encoding utf8
+    } catch {
+        Write-Stream ("WARNING: failed to persist stream state to {0}: {1}" -f $Path, $_.Exception.Message) 'Yellow'
+    }
+}
+
+$CompletedIds = @()
+if ($Resume) {
+    $CompletedIds = Read-StreamState -Path $StreamStateFile
+    if ($CompletedIds.Count -gt 0) {
+        Write-Stream ("resume: skipping {0} previously-completed subs in this slice" -f $CompletedIds.Count) 'DarkGray'
+    }
+}
+
+# ---- Build the inner-script passthrough --------------------------------------
+$InventoryPassthrough = @{}
+if ($DeviceLogin)     { $InventoryPassthrough['DeviceLogin']     = $true }
+if ($Obfuscate)       { $InventoryPassthrough['Obfuscate']       = $true }
+if ($SkipMetrics)     { $InventoryPassthrough['SkipMetrics']     = $true }
+if ($SkipConsumption) { $InventoryPassthrough['SkipConsumption'] = $true }
+$InventoryPassthrough['ConcurrencyLimit'] = $ConcurrencyLimit
+
+# ---- Per-sub iteration -------------------------------------------------------
+#
+# This is the same shape as the wrapper's existing loop: invoke the inner
+# script via `&`, capture $Global:Resources / $Global:Consumption* afterward,
+# and record a per-sub status row for the wrapper to aggregate.
+
+$ResourceCounts        = @()
+# Plain string array. We never call .Add() on this — only `+=`, which creates a
+# new array each time. Cheaper than fighting [List[T]]::new() constructor
+# overload resolution against an empty PowerShell array argument.
+$Completed             = @($CompletedIds)
+$FailedSubs            = @()
+
+# The inner script's $Global:ConsumptionRecordCount / $Global:ConsumptionFailedSubs
+# are *running totals*: ResourceInventory.ps1 only nil-initializes them once and
+# then accumulates with += across every subscription it processes in this
+# worker's scope. Reset them to known-zero state up-front so the worker reads
+# the entire-slice running total once after the loop, instead of summing
+# per-iteration snapshots (which would double-count: 100, 300, 600 for three
+# 100-record subs).
+$Global:ConsumptionRecordCount = 0
+$Global:ConsumptionFailedSubs  = @()
+
+$pairCount = [Math]::Min($SubscriptionIds.Count, $SubscriptionNames.Count)
+for ($i = 0; $i -lt $pairCount; $i++) {
+    $subId   = $SubscriptionIds[$i]
+    $subName = $SubscriptionNames[$i]
+
+    if ($Resume -and ($Completed -contains $subId)) {
+        Write-Stream ("skipping (already completed): {0} ({1})" -f $subName, $subId) 'DarkGray'
+        continue
+    }
+
+    Write-Stream ("processing: {0} ({1})" -f $subName, $subId) 'Cyan'
+
+    try {
+        & (Join-Path $ScriptRoot 'ResourceInventory.ps1') -TenantID $TenantID -SubscriptionID $subId @InventoryPassthrough -RunAllSubs
+        # Only treat as failure if the inner script set a non-zero exit code.
+        # Some completion paths in ResourceInventory.ps1 leave $LASTEXITCODE
+        # unset ($null), and PowerShell's `-ne 0` returns $true against $null,
+        # which would spuriously fail every successful sub.
+        if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
+
+        # Capture inner-script globals while we are still in the same scope.
+        # ResourceInventory.ps1 is invoked via `&` so its $Global:Resources lives
+        # in this stream worker's scope. The inner script resets $Global:Resources
+        # to @() at the start of every invocation.
+        $resCount = if ($null -ne $Global:Resources) { @($Global:Resources).Count } else { 0 }
+        $ResourceCounts += [pscustomobject]@{ Name = $subName; Id = $subId; Count = $resCount }
+
+        if ($resCount -eq 0) {
+            Write-Stream ("WARNING: '{0}' returned 0 resources (likely permission gap or empty sub)" -f $subName) 'Yellow'
+        } else {
+            Write-Stream ("done: {0} - {1:N0} resources" -f $subName, $resCount) 'Green'
+        }
+
+        if (-not ($Completed -contains $subId)) {
+            $Completed += $subId
+            Write-StreamState -Path $StreamStateFile -Completed @($Completed)
+        }
+    } catch {
+        $errRecord = $_
+        Write-Stream ("ERROR processing {0}: {1}" -f $subName, $errRecord.Exception.Message) 'Red'
+
+        # Build a structured failure record. Append to a per-stream failures log
+        # so per-sub diagnostic detail survives even when many subs fail in one
+        # stream. Mirrors the parent wrapper's diag-log shape.
+        $diagLines = @()
+        $diagLines += "==== Failure for subscription: $subName ($subId) [$Tag] ===="
+        $diagLines += "Timestamp: $(Get-Date -Format 'o')"
+        $diagLines += "Message:   $($errRecord.Exception.Message)"
+        $diagLines += "Type:      $($errRecord.Exception.GetType().FullName)"
+        $inner = $errRecord.Exception.InnerException
+        $depth = 0
+        while ($null -ne $inner -and $depth -lt 5) {
+            $diagLines += "Inner[$depth] Type:    $($inner.GetType().FullName)"
+            $diagLines += "Inner[$depth] Message: $($inner.Message)"
+            $inner = $inner.InnerException
+            $depth++
+        }
+        if ($null -ne $errRecord.InvocationInfo) {
+            $diagLines += "ScriptName:    $($errRecord.InvocationInfo.ScriptName)"
+            $diagLines += "Line:          $($errRecord.InvocationInfo.ScriptLineNumber)"
+            $diagLines += "PositionMsg:   $($errRecord.InvocationInfo.PositionMessage)"
+        }
+        $diagLines += "StackTrace:"
+        $diagLines += $errRecord.ScriptStackTrace
+        if ($null -ne $errRecord.Exception.StackTrace) {
+            $diagLines += "ExceptionStackTrace:"
+            $diagLines += $errRecord.Exception.StackTrace
+        }
+        $diagLines += ""
+
+        try { $diagLines | Out-File -FilePath $StreamFailuresPath -Append -Encoding utf8 }
+        catch { Write-Stream ("could not write to stream failures log {0}: {1}" -f $StreamFailuresPath, $_.Exception.Message) 'Yellow' }
+
+        $FailedSubs += [pscustomobject]@{ Id = $subId; Name = $subName; Reason = $errRecord.Exception.Message }
+    }
+}
+
+# ---- Per-stream summary ------------------------------------------------------
+#
+# Single JSON file the parent wrapper aggregates across all streams.
+#
+# Read the consumption totals from the inner-script globals once, here, after
+# the entire slice has been processed. The inner script accumulates these
+# across all subs in this worker's scope (see the reset at the top of the
+# loop), so a single read at the end gives the correct slice total without
+# the per-iteration double-counting trap.
+$ConsumptionTotal      = if ($null -ne $Global:ConsumptionRecordCount) { [int]$Global:ConsumptionRecordCount } else { 0 }
+$ConsumptionFailedSubs = if ($null -ne $Global:ConsumptionFailedSubs)  { @($Global:ConsumptionFailedSubs) } else { @() }
+
+$summary = [pscustomobject]@{
+    StreamId               = $StreamId
+    Tenant                 = $TenantID
+    Status                 = if ($FailedSubs.Count -eq 0) { 'ok' } else { 'partial-failure' }
+    SubsProcessed          = $pairCount
+    Completed              = @($Completed)
+    Failed                 = $FailedSubs
+    ResourceCounts         = $ResourceCounts
+    ConsumptionRecords     = $ConsumptionTotal
+    ConsumptionFailedSubs  = @($ConsumptionFailedSubs | Select-Object -Unique)
+}
+try {
+    $summary | ConvertTo-Json -Depth 6 | Set-Content -Path $StreamSummaryPath -Encoding utf8
+} catch {
+    Write-Stream ("FATAL: could not write stream summary to {0}: {1}" -f $StreamSummaryPath, $_.Exception.Message) 'Red'
+    exit 1
+}
+
+Write-Stream ("complete: {0}/{1} succeeded, {2} failed" -f $Completed.Count, $pairCount, $FailedSubs.Count) 'Green'
+exit 0

--- a/Run-AllSubscriptions.Stream.ps1
+++ b/Run-AllSubscriptions.Stream.ps1
@@ -84,6 +84,13 @@ Write-Stream ("starting; subs in slice: {0}" -f $SubscriptionIds.Count) 'Cyan'
 # context without prompting for sign-in. Import-AzContext is idempotent.
 try {
     Import-Module Az.Accounts -ErrorAction Stop -Force | Out-Null
+    # Prevent the imported context from being persisted to the user's on-disk
+    # AzureRmContext.json. Without this, every parallel worker writes its
+    # token cache to the same shared profile and the streams race on disk
+    # state. Process-scope auto-save is per-process, so calling it here
+    # confines this worker's context to in-memory.
+    try { Disable-AzContextAutosave -Scope Process -ErrorAction Stop | Out-Null }
+    catch { Write-Stream ("WARNING: could not disable AzContext autosave: {0}" -f $_.Exception.Message) 'Yellow' }
     Import-AzContext -Path $AzContextPath -ErrorAction Stop | Out-Null
     Write-Stream "Az context imported from shared snapshot" 'Green'
 } catch {
@@ -96,8 +103,10 @@ try {
         Status        = 'failed-to-start'
         Reason        = $_.Exception.Message
         Completed     = @()
-        Failed        = @($SubscriptionIds | ForEach-Object {
-            [pscustomobject]@{ Id = $_; Reason = 'stream did not start: Az context import failed' }
+        Failed        = @(0..([Math]::Max($SubscriptionIds.Count, $SubscriptionNames.Count) - 1) | ForEach-Object {
+            $name = if ($_ -lt $SubscriptionNames.Count) { $SubscriptionNames[$_] } else { '<unknown>' }
+            $id   = if ($_ -lt $SubscriptionIds.Count)   { $SubscriptionIds[$_] }   else { '<unknown>' }
+            [pscustomobject]@{ Id = $id; Name = $name; Reason = 'stream did not start: Az context import failed' }
         })
         ResourceCounts = @()
     } | ConvertTo-Json -Depth 5 | Set-Content -Path $StreamSummaryPath -Encoding utf8

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -8,7 +8,8 @@ param (
     [switch]$Obfuscate,
     [switch]$SkipMetrics,
     [switch]$SkipConsumption,
-    [switch]$Resume
+    [switch]$Resume,
+    [switch]$IncludeDisabled
 )
 
 $RunStartTime = Get-Date
@@ -73,7 +74,28 @@ try {
 }
 
 # Get all Azure subscriptions
-$subscriptions = Get-AzSubscription
+$allSubscriptions = Get-AzSubscription
+
+# Filter out non-Enabled subscriptions by default. Disabled / Warned / Deleted
+# subscriptions return little-to-no data from Resource Graph and most ARM
+# data-plane calls, so processing them produces near-empty per-subscription
+# reports while still costing wall-clock time (which matters for environments
+# like Azure Cloud Shell where the session has a hard maximum lifetime).
+# Pass -IncludeDisabled to inventory every subscription regardless of state.
+if ($IncludeDisabled) {
+    $subscriptions = $allSubscriptions
+    $excluded = @()
+} else {
+    $subscriptions = @($allSubscriptions | Where-Object { $_.State -eq 'Enabled' })
+    $excluded     = @($allSubscriptions | Where-Object { $_.State -ne 'Enabled' })
+}
+
+Write-Host ("Subscriptions visible: {0}" -f $allSubscriptions.Count) -ForegroundColor Cyan
+if ($excluded.Count -gt 0) {
+    $byState = $excluded | Group-Object -Property State | ForEach-Object { ('{0}: {1}' -f $_.Name, $_.Count) }
+    Write-Host ("Excluded {0} non-Enabled subscription(s) [{1}]. Use -IncludeDisabled to inventory them anyway." -f $excluded.Count, ($byState -join ', ')) -ForegroundColor Yellow
+}
+Write-Host ("Subscriptions to process: {0}" -f $subscriptions.Count) -ForegroundColor Cyan
 
 # Apply resume filter (only when -Resume is explicitly passed)
 $CompletedIds = @()
@@ -170,7 +192,11 @@ if ($FailedSubscriptions.Count -eq 0 -and (Test-Path -Path $ResumeStateFile -Pat
 $Elapsed = (Get-Date) - $RunStartTime
 Write-Host ""
 Write-Host "================ Summary ================" -ForegroundColor Green
-Write-Host ("Subscriptions Total:     {0}" -f $subscriptions.Count) -ForegroundColor Green
+Write-Host ("Subscriptions Visible:   {0}" -f $allSubscriptions.Count) -ForegroundColor Green
+if ($excluded.Count -gt 0) {
+    Write-Host ("Subscriptions Excluded:  {0} (non-Enabled; use -IncludeDisabled to inventory them)" -f $excluded.Count) -ForegroundColor Green
+}
+Write-Host ("Subscriptions Eligible:  {0}" -f $subscriptions.Count) -ForegroundColor Green
 if ($Resume) {
     Write-Host ("Subscriptions Skipped:   {0} (already completed)" -f $SkippedCount) -ForegroundColor Green
 }

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -296,6 +296,7 @@ if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = 
 
 # Loop through each subscription and run ResourceInventory
 $SkippedCount = 0
+$DiagFile = $null
 foreach ($sub in $subscriptions) {
     if ($Resume -and ($CompletedIds -contains $sub.Id)) {
         Write-Host ("Skipping (already completed): {0} ({1})" -f $sub.Name, $sub.Id) -ForegroundColor DarkGray
@@ -316,7 +317,69 @@ foreach ($sub in $subscriptions) {
             Save-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID -Ids $CompletedIds
         }
     } catch {
-        Write-Host "ERROR processing subscription $($sub.Name): $_" -ForegroundColor Red
+        # Surface the full exception chain so failures (e.g. EPPlus Save errors,
+        # OOM in long CloudShell runs, file-handle leaks) are diagnosable instead
+        # of being summarised to a single line. See #16.
+        $errRecord = $_
+        Write-Host "ERROR processing subscription $($sub.Name): $errRecord" -ForegroundColor Red
+
+        $diagLines = @()
+        $diagLines += "==== Failure for subscription: $($sub.Name) ($($sub.Id)) ===="
+        $diagLines += "Timestamp: $(Get-Date -Format 'o')"
+        $diagLines += "Message:   $($errRecord.Exception.Message)"
+        $diagLines += "Type:      $($errRecord.Exception.GetType().FullName)"
+
+        $inner = $errRecord.Exception.InnerException
+        $depth = 0
+        while ($null -ne $inner -and $depth -lt 5) {
+            $diagLines += "Inner[$depth] Type:    $($inner.GetType().FullName)"
+            $diagLines += "Inner[$depth] Message: $($inner.Message)"
+            $inner = $inner.InnerException
+            $depth++
+        }
+
+        if ($null -ne $errRecord.InvocationInfo) {
+            $diagLines += "ScriptName:    $($errRecord.InvocationInfo.ScriptName)"
+            $diagLines += "Line:          $($errRecord.InvocationInfo.ScriptLineNumber)"
+            $diagLines += "PositionMsg:   $($errRecord.InvocationInfo.PositionMessage)"
+        }
+
+        $diagLines += "StackTrace:"
+        $diagLines += $errRecord.ScriptStackTrace
+        if ($null -ne $errRecord.Exception.StackTrace) {
+            $diagLines += "ExceptionStackTrace:"
+            $diagLines += $errRecord.Exception.StackTrace
+        }
+
+        # Environment snapshot — useful when CloudShell runs out of memory or disk
+        try {
+            $proc = Get-Process -Id $PID
+            $diagLines += "Process WorkingSet (MB):  $([math]::Round($proc.WorkingSet64 / 1MB, 1))"
+            $diagLines += "Process PrivateMemory (MB): $([math]::Round($proc.PrivateMemorySize64 / 1MB, 1))"
+        } catch { }
+
+        try {
+            $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+            if (Test-Path $InventoryRoot) {
+                $rootDrive = (Get-Item $InventoryRoot).PSDrive
+                if ($rootDrive) {
+                    $diagLines += "Free disk on $($rootDrive.Name): (MB): $([math]::Round($rootDrive.Free / 1MB, 1))"
+                }
+            }
+        } catch { }
+
+        $diagLines += ""
+
+        # Write to a per-run failures file so we don't lose the detail when many subs fail.
+        if ($null -eq $DiagFile) {
+            $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+            if (-not (Test-Path $InventoryRoot)) {
+                try { New-Item -ItemType Directory -Path $InventoryRoot -Force | Out-Null } catch { }
+            }
+            $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
+        }
+        try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 } catch { }
+
         $FailedSubscriptions += $sub.Name
     }
 
@@ -378,6 +441,9 @@ if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
     Write-Host ("Resume State:            {0}" -f $ResumeStateFile) -ForegroundColor Yellow
     Write-Host "Re-run with -Resume to retry failed and any unprocessed subscriptions." -ForegroundColor Yellow
+    if ($DiagFile -and (Test-Path $DiagFile)) {
+        Write-Host ("Failure Diagnostics:     {0}" -f $DiagFile) -ForegroundColor Red
+    }
 }
 Write-Host ("Execution Time:          {0}" -f $Elapsed.ToString('hh\:mm\:ss')) -ForegroundColor Green
 if ($OuterZipFile) {

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -57,16 +57,72 @@ function Save-CompletedSubscriptionIds {
     }
 }
 
-# Authenticate
+# Authenticate, but only if needed.
+#
+# In environments like Azure Cloud Shell the shell already has a valid az CLI
+# and Az PowerShell session for the signed-in user. Unconditionally calling
+# `az login` and `Connect-AzAccount` from the wrapper produces a redundant
+# browser/device-code prompt every run. The script also needs each context
+# to be on the requested tenant - if either is on a different tenant the
+# subscription queries below will return the wrong (or no) results.
+#
+# Check both contexts first; only sign in for the side that is missing or on
+# the wrong tenant. The signal we care about is the tenant, not the default
+# subscription, because per-subscription scoping is handled at use-site
+# (Set-AzContext / --subscriptions / resource-id-scoped Get-AzMetric).
+
+function Get-AzCliSignedInTenant {
+    $raw = az account show --output json 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $raw) { return $null }
+    try { return ($raw | ConvertFrom-Json).tenantId } catch { return $null }
+}
+
+function Get-AzPsSignedInTenant {
+    try {
+        $ctx = Get-AzContext -ErrorAction Stop
+        if ($null -eq $ctx -or $null -eq $ctx.Account) { return $null }
+        return $ctx.Tenant.Id
+    } catch {
+        return $null
+    }
+}
+
 try {
-    if ($DeviceLogin) {
-        az login -t $TenantID --use-device-code --only-show-errors | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "az login failed with exit code $LASTEXITCODE" }
-        Connect-AzAccount -Tenant $TenantID -UseDeviceAuthentication | Out-Null
+    $cliTenant = Get-AzCliSignedInTenant
+    $psTenant  = Get-AzPsSignedInTenant
+
+    $cliOk = ($cliTenant -eq $TenantID)
+    $psOk  = ($psTenant  -eq $TenantID)
+
+    if ($cliOk -and $psOk) {
+        Write-Host ("Existing session detected for tenant {0}; skipping interactive login." -f $TenantID) -ForegroundColor Green
     } else {
-        az login -t $TenantID --only-show-errors | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "az login failed with exit code $LASTEXITCODE" }
-        Connect-AzAccount -Tenant $TenantID | Out-Null
+        if (-not $cliOk) {
+            if ($null -eq $cliTenant) {
+                Write-Host "az CLI is not signed in; authenticating..." -ForegroundColor Cyan
+            } else {
+                Write-Host ("az CLI is signed in to tenant {0}; switching to {1}..." -f $cliTenant, $TenantID) -ForegroundColor Cyan
+            }
+            if ($DeviceLogin) {
+                az login -t $TenantID --use-device-code --only-show-errors | Out-Null
+            } else {
+                az login -t $TenantID --only-show-errors | Out-Null
+            }
+            if ($LASTEXITCODE -ne 0) { throw "az login failed with exit code $LASTEXITCODE" }
+        }
+
+        if (-not $psOk) {
+            if ($null -eq $psTenant) {
+                Write-Host "Az PowerShell is not signed in; authenticating..." -ForegroundColor Cyan
+            } else {
+                Write-Host ("Az PowerShell is signed in to tenant {0}; switching to {1}..." -f $psTenant, $TenantID) -ForegroundColor Cyan
+            }
+            if ($DeviceLogin) {
+                Connect-AzAccount -Tenant $TenantID -UseDeviceAuthentication | Out-Null
+            } else {
+                Connect-AzAccount -Tenant $TenantID | Out-Null
+            }
+        }
     }
 } catch {
     Write-Host "ERROR: Authentication failed. $_" -ForegroundColor Red

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -20,7 +20,8 @@ $FailedSubscriptions = @()
 # anything else writes to the host.
 $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
 if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {
-    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null }
+    catch { Write-Verbose ("InventoryRoot create failed at {0}: {1}" -f $InventoryRoot, $_.Exception.Message) }
 }
 
 # Wrapper-level transcript.
@@ -60,7 +61,8 @@ try {
 function Exit-Wrapper {
     param([int]$Code = 0)
     if ($WrapperTranscriptStarted) {
-        try { Stop-Transcript | Out-Null } catch { }
+        try { Stop-Transcript | Out-Null }
+        catch { Write-Verbose ("Stop-Transcript on Exit-Wrapper failed: {0}" -f $_.Exception.Message) }
     }
     exit $Code
 }
@@ -161,7 +163,8 @@ function Invoke-PreFlightChecks {
         Write-Host "  This usually means: readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle." -ForegroundColor Red
         Write-Host "  Verify the directory is writable and re-run." -ForegroundColor Red
         # Best-effort cleanup in case Set-Content partially succeeded.
-        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } }
+        catch { Write-Verbose ("Probe cleanup failed at {0}: {1}" -f $probePath, $_.Exception.Message) }
         Exit-Wrapper -Code 1
     }
 
@@ -536,7 +539,7 @@ foreach ($sub in $subscriptions) {
             $proc = Get-Process -Id $PID
             $diagLines += "Process WorkingSet (MB):  $([math]::Round($proc.WorkingSet64 / 1MB, 1))"
             $diagLines += "Process PrivateMemory (MB): $([math]::Round($proc.PrivateMemorySize64 / 1MB, 1))"
-        } catch { }
+        } catch { Write-Verbose ("Process snapshot failed: {0}" -f $_.Exception.Message) }
 
         try {
             $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
@@ -546,7 +549,7 @@ foreach ($sub in $subscriptions) {
                     $diagLines += "Free disk on $($rootDrive.Name): (MB): $([math]::Round($rootDrive.Free / 1MB, 1))"
                 }
             }
-        } catch { }
+        } catch { Write-Verbose ("Disk snapshot failed: {0}" -f $_.Exception.Message) }
 
         $diagLines += ""
 
@@ -554,11 +557,13 @@ foreach ($sub in $subscriptions) {
         if ($null -eq $DiagFile) {
             $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
             if (-not (Test-Path $InventoryRoot)) {
-                try { New-Item -ItemType Directory -Path $InventoryRoot -Force | Out-Null } catch { }
+                try { New-Item -ItemType Directory -Path $InventoryRoot -Force | Out-Null }
+                catch { Write-Verbose ("InventoryRoot create failed at {0}: {1}" -f $InventoryRoot, $_.Exception.Message) }
             }
             $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
         }
-        try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 } catch { }
+        try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 }
+        catch { Write-Verbose ("DiagFile write failed at {0}: {1}" -f $DiagFile, $_.Exception.Message) }
 
         $FailedSubscriptions += $sub.Name
     }
@@ -693,5 +698,6 @@ Write-Host "=========================================" -ForegroundColor Green
 # Stop the wrapper transcript on the normal-completion path. Error paths take
 # Exit-Wrapper which does the same.
 if ($WrapperTranscriptStarted) {
-    try { Stop-Transcript | Out-Null } catch { }
+    try { Stop-Transcript | Out-Null }
+    catch { Write-Verbose ("Stop-Transcript on normal completion failed: {0}" -f $_.Exception.Message) }
 }

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -341,6 +341,11 @@ if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = 
 # Loop through each subscription and run ResourceInventory
 $SkippedCount = 0
 $DiagFile = $null
+# Per-subscription resource counts collected for the final summary so the user
+# can see at a glance which subscriptions came back empty (the most common
+# explanation is that the signed-in identity does not have Reader on the
+# subscription, but it can also legitimately mean the subscription is empty).
+$SubResourceCounts = @()
 foreach ($sub in $subscriptions) {
     if ($Resume -and ($CompletedIds -contains $sub.Id)) {
         Write-Host ("Skipping (already completed): {0} ({1})" -f $sub.Name, $sub.Id) -ForegroundColor DarkGray
@@ -353,6 +358,31 @@ foreach ($sub in $subscriptions) {
     try {
         & (Join-Path $PSScriptRoot "ResourceInventory.ps1") -TenantID $TenantID -SubscriptionID $sub.Id @InventoryPassthrough -RunAllSubs
         if ($LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
+
+        # Capture the per-subscription resource count from the inner script.
+        # ResourceInventory.ps1 invokes via `& <path>` so its $Global:Resources
+        # lives in this wrapper's scope. The inner script resets that variable
+        # to @() at the start of every invocation, so the count after return
+        # accurately reflects the subscription that just finished.
+        $resCount = if ($null -ne $Global:Resources) { @($Global:Resources).Count } else { 0 }
+        $SubResourceCounts += [pscustomobject]@{
+            Name  = $sub.Name
+            Id    = $sub.Id
+            Count = $resCount
+        }
+
+        if ($resCount -eq 0) {
+            # Loud yellow signal so this stands out in the per-iteration narration
+            # and in the wrapper transcript. The most common cause is the signed-in
+            # identity not having Reader on the subscription; second is a sub that
+            # genuinely has no resources. Either way the user almost always wants
+            # to know immediately rather than discover it days later when the
+            # consolidated report turns out to be empty for some subs.
+            Write-Host ("WARNING: Subscription '{0}' returned 0 resources. Likely permission gap (no Reader on the subscription) or a genuinely empty subscription. Verify with: az graph query -q ""resources | summarize count()"" --subscriptions {1}" -f $sub.Name, $sub.Id) -ForegroundColor Yellow
+        } else {
+            Write-Host ("Resources collected: {0:N0}" -f $resCount) -ForegroundColor DarkGreen
+        }
+
         Write-Host "Completed subscription: $($sub.Name)" -ForegroundColor Green
 
         # Mark complete and persist immediately so a mid-run sign-out is recoverable.
@@ -481,6 +511,29 @@ if ($Resume) {
     Write-Host ("Subscriptions Skipped:   {0} (already completed)" -f $SkippedCount) -ForegroundColor Green
 }
 Write-Host ("Subscriptions Processed: {0}" -f ($subscriptions.Count - $SkippedCount)) -ForegroundColor Green
+
+# Surface the per-subscription resource-count result so the user does not have
+# to scan individual transcripts to find subs that came back empty. Empty subs
+# are shown distinctly because they almost always indicate a permission gap;
+# treating them as "successful" in the summary is misleading.
+$EmptySubs = @($SubResourceCounts | Where-Object { $_.Count -eq 0 })
+$NonEmptySubs = @($SubResourceCounts | Where-Object { $_.Count -gt 0 })
+if ($SubResourceCounts.Count -gt 0) {
+    $totalRes = ($SubResourceCounts | Measure-Object -Property Count -Sum).Sum
+    Write-Host ("Total Resources:         {0:N0} across {1} subscription(s)" -f $totalRes, $NonEmptySubs.Count) -ForegroundColor Green
+}
+if ($EmptySubs.Count -gt 0) {
+    Write-Host ""
+    Write-Host ("Subscriptions Empty:     {0} (returned 0 resources)" -f $EmptySubs.Count) -ForegroundColor Yellow
+    Write-Host "  Likely permission gap (no Reader on the subscription) or genuinely empty subscription." -ForegroundColor Yellow
+    Write-Host "  Verify Reader access for these specifically:" -ForegroundColor Yellow
+    foreach ($e in $EmptySubs) {
+        Write-Host ("    - {0} ({1})" -f $e.Name, $e.Id) -ForegroundColor Yellow
+    }
+    Write-Host "  Acid test: az graph query -q ""resources | summarize count()"" --subscriptions <id>" -ForegroundColor Yellow
+    Write-Host ""
+}
+
 if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
     Write-Host ("Resume State:            {0}" -f $ResumeStateFile) -ForegroundColor Yellow

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -534,6 +534,36 @@ if ($EmptySubs.Count -gt 0) {
     Write-Host ""
 }
 
+# Surface consumption (billing) data health. The inner script's consumption
+# loop populates these globals; if every Get-UsageAggregates call failed
+# (typically because the Az PowerShell module is broken on disk and cannot
+# load its bundled MSAL/Azure.Core assemblies) the customer ends up with an
+# empty consumption sheet and no signal that anything went wrong. Make it
+# loud here so it's caught before the report is shared.
+$consumptionRecords = if ($null -ne $Global:ConsumptionRecordCount) { [int]$Global:ConsumptionRecordCount } else { 0 }
+$consumptionFailures = if ($null -ne $Global:ConsumptionFailedSubs) { @($Global:ConsumptionFailedSubs) } else { @() }
+if ($consumptionRecords -gt 0 -or $consumptionFailures.Count -gt 0) {
+    Write-Host ("Consumption Records:     {0:N0} record(s) collected" -f $consumptionRecords) -ForegroundColor Green
+}
+if ($consumptionFailures.Count -gt 0) {
+    Write-Host ""
+    Write-Host ("Consumption Failures:    {0} subscription(s)" -f $consumptionFailures.Count) -ForegroundColor Yellow
+    # The consumption failure message is repeated verbatim across every sub
+    # when the cause is a broken Az module - dedupe to avoid screen wall.
+    $uniqueMessages = @($consumptionFailures | Select-Object -ExpandProperty Message -Unique)
+    foreach ($m in $uniqueMessages) {
+        Write-Host ("  - {0}" -f $m) -ForegroundColor Yellow
+    }
+    if ($uniqueMessages | Where-Object { $_ -match 'context has not been properly initialized|Could not load file or assembly|MSAL|Azure\.Core' }) {
+        Write-Host "  This message strongly suggests the Az PowerShell module is broken on disk." -ForegroundColor Yellow
+        Write-Host "  Reinstall with:" -ForegroundColor Yellow
+        Write-Host "    Get-Module Az* -ListAvailable | Uninstall-Module -Force" -ForegroundColor Yellow
+        Write-Host "    Install-Module -Name Az -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck" -ForegroundColor Yellow
+    }
+    Write-Host "  Note: the consumption sheet in the output report may be empty or incomplete for these subscriptions." -ForegroundColor Yellow
+    Write-Host ""
+}
+
 if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
     Write-Host ("Resume State:            {0}" -f $ResumeStateFile) -ForegroundColor Yellow

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -65,6 +65,112 @@ function Exit-Wrapper {
     exit $Code
 }
 
+# === Pre-flight checks ===
+#
+# Detect the most common environment problems that make a long run pointless,
+# before authentication, tenant resolution, or any per-subscription work.
+# Each check is one of:
+#   - Hard fail: print a clear message + remediation, call Exit-Wrapper.
+#   - Warn:      print a clear message and continue (the run will still
+#                produce useful output, just with a known caveat).
+#
+# NOTE: Keep this block in sync with the same block at the top of
+# ResourceInventory.ps1 (just before its Start-Transcript call). They are
+# inlined in both files rather than dot-sourced from a shared file because
+# the dot-source itself is a failure surface (path resolution, missing file)
+# we do not want to add to a script whose entire job is to fail loudly when
+# the environment is wrong.
+function Invoke-PreFlightChecks {
+    param(
+        [Parameter(Mandatory = $true)] [string] $InventoryRoot
+    )
+
+    Write-Host "Running pre-flight checks..." -ForegroundColor Cyan
+
+    # 1. Cloud Shell mount detection.
+    #
+    # Get-CloudDrive ships with the Az.CloudShell module which is preloaded
+    # in Cloud Shell and not present in regular PowerShell installs. So the
+    # cmdlet's existence is our "are we in Cloud Shell" probe; its return
+    # value is our "is the drive mounted" probe.
+    #   - Cmdlet absent       -> not in Cloud Shell, skip the check entirely.
+    #   - Cmdlet present, $null returned -> Cloud Shell, ephemeral mode
+    #                            (verified live: emits "Clouddrive is not
+    #                            mounted" warning on stream 3 and returns null).
+    #   - Cmdlet present, object returned -> Cloud Shell, drive mounted.
+    # The 3>$null suppresses the noisy WARNING so our message is the first
+    # thing the user sees.
+    if (Get-Command Get-CloudDrive -ErrorAction SilentlyContinue) {
+        $CheckCloudDrive = Get-CloudDrive 3>$null 2>$null
+        if ($null -eq $CheckCloudDrive) {
+            Write-Host ""
+            Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
+            Write-Host "  Outputs in $InventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
+            Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
+            Write-Host "    clouddrive mount" -ForegroundColor Yellow
+            Write-Host "  Continuing in ephemeral mode - download the report ZIP from $InventoryRoot before closing the shell." -ForegroundColor Yellow
+            Write-Host ""
+        } else {
+            Write-Host ("Cloud Shell drive mounted: {0}" -f $CheckCloudDrive.Name) -ForegroundColor Green
+        }
+    }
+
+    # 2. Disk space probe at the inventory root.
+    #
+    # Cloud Shell quota is 5 GB total. A 100+ subscription run can produce
+    # 200+ MB of zips and intermediate files; if free space is already low
+    # the run will fail late with a confusing "There is not enough space"
+    # somewhere deep in EPPlus. Catch it now.
+    try {
+        $rootItem = Get-Item -Path $InventoryRoot -ErrorAction Stop
+        $drive = $rootItem.PSDrive
+        if ($null -ne $drive -and $null -ne $drive.Free) {
+            $freeMB = [math]::Round($drive.Free / 1MB, 0)
+            if ($freeMB -lt 100) {
+                Write-Host ("ERROR: Free disk space at {0} is {1} MB. The script needs at least 100 MB to start. Free space and re-run." -f $InventoryRoot, $freeMB) -ForegroundColor Red
+                Exit-Wrapper -Code 1
+            } elseif ($freeMB -lt 500) {
+                Write-Host ("WARNING: Free disk space at {0} is {1} MB. A large multi-subscription run can exceed this. Consider freeing space before running." -f $InventoryRoot, $freeMB) -ForegroundColor Yellow
+            } else {
+                Write-Host ("Free disk space: {0:N0} MB at {1}" -f $freeMB, $InventoryRoot) -ForegroundColor Green
+            }
+        }
+    } catch {
+        # If we cannot read free space (uncommon - usually means the inventory
+        # root is on an exotic filesystem), warn but do not fail. The write
+        # probe below is the real correctness gate.
+        Write-Host ("WARNING: Could not determine free disk space at {0}: {1}" -f $InventoryRoot, $_.Exception.Message) -ForegroundColor Yellow
+    }
+
+    # 3. Write probe.
+    #
+    # Catches any reason the script cannot create files in $InventoryRoot:
+    # readonly mount, permissions, antivirus quarantine, DLP product, etc.
+    # Cheap (~1 ms) and definitive.
+    $probePath = Join-Path $InventoryRoot (".write-probe-{0}.tmp" -f ([guid]::NewGuid()))
+    try {
+        Set-Content -Path $probePath -Value 'preflight write probe' -Encoding utf8 -ErrorAction Stop
+        $probeRead = Get-Content -Path $probePath -Raw -ErrorAction Stop
+        if ($probeRead -notmatch 'preflight write probe') {
+            throw "Write probe content mismatch (read back '$probeRead')"
+        }
+        Remove-Item -Path $probePath -Force -ErrorAction Stop
+        Write-Host ("Write probe: OK ({0})" -f $InventoryRoot) -ForegroundColor Green
+    } catch {
+        Write-Host ("ERROR: Cannot write to {0}: {1}" -f $InventoryRoot, $_.Exception.Message) -ForegroundColor Red
+        Write-Host "  This usually means: readonly directory, denied permissions, antivirus or DLP product blocking writes, or a stale handle." -ForegroundColor Red
+        Write-Host "  Verify the directory is writable and re-run." -ForegroundColor Red
+        # Best-effort cleanup in case Set-Content partially succeeded.
+        try { if (Test-Path $probePath) { Remove-Item -Path $probePath -Force -ErrorAction SilentlyContinue } } catch { }
+        Exit-Wrapper -Code 1
+    }
+
+    Write-Host "Pre-flight checks passed." -ForegroundColor Green
+    Write-Host ""
+}
+
+Invoke-PreFlightChecks -InventoryRoot $InventoryRoot
+
 # Resolve a tenant identifier to a tenant GUID.
 #
 # -TenantID may be passed as either a GUID (the canonical form) or as a verified

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -111,14 +111,21 @@ function Save-CompletedSubscriptionIds {
 # In environments like Azure Cloud Shell the shell already has a valid az CLI
 # and Az PowerShell session for the signed-in user. Unconditionally calling
 # `az login` and `Connect-AzAccount` from the wrapper produces a redundant
-# browser/device-code prompt every run. The script also needs each context
-# to be on the requested tenant - if either is on a different tenant the
-# subscription queries below will return the wrong (or no) results.
+# browser/device-code prompt every run.
 #
-# Check both contexts first; only sign in for the side that is missing or on
-# the wrong tenant. The signal we care about is the tenant, not the default
-# subscription, because per-subscription scoping is handled at use-site
-# (Set-AzContext / --subscriptions / resource-id-scoped Get-AzMetric).
+# Two things have to be true to skip the interactive login:
+#   1. The cached context for each side must be on the requested tenant.
+#   2. That cached context must still be able to *acquire a token* silently.
+# Condition 1 alone is not enough: a context can persist on disk (e.g. in
+# ~/.Azure/AzureRmContext.json) with the right tenant ID but an expired or
+# revoked refresh token. In that state Azure AD requires user interaction
+# (typically driven by Conditional Access or MFA), so any data-plane call
+# from inside the script will emit a warning like "Unable to acquire token
+# for tenant ... User interaction is required" and silently return nothing -
+# producing an empty inventory rather than failing loudly.
+#
+# Therefore the gate probes token acquisition for the requested tenant on both
+# sides. Only if both probes succeed do we skip the login.
 
 function Get-AzCliSignedInTenant {
     $raw = az account show --output json 2>$null
@@ -136,21 +143,57 @@ function Get-AzPsSignedInTenant {
     }
 }
 
+# Probe whether az CLI can silently acquire a token for $TenantID.
+# Returns $true on success, $false on any failure.
+function Test-AzCliTokenSilent {
+    param([Parameter(Mandatory=$true)][string]$Tenant)
+    az account get-access-token --tenant $Tenant --output none 2>$null
+    return ($LASTEXITCODE -eq 0)
+}
+
+# Probe whether Az PowerShell can silently acquire a token for $TenantID.
+# Get-AzAccessToken in this configuration emits a non-terminating warning
+# instead of throwing on token-acquisition failure, so we capture warnings
+# explicitly and treat any warning as a failure signal in addition to
+# catching outright exceptions.
+function Test-AzPsTokenSilent {
+    param([Parameter(Mandatory=$true)][string]$Tenant)
+    $warnings = @()
+    try {
+        $token = Get-AzAccessToken -TenantId $Tenant -ErrorAction Stop -WarningVariable warnings -WarningAction SilentlyContinue
+        if ($null -eq $token -or [string]::IsNullOrWhiteSpace($token.Token)) { return $false }
+        if ($warnings.Count -gt 0) { return $false }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 try {
     $cliTenant = Get-AzCliSignedInTenant
     $psTenant  = Get-AzPsSignedInTenant
 
-    $cliOk = ($cliTenant -eq $TenantID)
-    $psOk  = ($psTenant  -eq $TenantID)
+    $cliTenantOk = ($cliTenant -eq $TenantID)
+    $psTenantOk  = ($psTenant  -eq $TenantID)
+
+    $cliTokenOk = $false
+    $psTokenOk  = $false
+    if ($cliTenantOk) { $cliTokenOk = Test-AzCliTokenSilent -Tenant $TenantID }
+    if ($psTenantOk)  { $psTokenOk  = Test-AzPsTokenSilent  -Tenant $TenantID }
+
+    $cliOk = $cliTenantOk -and $cliTokenOk
+    $psOk  = $psTenantOk  -and $psTokenOk
 
     if ($cliOk -and $psOk) {
-        Write-Host ("Existing session detected for tenant {0}; skipping interactive login." -f $TenantID) -ForegroundColor Green
+        Write-Host ("Existing session detected for tenant {0} (token probe ok); skipping interactive login." -f $TenantID) -ForegroundColor Green
     } else {
         if (-not $cliOk) {
             if ($null -eq $cliTenant) {
                 Write-Host "az CLI is not signed in; authenticating..." -ForegroundColor Cyan
-            } else {
+            } elseif (-not $cliTenantOk) {
                 Write-Host ("az CLI is signed in to tenant {0}; switching to {1}..." -f $cliTenant, $TenantID) -ForegroundColor Cyan
+            } else {
+                Write-Host ("az CLI session for tenant {0} cannot acquire a token silently (likely expired or CA/MFA-gated); re-authenticating..." -f $TenantID) -ForegroundColor Cyan
             }
             if ($DeviceLogin) {
                 az login -t $TenantID --use-device-code --only-show-errors | Out-Null
@@ -163,8 +206,10 @@ try {
         if (-not $psOk) {
             if ($null -eq $psTenant) {
                 Write-Host "Az PowerShell is not signed in; authenticating..." -ForegroundColor Cyan
-            } else {
+            } elseif (-not $psTenantOk) {
                 Write-Host ("Az PowerShell is signed in to tenant {0}; switching to {1}..." -f $psTenant, $TenantID) -ForegroundColor Cyan
+            } else {
+                Write-Host ("Az PowerShell session for tenant {0} cannot acquire a token silently (likely expired or CA/MFA-gated); re-authenticating..." -f $TenantID) -ForegroundColor Cyan
             }
             if ($DeviceLogin) {
                 Connect-AzAccount -Tenant $TenantID -UseDeviceAuthentication | Out-Null
@@ -178,8 +223,31 @@ try {
     exit 1
 }
 
-# Get all Azure subscriptions
-$allSubscriptions = Get-AzSubscription
+# Get all Azure subscriptions.
+#
+# Get-AzSubscription emits warnings (rather than throwing) when token
+# acquisition for a tenant fails - typically due to CA/MFA gating. In that
+# state the cmdlet returns no subscriptions, which would otherwise cause
+# this wrapper to report "All subscriptions processed!" with an empty
+# inventory. Capture warnings and treat zero-results-with-warnings as a
+# loud failure instead of a silent one.
+$subWarnings = @()
+$allSubscriptions = Get-AzSubscription -TenantId $TenantID -WarningVariable subWarnings -WarningAction SilentlyContinue
+if ($null -eq $allSubscriptions) { $allSubscriptions = @() }
+$allSubscriptions = @($allSubscriptions)
+
+if ($allSubscriptions.Count -eq 0) {
+    Write-Host ("ERROR: Get-AzSubscription returned no subscriptions for tenant {0}." -f $TenantID) -ForegroundColor Red
+    if ($subWarnings.Count -gt 0) {
+        Write-Host "Underlying warnings:" -ForegroundColor Red
+        foreach ($w in $subWarnings) { Write-Host ("  - {0}" -f $w) -ForegroundColor Red }
+        Write-Host "This typically indicates the cached session cannot acquire a token (Conditional Access / MFA), or the signed-in identity has no access to any subscription in this tenant." -ForegroundColor Yellow
+        Write-Host "Try re-running with -DeviceLogin, or sign out and sign back in to the requested tenant." -ForegroundColor Yellow
+    } else {
+        Write-Host "The signed-in identity may have no subscriptions in this tenant. Verify with 'Get-AzSubscription -TenantId <id>' interactively." -ForegroundColor Yellow
+    }
+    exit 1
+}
 
 # Filter out non-Enabled subscriptions by default. Disabled / Warned / Deleted
 # subscriptions return little-to-no data from Resource Graph and most ARM

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -15,6 +15,56 @@ param (
 $RunStartTime = Get-Date
 $FailedSubscriptions = @()
 
+# Inventory root (used for resume state, consolidated output, and the wrapper
+# transcript). Computed up front so the transcript can be started before
+# anything else writes to the host.
+$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {
+    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+}
+
+# Wrapper-level transcript.
+#
+# ResourceInventory.ps1 already records a per-subscription transcript inside
+# each subscription's output folder. That captures everything inside a single
+# sub's run, but it does not capture the wrapper's own output: tenant
+# resolution, the auth gate's decisions, resume-state messages, the
+# Processing/Completed/ERROR cross-iteration narration, the consolidation
+# step, or the final summary. For multi-subscription runs that bookkeeping is
+# the most useful diagnostic signal of all - which sub failed, why, what came
+# before, and how the wrapper proceeded.
+#
+# This transcript runs at the wrapper level for every invocation (single sub
+# or many) and lands at:
+#   <InventoryRoot>/RunAllSubscriptions_transcript_<timestamp>.txt
+# It also catches everything Write-Host'd by the inner script into the same
+# console session, so the file is a complete record of one wrapper invocation.
+# Start-Transcript is idempotent in the sense that we Stop it on every exit
+# path via Exit-Wrapper.
+$WrapperTranscriptStarted = $false
+$WrapperTranscriptFile = Join-Path $InventoryRoot ("RunAllSubscriptions_transcript_{0}.txt" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
+try {
+    Start-Transcript -Path $WrapperTranscriptFile -UseMinimalHeader -Force | Out-Null
+    $WrapperTranscriptStarted = $true
+    Write-Host ("Wrapper transcript: {0}" -f $WrapperTranscriptFile) -ForegroundColor DarkGray
+} catch {
+    # Non-fatal. If transcript fails to start (rare - usually permissions or
+    # an already-running transcript on this host), the run continues without
+    # one rather than aborting.
+    Write-Host ("WARNING: Could not start wrapper transcript at {0}: {1}" -f $WrapperTranscriptFile, $_.Exception.Message) -ForegroundColor Yellow
+}
+
+# Single exit path that ensures the wrapper transcript is stopped before
+# returning to the host. Used by every error path that previously called
+# `exit <code>` directly.
+function Exit-Wrapper {
+    param([int]$Code = 0)
+    if ($WrapperTranscriptStarted) {
+        try { Stop-Transcript | Out-Null } catch { }
+    }
+    exit $Code
+}
+
 # Resolve a tenant identifier to a tenant GUID.
 #
 # -TenantID may be passed as either a GUID (the canonical form) or as a verified
@@ -61,13 +111,7 @@ try {
     $TenantID = Resolve-TenantId -Value $TenantID
 } catch {
     Write-Host ("ERROR: {0}" -f $_.Exception.Message) -ForegroundColor Red
-    exit 1
-}
-
-# Inventory root (used for resume state and consolidated output)
-$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
-if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {
-    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+    Exit-Wrapper -Code 1
 }
 
 # Resume state helpers
@@ -220,7 +264,7 @@ try {
     }
 } catch {
     Write-Host "ERROR: Authentication failed. $_" -ForegroundColor Red
-    exit 1
+    Exit-Wrapper -Code 1
 }
 
 # Get all Azure subscriptions.
@@ -246,7 +290,7 @@ if ($allSubscriptions.Count -eq 0) {
     } else {
         Write-Host "The signed-in identity may have no subscriptions in this tenant. Verify with 'Get-AzSubscription -TenantId <id>' interactively." -ForegroundColor Yellow
     }
-    exit 1
+    Exit-Wrapper -Code 1
 }
 
 # Filter out non-Enabled subscriptions by default. Disabled / Warned / Deleted
@@ -444,9 +488,21 @@ if ($FailedSubscriptions.Count -gt 0) {
     if ($DiagFile -and (Test-Path $DiagFile)) {
         Write-Host ("Failure Diagnostics:     {0}" -f $DiagFile) -ForegroundColor Red
     }
+    if ($WrapperTranscriptStarted) {
+        Write-Host ("Wrapper Transcript:      {0}" -f $WrapperTranscriptFile) -ForegroundColor Red
+    }
 }
 Write-Host ("Execution Time:          {0}" -f $Elapsed.ToString('hh\:mm\:ss')) -ForegroundColor Green
 if ($OuterZipFile) {
     Write-Host ("Consolidated Report:     {0}" -f $OuterZipFile) -ForegroundColor Green
 }
+if ($WrapperTranscriptStarted) {
+    Write-Host ("Wrapper Transcript:      {0}" -f $WrapperTranscriptFile) -ForegroundColor Green
+}
 Write-Host "=========================================" -ForegroundColor Green
+
+# Stop the wrapper transcript on the normal-completion path. Error paths take
+# Exit-Wrapper which does the same.
+if ($WrapperTranscriptStarted) {
+    try { Stop-Transcript | Out-Null } catch { }
+}

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -15,6 +15,55 @@ param (
 $RunStartTime = Get-Date
 $FailedSubscriptions = @()
 
+# Resolve a tenant identifier to a tenant GUID.
+#
+# -TenantID may be passed as either a GUID (the canonical form) or as a verified
+# domain (e.g. "contoso.onmicrosoft.com" or "contoso.com"). When given a domain,
+# resolve it to the GUID via Microsoft's public OIDC discovery endpoint:
+#
+#   https://login.microsoftonline.com/<domain>/v2.0/.well-known/openid-configuration
+#
+# That endpoint is anonymous (no sign-in required) and returns a JSON document
+# whose "issuer" field embeds the tenant GUID. Resolving up front means every
+# downstream call (az login, Get-AzSubscription, the resume state filename, the
+# auth gate) operates on a stable identifier even if Azure later renames the
+# domain.
+function Resolve-TenantId {
+    param([Parameter(Mandatory=$true)][string]$Value)
+
+    $guidPattern = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    if ($Value -match $guidPattern) { return $Value }
+
+    $url = "https://login.microsoftonline.com/$Value/v2.0/.well-known/openid-configuration"
+    Write-Host ("Resolving tenant '{0}' via OIDC discovery..." -f $Value) -ForegroundColor Cyan
+    try {
+        $config = Invoke-RestMethod -Uri $url -Method Get -ErrorAction Stop
+    } catch {
+        throw "Could not resolve tenant '$Value' to a GUID. Check that it is a valid Azure AD domain or pass the tenant GUID directly. Underlying error: $($_.Exception.Message)"
+    }
+
+    if ($null -eq $config -or [string]::IsNullOrWhiteSpace($config.issuer)) {
+        throw "OIDC discovery for tenant '$Value' returned an unexpected response (no issuer)."
+    }
+
+    # issuer looks like https://login.microsoftonline.com/<guid>/v2.0
+    $segments = $config.issuer -split '/'
+    $resolved = $segments | Where-Object { $_ -match $guidPattern } | Select-Object -First 1
+    if (-not $resolved) {
+        throw "OIDC discovery for tenant '$Value' did not contain a recognizable tenant GUID. issuer='$($config.issuer)'"
+    }
+
+    Write-Host ("Resolved tenant '{0}' -> {1}" -f $Value, $resolved) -ForegroundColor Green
+    return $resolved
+}
+
+try {
+    $TenantID = Resolve-TenantId -Value $TenantID
+} catch {
+    Write-Host ("ERROR: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    exit 1
+}
+
 # Inventory root (used for resume state and consolidated output)
 $InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
 if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -7,11 +7,54 @@ param (
     [switch]$DeviceLogin,
     [switch]$Obfuscate,
     [switch]$SkipMetrics,
-    [switch]$SkipConsumption
+    [switch]$SkipConsumption,
+    [switch]$Resume
 )
 
 $RunStartTime = Get-Date
 $FailedSubscriptions = @()
+
+# Inventory root (used for resume state and consolidated output)
+$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
+if (-not (Test-Path -Path $InventoryRoot -PathType Container)) {
+    try { New-Item -Path $InventoryRoot -ItemType Directory -Force | Out-Null } catch { }
+}
+
+# Resume state helpers
+$ResumeStateFile = Join-Path $InventoryRoot (".resume-state-{0}.json" -f $TenantID)
+
+function Get-CompletedSubscriptionIds {
+    param([string]$Path, [string]$Tenant)
+
+    if (-not (Test-Path -Path $Path -PathType Leaf)) { return @() }
+    try {
+        $state = Get-Content -Path $Path -Raw | ConvertFrom-Json
+        if ($state.TenantID -ne $Tenant) {
+            Write-Host ("Resume state file is for a different tenant ({0}); ignoring." -f $state.TenantID) -ForegroundColor Yellow
+            return @()
+        }
+        if ($null -eq $state.CompletedSubscriptionIds) { return @() }
+        return @($state.CompletedSubscriptionIds)
+    } catch {
+        Write-Host ("Could not read resume state file ({0}); starting fresh. $_" -f $Path) -ForegroundColor Yellow
+        return @()
+    }
+}
+
+function Save-CompletedSubscriptionIds {
+    param([string]$Path, [string]$Tenant, [string[]]$Ids)
+
+    $state = [pscustomobject]@{
+        TenantID                  = $Tenant
+        CompletedSubscriptionIds  = @($Ids)
+        LastUpdated               = (Get-Date).ToString('o')
+    }
+    try {
+        $state | ConvertTo-Json -Depth 4 | Set-Content -Path $Path -Encoding utf8
+    } catch {
+        Write-Host ("WARNING: Failed to persist resume state to {0}: $_" -f $Path) -ForegroundColor Yellow
+    }
+}
 
 # Authenticate
 try {
@@ -32,6 +75,22 @@ try {
 # Get all Azure subscriptions
 $subscriptions = Get-AzSubscription
 
+# Apply resume filter (only when -Resume is explicitly passed)
+$CompletedIds = @()
+if ($Resume) {
+    $CompletedIds = Get-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID
+    if ($CompletedIds.Count -gt 0) {
+        Write-Host ("Resume mode: {0} previously completed subscription(s) will be skipped." -f $CompletedIds.Count) -ForegroundColor Cyan
+    } else {
+        Write-Host "Resume mode: no previous state found; processing all subscriptions." -ForegroundColor Cyan
+    }
+} else {
+    # Without -Resume, do not auto-skip. Inform the user if stale state exists.
+    if (Test-Path -Path $ResumeStateFile -PathType Leaf) {
+        Write-Host ("Note: resume state file exists at {0}. Pass -Resume to skip previously completed subscriptions." -f $ResumeStateFile) -ForegroundColor Yellow
+    }
+}
+
 # Build passthrough hashtable for optional switches
 $InventoryPassthrough = @{}
 if ($DeviceLogin)      { $InventoryPassthrough['DeviceLogin'] = $true }
@@ -41,13 +100,26 @@ if ($SkipConsumption)  { $InventoryPassthrough['SkipConsumption'] = $true }
 if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = $true }
 
 # Loop through each subscription and run ResourceInventory
+$SkippedCount = 0
 foreach ($sub in $subscriptions) {
+    if ($Resume -and ($CompletedIds -contains $sub.Id)) {
+        Write-Host ("Skipping (already completed): {0} ({1})" -f $sub.Name, $sub.Id) -ForegroundColor DarkGray
+        $SkippedCount++
+        continue
+    }
+
     Write-Host "Processing subscription: $($sub.Name) ($($sub.Id))" -ForegroundColor Cyan
 
     try {
         & (Join-Path $PSScriptRoot "ResourceInventory.ps1") -TenantID $TenantID -SubscriptionID $sub.Id @InventoryPassthrough -RunAllSubs
         if ($LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
         Write-Host "Completed subscription: $($sub.Name)" -ForegroundColor Green
+
+        # Mark complete and persist immediately so a mid-run sign-out is recoverable.
+        if (-not ($CompletedIds -contains $sub.Id)) {
+            $CompletedIds += $sub.Id
+            Save-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID -Ids $CompletedIds
+        }
     } catch {
         Write-Host "ERROR processing subscription $($sub.Name): $_" -ForegroundColor Red
         $FailedSubscriptions += $sub.Name
@@ -59,7 +131,6 @@ foreach ($sub in $subscriptions) {
 Write-Host "All subscriptions processed!" -ForegroundColor Green
 
 # Consolidate per-subscription ZIPs into a single outer ZIP
-$InventoryRoot = if ($PSVersionTable.Platform -eq 'Unix') { "$HOME/InventoryReports" } else { "C:\InventoryReports" }
 $OuterZipFile = $null
 
 if (Test-Path -Path $InventoryRoot -PathType Container) {
@@ -84,13 +155,30 @@ if (Test-Path -Path $InventoryRoot -PathType Container) {
     Write-Host ("Inventory root not found at {0}. Nothing to consolidate." -f $InventoryRoot) -ForegroundColor Yellow
 }
 
+# Clean up resume state on a fully successful run (all subs processed, no failures).
+# Otherwise leave it so the next invocation with -Resume can pick up where this stopped.
+if ($FailedSubscriptions.Count -eq 0 -and (Test-Path -Path $ResumeStateFile -PathType Leaf)) {
+    try {
+        Remove-Item -Path $ResumeStateFile -Force
+        Write-Host "Resume state cleared (clean run)." -ForegroundColor Green
+    } catch {
+        Write-Host ("WARNING: Could not remove resume state file {0}: $_" -f $ResumeStateFile) -ForegroundColor Yellow
+    }
+}
+
 # Final summary
 $Elapsed = (Get-Date) - $RunStartTime
 Write-Host ""
 Write-Host "================ Summary ================" -ForegroundColor Green
-Write-Host ("Subscriptions Processed: {0}" -f $subscriptions.Count) -ForegroundColor Green
+Write-Host ("Subscriptions Total:     {0}" -f $subscriptions.Count) -ForegroundColor Green
+if ($Resume) {
+    Write-Host ("Subscriptions Skipped:   {0} (already completed)" -f $SkippedCount) -ForegroundColor Green
+}
+Write-Host ("Subscriptions Processed: {0}" -f ($subscriptions.Count - $SkippedCount)) -ForegroundColor Green
 if ($FailedSubscriptions.Count -gt 0) {
     Write-Host ("Subscriptions Failed:    {0} ({1})" -f $FailedSubscriptions.Count, ($FailedSubscriptions -join ', ')) -ForegroundColor Red
+    Write-Host ("Resume State:            {0}" -f $ResumeStateFile) -ForegroundColor Yellow
+    Write-Host "Re-run with -Resume to retry failed and any unprocessed subscriptions." -ForegroundColor Yellow
 }
 Write-Host ("Execution Time:          {0}" -f $Elapsed.ToString('hh\:mm\:ss')) -ForegroundColor Green
 if ($OuterZipFile) {

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -20,7 +20,27 @@ param (
     # without hitting Azure Monitor's 12,000 reads/hour/subscription ceiling.
     # Don't go above ~24 in a single tenant - tenant-scoped Resource Graph
     # rate limits start to bite.
-    [int]$ConcurrencyLimit = 6
+    [int]$ConcurrencyLimit = 6,
+
+    # Number of parallel "streams" that process subscriptions concurrently.
+    # Default 1 = current sequential behavior, no change. Each stream is a
+    # separate `pwsh` background process with its own Az PowerShell context
+    # and its own resume-state file (.resume-state-<TenantID>-stream-<N>.json),
+    # so they cannot race on the shared Az static state or the resume file.
+    # The wrapper splits the eligible subscription list into N approximately
+    # equal chunks at the start and assigns one chunk per stream.
+    #
+    # Practical guidance:
+    #   1   = sequential (default, lowest memory, easiest to debug)
+    #   2-4 = recommended for most large-tenant runs
+    #   5-8 = only if you've validated memory headroom (each stream loads its
+    #         own Az module set, ~400MB resident; on Cloud Shell's 5GB cap,
+    #         4 streams is the practical ceiling)
+    #
+    # Tenant-scoped Azure Resource Graph rate limits (~15 req/sec/tenant) are
+    # the hard ceiling - more than ~6 parallel streams in one tenant will
+    # start to throttle and provide no further wall-time benefit.
+    [int]$ParallelStreams = 1
 )
 
 $RunStartTime = Get-Date
@@ -434,19 +454,20 @@ if ($excluded.Count -gt 0) {
 }
 Write-Host ("Subscriptions to process: {0}" -f $subscriptions.Count) -ForegroundColor Cyan
 
-# Apply resume filter (only when -Resume is explicitly passed)
-$CompletedIds = @()
+# Always seed $CompletedIds from the existing state file. -Resume only
+# controls whether we *use* that list to skip subscriptions; reading it
+# either way ensures the per-iteration writes below append to existing
+# state instead of overwriting it.
+$CompletedIds = Get-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID
 if ($Resume) {
-    $CompletedIds = Get-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID
     if ($CompletedIds.Count -gt 0) {
         Write-Host ("Resume mode: {0} previously completed subscription(s) will be skipped." -f $CompletedIds.Count) -ForegroundColor Cyan
     } else {
         Write-Host "Resume mode: no previous state found; processing all subscriptions." -ForegroundColor Cyan
     }
 } else {
-    # Without -Resume, do not auto-skip. Inform the user if stale state exists.
-    if (Test-Path -Path $ResumeStateFile -PathType Leaf) {
-        Write-Host ("Note: resume state file exists at {0}. Pass -Resume to skip previously completed subscriptions." -f $ResumeStateFile) -ForegroundColor Yellow
+    if ($CompletedIds.Count -gt 0) {
+        Write-Host ("Note: resume state file exists at {0} ({1} previously completed). Pass -Resume to skip them." -f $ResumeStateFile, $CompletedIds.Count) -ForegroundColor Yellow
     }
 }
 
@@ -471,6 +492,10 @@ $DiagFile = $null
 # explanation is that the signed-in identity does not have Reader on the
 # subscription, but it can also legitimately mean the subscription is empty).
 $SubResourceCounts = @()
+
+if ($ParallelStreams -le 1) {
+    # === SEQUENTIAL PATH (default) ============================================
+    # Original behavior, unchanged. Selected when -ParallelStreams 1 or unset.
 foreach ($sub in $subscriptions) {
     if ($Resume -and ($CompletedIds -contains $sub.Id)) {
         Write-Host ("Skipping (already completed): {0} ({1})" -f $sub.Name, $sub.Id) -ForegroundColor DarkGray
@@ -585,6 +610,329 @@ foreach ($sub in $subscriptions) {
     }
 
     Write-Host "-----------------------------------" -ForegroundColor Gray
+}
+
+} else {
+    # === PARALLEL-STREAMS PATH ================================================
+    #
+    # Each "stream" is a separate `pwsh` background job (Start-Job runs the
+    # provided ScriptBlock in a fresh process). Process-level isolation is
+    # what makes this safe: the inner script's `Set-AzContext -Subscription`
+    # call (in the consumption phase) mutates *process-global* Az PowerShell
+    # state, so two streams running in the same process would race each
+    # other's contexts and silently cross-contaminate consumption data.
+    # A separate process per stream sidesteps that entirely.
+    #
+    # Each stream owns:
+    #   - Its own slice of the eligible subscription list (round-robin split).
+    #   - Its own resume-state file at
+    #     $InventoryRoot/.resume-state-<TenantID>-stream-<N>.json
+    #     so concurrent state writes cannot race.
+    #   - Its own per-stream summary JSON (Stream_<N>_Summary.json) which the
+    #     parent aggregates at the end.
+    #   - Its own per-stream failures log (RunAllSubscriptions_failures_*_stream-<N>.log).
+    #
+    # All streams share:
+    #   - One Az context snapshot, written by the parent via Save-AzContext
+    #     and imported by every stream via Import-AzContext. This is the only
+    #     way to avoid an interactive sign-in prompt in each child process.
+    #     The snapshot is removed after all streams finish.
+    #
+    # Output is interleaved (each stream prints its own lines, prefixed
+    # `[stream-N]`). The final summary is consolidated from the per-stream
+    # summary JSON files.
+
+    $StreamCount = [Math]::Min($ParallelStreams, $subscriptions.Count)
+    Write-Host ""
+    Write-Host ("Parallel-streams mode: {0} streams across {1} eligible subscription(s)" -f $StreamCount, $subscriptions.Count) -ForegroundColor Cyan
+    if ($ParallelStreams -gt $subscriptions.Count) {
+        Write-Host ("Note: -ParallelStreams {0} clamped to {1} (one stream per subscription is the practical limit)." -f $ParallelStreams, $StreamCount) -ForegroundColor DarkGray
+    }
+    Write-Host "Each stream is a separate pwsh background job with its own Az context and resume-state file." -ForegroundColor DarkGray
+    Write-Host ""
+
+    if ($StreamCount -le 1) {
+        # User asked for parallel but only one (or zero) sub is eligible.
+        # Process it inline using the same per-sub logic the sequential
+        # branch uses, instead of bailing and asking the user to re-run.
+        Write-Host "Only one eligible subscription; running sequentially." -ForegroundColor Yellow
+        if ($subscriptions.Count -gt 0) {
+            $sub = $subscriptions[0]
+            Write-Host "Processing subscription: $($sub.Name) ($($sub.Id))" -ForegroundColor Cyan
+            try {
+                & (Join-Path $PSScriptRoot "ResourceInventory.ps1") -TenantID $TenantID -SubscriptionID $sub.Id @InventoryPassthrough -RunAllSubs
+                if ($LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
+                $resCount = if ($null -ne $Global:Resources) { @($Global:Resources).Count } else { 0 }
+                $SubResourceCounts += [pscustomobject]@{ Name = $sub.Name; Id = $sub.Id; Count = $resCount }
+                if ($resCount -eq 0) {
+                    Write-Host ("WARNING: '{0}' returned 0 resources." -f $sub.Name) -ForegroundColor Yellow
+                } else {
+                    Write-Host ("Resources collected: {0:N0}" -f $resCount) -ForegroundColor DarkGreen
+                }
+                if (-not ($CompletedIds -contains $sub.Id)) {
+                    $CompletedIds += $sub.Id
+                    Save-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID -Ids $CompletedIds
+                }
+            } catch {
+                Write-Host ("ERROR processing subscription {0}: {1}" -f $sub.Name, $_.Exception.Message) -ForegroundColor Red
+                $FailedSubscriptions += $sub.Name
+            }
+        }
+        # Skip the parallel orchestration entirely; fall through to the
+        # post-processing (consolidation, summary) below.
+        $StreamCount = 0
+    }
+    if ($StreamCount -ge 2) {
+
+    # Snapshot the parent's Az context to a shared file so each stream can
+    # Import-AzContext without prompting. Save-AzContext writes a JSON file
+    # containing a token cache, so it MUST NOT be left on disk after the
+    # run completes - that's the responsibility of the `finally` block
+    # below, which guarantees cleanup even on stream-launch crash, on
+    # Receive-Job failure, or on Ctrl+C.
+    $AzContextSnapshot = Join-Path $InventoryRoot (".rda-stream-azcontext-{0}.json" -f ([guid]::NewGuid().ToString()))
+    try {
+        Save-AzContext -Path $AzContextSnapshot -Force -ErrorAction Stop | Out-Null
+    } catch {
+        Write-Host ("ERROR: could not snapshot Az context for stream workers: {0}" -f $_.Exception.Message) -ForegroundColor Red
+        Write-Host "Re-run without -ParallelStreams to use the sequential code path." -ForegroundColor Yellow
+        # No snapshot was successfully written, so no security cleanup needed -
+        # but Save-AzContext can write a partial file before throwing on some
+        # error paths, so still try to remove it.
+        if (Test-Path -Path $AzContextSnapshot) {
+            try { Remove-Item -Path $AzContextSnapshot -Force }
+            catch { Write-Verbose ("Could not remove partial Az context snapshot: {0}" -f $_.Exception.Message) }
+        }
+        Exit-Wrapper -Code 1
+    }
+
+    # Everything from here until the matching `finally` is the orchestration
+    # body. The `finally` guarantees the Az context snapshot is always wiped,
+    # which is the primary reason for this try/finally structure.
+    try {
+        $WorkerScript = Join-Path $PSScriptRoot 'Run-AllSubscriptions.Stream.ps1'
+        if (-not (Test-Path -Path $WorkerScript -PathType Leaf)) {
+            Write-Host ("ERROR: parallel worker script not found at {0}." -f $WorkerScript) -ForegroundColor Red
+            Write-Host "Make sure Run-AllSubscriptions.Stream.ps1 is present alongside Run-AllSubscriptions.ps1, or re-run without -ParallelStreams." -ForegroundColor Yellow
+            Exit-Wrapper -Code 1
+        }
+
+        # Round-robin split: sub 0 -> stream 0, sub 1 -> stream 1, ..., sub N -> stream (N % StreamCount).
+        # This balances the slices regardless of how subscription sizes vary,
+        # and keeps slices roughly the same length even when the total
+        # subscription count is not evenly divisible by StreamCount.
+        $slices = New-Object 'System.Collections.Generic.List[object][]' $StreamCount
+        for ($i = 0; $i -lt $StreamCount; $i++) {
+            $slices[$i] = New-Object 'System.Collections.Generic.List[object]'
+        }
+        for ($i = 0; $i -lt $subscriptions.Count; $i++) {
+            $slices[$i % $StreamCount].Add($subscriptions[$i])
+        }
+
+        # Build per-stream output paths up front so we know where to look later.
+        $StreamSummaries = @()
+        $jobs = @()
+        for ($s = 0; $s -lt $StreamCount; $s++) {
+            $sliceList     = $slices[$s]
+            $sliceIds      = @($sliceList | ForEach-Object { $_.Id })
+            $sliceNames    = @($sliceList | ForEach-Object { $_.Name })
+
+            $summaryPath   = Join-Path $InventoryRoot (".rda-stream-{0}-summary.json"   -f $s)
+            $failuresPath  = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}_stream-{1}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'), $s)
+
+            $StreamSummaries += [pscustomobject]@{
+                StreamId     = $s
+                SummaryPath  = $summaryPath
+                FailuresPath = $failuresPath
+                SubCount     = $sliceList.Count
+            }
+
+            Write-Host ("[stream-{0}] queued: {1} subscription(s)" -f $s, $sliceList.Count) -ForegroundColor DarkCyan
+
+            # Pass arguments to the worker via a single hashtable so the worker
+            # script's named parameters bind correctly. Start-Job's -FilePath
+            # mode passes ArgumentList positionally which collides with our
+            # named-parameter contract. Switches are only included when they
+            # are set, since switch parameters bind correctly from a splatted
+            # hashtable when present with value $true.
+            $workerArgs = @{
+                TenantID           = $TenantID
+                StreamId           = [string]$s
+                InventoryRoot      = $InventoryRoot
+                ScriptRoot         = $PSScriptRoot
+                AzContextPath      = $AzContextSnapshot
+                StreamSummaryPath  = $summaryPath
+                StreamFailuresPath = $failuresPath
+                SubscriptionIds    = $sliceIds
+                SubscriptionNames  = $sliceNames
+                ConcurrencyLimit   = $ConcurrencyLimit
+            }
+            if ($Resume)          { $workerArgs.Resume          = $true }
+            if ($DeviceLogin)     { $workerArgs.DeviceLogin     = $true }
+            if ($Obfuscate)       { $workerArgs.Obfuscate       = $true }
+            if ($SkipMetrics)     { $workerArgs.SkipMetrics     = $true }
+            if ($SkipConsumption) { $workerArgs.SkipConsumption = $true }
+
+            $jobs += Start-Job -ScriptBlock {
+                param($WorkerScript, $WorkerArgs)
+                & $WorkerScript @WorkerArgs
+            } -ArgumentList @($WorkerScript, $workerArgs)
+        }
+
+        # Stream output back to the user as it arrives. Receive-Job is
+        # non-blocking when called against a still-running job; without this
+        # loop the wrapper would appear frozen until every stream completed.
+        Write-Host ""
+        Write-Host "All streams launched. Streaming output (lines prefixed [stream-N]):" -ForegroundColor Green
+        Write-Host ""
+        # Initial drain handles the case where every stream crashes immediately
+        # (jobs reach Completed state in <1500 ms, so the loop predicate would
+        # otherwise be false on first check and we'd skip output streaming).
+        $jobs | Receive-Job
+        while ($jobs | Where-Object { $_.State -eq 'Running' }) {
+            $jobs | Receive-Job
+            Start-Sleep -Milliseconds 1500
+        }
+        # Drain anything still buffered after all jobs reached terminal state.
+        $jobs | Receive-Job
+
+        # Capture exit codes and any errors from the jobs themselves before removing.
+        foreach ($j in $jobs) {
+            if ($j.State -ne 'Completed') {
+                Write-Host ("[stream-{0}] job ended in state {1}" -f $j.Id, $j.State) -ForegroundColor Yellow
+            }
+        }
+        $jobs | Remove-Job -Force
+
+        # Aggregate per-stream summaries into the wrapper's existing
+        # accumulators so the consolidated summary at end-of-run looks the
+        # same shape as a sequential run.
+        foreach ($s in $StreamSummaries) {
+            if (-not (Test-Path -Path $s.SummaryPath -PathType Leaf)) {
+                Write-Host ("[stream-{0}] WARNING: no summary file at {1} - the stream did not finish cleanly" -f $s.StreamId, $s.SummaryPath) -ForegroundColor Yellow
+                $FailedSubscriptions += ("stream-{0} (no summary)" -f $s.StreamId)
+                continue
+            }
+            try {
+                $streamSummary = Get-Content -Path $s.SummaryPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+            } catch {
+                Write-Host ("[stream-{0}] ERROR: could not parse summary file {1}: {2}" -f $s.StreamId, $s.SummaryPath, $_.Exception.Message) -ForegroundColor Red
+                $FailedSubscriptions += ("stream-{0} (corrupt summary)" -f $s.StreamId)
+                continue
+            }
+
+            # Surface stream-level failures (failed-to-start, etc.) so the
+            # wrapper transcript distinguishes "the whole stream broke" from
+            # "the stream ran fine but some subs in it failed". Per-sub
+            # failures are still folded into $FailedSubscriptions via the
+            # streamSummary.Failed enumeration below.
+            if ($streamSummary.Status -and $streamSummary.Status -ne 'ok' -and $streamSummary.Status -ne 'partial-failure') {
+                $reasonText = if ($streamSummary.Reason) { $streamSummary.Reason } else { '(no reason given)' }
+                Write-Host ("[stream-{0}] stream status: {1} - {2}" -f $s.StreamId, $streamSummary.Status, $reasonText) -ForegroundColor Red
+            }
+
+            if ($streamSummary.ResourceCounts) {
+                foreach ($rc in $streamSummary.ResourceCounts) {
+                    $SubResourceCounts += [pscustomobject]@{
+                        Name  = $rc.Name
+                        Id    = $rc.Id
+                        Count = [int]$rc.Count
+                    }
+                }
+            }
+
+            if ($streamSummary.Failed) {
+                foreach ($f in $streamSummary.Failed) {
+                    $FailedSubscriptions += ("{0} (stream-{1}: {2})" -f $f.Name, $s.StreamId, $f.Reason)
+                }
+            }
+
+            if ($null -ne $streamSummary.ConsumptionRecords) {
+                if ($null -eq $Global:ConsumptionRecordCount) { $Global:ConsumptionRecordCount = 0 }
+                $Global:ConsumptionRecordCount = [int]$Global:ConsumptionRecordCount + [int]$streamSummary.ConsumptionRecords
+            }
+            if ($streamSummary.ConsumptionFailedSubs -and $streamSummary.ConsumptionFailedSubs.Count -gt 0) {
+                if ($null -eq $Global:ConsumptionFailedSubs) { $Global:ConsumptionFailedSubs = @() }
+                $Global:ConsumptionFailedSubs += @($streamSummary.ConsumptionFailedSubs)
+            }
+
+            # If a stream wrote a failures log, add it to the wrapper's diag-file
+            # accumulator so the final summary surfaces the path. The wrapper's
+            # existing $DiagFile was nullable; using a single concatenated log
+            # avoids breaking that contract.
+            if ((Test-Path -Path $s.FailuresPath -PathType Leaf) -and ((Get-Item $s.FailuresPath).Length -gt 0)) {
+                if ($null -eq $DiagFile) {
+                    $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
+                }
+                try {
+                    Get-Content -Path $s.FailuresPath -Raw | Out-File -FilePath $DiagFile -Append -Encoding utf8
+                } catch {
+                    Write-Verbose ("Failed to merge stream failures log {0}: {1}" -f $s.FailuresPath, $_.Exception.Message)
+                }
+            }
+        }
+
+        # Clean up per-stream summary JSON files (the data is now folded into
+        # the wrapper's accumulators). Per-stream failures logs are NOT deleted -
+        # they are referenced from the merged $DiagFile via Append above. The
+        # Az context snapshot cleanup lives in the `finally` block below so it
+        # runs even on failure paths.
+        foreach ($s in $StreamSummaries) {
+            if (Test-Path -Path $s.SummaryPath) {
+                try { Remove-Item -Path $s.SummaryPath -Force } catch { Write-Verbose ("Could not remove stream summary {0}: {1}" -f $s.SummaryPath, $_.Exception.Message) }
+            }
+        }
+
+        # When parallel streams have completed (clean or otherwise), merge each
+        # stream's resume-state file into the unified resume-state file so a
+        # subsequent -Resume run picks up correctly. The unified file is also
+        # what the existing "clean run -> remove resume state" logic below
+        # will look at.
+        $allCompletedFromStreams = @()
+        for ($s = 0; $s -lt $StreamCount; $s++) {
+            $perStreamFile = Join-Path $InventoryRoot (".resume-state-{0}-stream-{1}.json" -f $TenantID, $s)
+            if (Test-Path -Path $perStreamFile -PathType Leaf) {
+                try {
+                    $obj = Get-Content -Path $perStreamFile -Raw | ConvertFrom-Json
+                    if ($null -ne $obj.Completed) {
+                        $allCompletedFromStreams += @($obj.Completed)
+                    }
+                } catch {
+                    Write-Verbose ("Could not read stream resume file {0}: {1}" -f $perStreamFile, $_.Exception.Message)
+                }
+            }
+        }
+        if ($allCompletedFromStreams.Count -gt 0) {
+            $CompletedIds = @($CompletedIds + $allCompletedFromStreams | Sort-Object -Unique)
+            Save-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID -Ids $CompletedIds
+        }
+        # Also delete per-stream resume files now that the unified file holds
+        # the truth - this prevents drift if a future run uses a different
+        # stream count.
+        for ($s = 0; $s -lt $StreamCount; $s++) {
+            $perStreamFile = Join-Path $InventoryRoot (".resume-state-{0}-stream-{1}.json" -f $TenantID, $s)
+            if (Test-Path -Path $perStreamFile -PathType Leaf) {
+                try { Remove-Item -Path $perStreamFile -Force } catch { Write-Verbose ("Could not remove stream resume file {0}: {1}" -f $perStreamFile, $_.Exception.Message) }
+            }
+        }
+    } finally {
+        # Unconditional cleanup of the Az context snapshot. This runs whether
+        # the orchestration succeeded, threw, or was interrupted via Ctrl+C
+        # while a child stream was still running. The snapshot file contains
+        # a token cache; leaving it on disk is a security exposure (bounded
+        # by the ~1h token lifetime, but real). Best-effort: log if the
+        # delete fails but do not propagate the error - that would mask the
+        # real exit reason.
+        if (Test-Path -Path $AzContextSnapshot) {
+            try {
+                Remove-Item -Path $AzContextSnapshot -Force -ErrorAction Stop
+            } catch {
+                Write-Host ("WARNING: could not remove Az context snapshot at {0}: {1}" -f $AzContextSnapshot, $_.Exception.Message) -ForegroundColor Yellow
+                Write-Host "  This file contains an Azure token cache and should be deleted manually." -ForegroundColor Yellow
+            }
+        }
+    }
+    }
 }
 
 Write-Host "All subscriptions processed!" -ForegroundColor Green

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -32,10 +32,11 @@ param (
     #
     # Practical guidance:
     #   1   = sequential (default, lowest memory, easiest to debug)
-    #   2-4 = recommended for most large-tenant runs
-    #   5-8 = only if you've validated memory headroom (each stream loads its
-    #         own Az module set, ~400MB resident; on Cloud Shell's 5GB cap,
-    #         4 streams is the practical ceiling)
+    #   2   = Cloud Shell (3.5 GB RAM / 2 vCPU). Saturates both vCPUs without
+    #         OOM-killing workers.
+    #   3-4 = local laptop / VM with 16+ GB RAM and 4+ vCPUs.
+    #   5+  = only if you have validated memory headroom (each stream loads
+    #         its own Az module set, roughly 400 MB resident).
     #
     # Tenant-scoped Azure Resource Graph rate limits (~15 req/sec/tenant) are
     # the hard ceiling - more than ~6 parallel streams in one tenant will

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -668,7 +668,7 @@ foreach ($sub in $subscriptions) {
                 try { New-Item -ItemType Directory -Path $InventoryRoot -Force | Out-Null }
                 catch { Write-Verbose ("InventoryRoot create failed at {0}: {1}" -f $InventoryRoot, $_.Exception.Message) }
             }
-            $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
+            $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}_{1}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss-fff'), [guid]::NewGuid().ToString().Substring(0,4))
         }
         try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 }
         catch { Write-Verbose ("DiagFile write failed at {0}: {1}" -f $DiagFile, $_.Exception.Message) }
@@ -741,7 +741,24 @@ foreach ($sub in $subscriptions) {
                     Save-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID -Ids $CompletedIds
                 }
             } catch {
-                Write-Host ("ERROR processing subscription {0}: {1}" -f $sub.Name, $_.Exception.Message) -ForegroundColor Red
+                # Match the sequential branch's diagnostic detail so users do not
+                # get a degraded error report when -ParallelStreams collapses to a
+                # single subscription. Mirrors the catch handler around line 615.
+                $errRecord = $_
+                Write-Host ("ERROR processing subscription {0}: {1}" -f $sub.Name, $errRecord) -ForegroundColor Red
+                $diagLines = @()
+                $diagLines += "==== Failure for subscription: $($sub.Name) ($($sub.Id)) ===="
+                $diagLines += "Timestamp: $(Get-Date -Format 'o')"
+                $diagLines += "Message:   $($errRecord.Exception.Message)"
+                $diagLines += "Type:      $($errRecord.Exception.GetType().FullName)"
+                $diagLines += "StackTrace:"
+                $diagLines += $errRecord.ScriptStackTrace
+                $diagLines += ""
+                if ($null -eq $DiagFile) {
+                    $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}_{1}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss-fff'), [guid]::NewGuid().ToString().Substring(0,4))
+                }
+                try { $diagLines | Out-File -FilePath $DiagFile -Append -Encoding utf8 }
+                catch { Write-Verbose ("DiagFile write failed at {0}: {1}" -f $DiagFile, $_.Exception.Message) }
                 $FailedSubscriptions += $sub.Name
             }
         }
@@ -855,8 +872,17 @@ foreach ($sub in $subscriptions) {
         # Initial drain handles the case where every stream crashes immediately
         # (jobs reach Completed state in <1500 ms, so the loop predicate would
         # otherwise be false on first check and we'd skip output streaming).
+        # Drain output once before the polling loop, in case all streams
+        # finished synchronously between Start-Job and our first poll
+        # (jobs reach Completed state in <1500 ms, so the loop predicate would
+        # otherwise be false on first check and we'd skip output streaming).
         $jobs | Receive-Job
-        while ($jobs | Where-Object { $_.State -eq 'Running' }) {
+        # Explicit count check is safer than truthiness on the Where-Object
+        # result: when zero jobs match, Where-Object returns $null which is
+        # falsy, but when one matches it returns a single non-array object
+        # whose truthiness varies by PowerShell edition. @(...).Count is
+        # always an integer.
+        while (@($jobs | Where-Object { $_.State -eq 'Running' }).Count -gt 0) {
             $jobs | Receive-Job
             Start-Sleep -Milliseconds 1500
         }
@@ -929,7 +955,7 @@ foreach ($sub in $subscriptions) {
             # avoids breaking that contract.
             if ((Test-Path -Path $s.FailuresPath -PathType Leaf) -and ((Get-Item $s.FailuresPath).Length -gt 0)) {
                 if ($null -eq $DiagFile) {
-                    $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'))
+                    $DiagFile = Join-Path $InventoryRoot ("RunAllSubscriptions_failures_{0}_{1}.log" -f (Get-Date -Format 'yyyy-MM-dd_HH-mm-ss-fff'), [guid]::NewGuid().ToString().Substring(0,4))
                 }
                 try {
                     Get-Content -Path $s.FailuresPath -Raw | Out-File -FilePath $DiagFile -Append -Encoding utf8

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -9,7 +9,18 @@ param (
     [switch]$SkipMetrics,
     [switch]$SkipConsumption,
     [switch]$Resume,
-    [switch]$IncludeDisabled
+    [switch]$IncludeDisabled,
+
+    # Forwarded to ResourceInventory.ps1's -ConcurrencyLimit. Default of 6 matches
+    # the inner script's own default. The inner script uses this as the throttle
+    # for its metrics-collection runspace pool (Get-AzMetric calls in
+    # Extension/Metrics.ps1). Tenants with metric-heavy subscriptions (many VMs,
+    # SQL DBs, Storage Accounts, Scale Sets, Container Registries) bottleneck on
+    # this phase; raising the limit to 12-24 typically cuts that phase 30-50%
+    # without hitting Azure Monitor's 12,000 reads/hour/subscription ceiling.
+    # Don't go above ~24 in a single tenant - tenant-scoped Resource Graph
+    # rate limits start to bite.
+    [int]$ConcurrencyLimit = 6
 )
 
 $RunStartTime = Get-Date
@@ -445,6 +456,11 @@ if ($DeviceLogin)      { $InventoryPassthrough['DeviceLogin'] = $true }
 if ($Obfuscate)        { $InventoryPassthrough['Obfuscate'] = $true }
 if ($SkipMetrics)      { $InventoryPassthrough['SkipMetrics'] = $true }
 if ($SkipConsumption)  { $InventoryPassthrough['SkipConsumption'] = $true }
+# Always forward ConcurrencyLimit so the operator can tune metrics-phase
+# throttling end-to-end from a single param instead of editing the inner
+# script's default. Defaults to 6 (the inner script's existing default), so
+# behavior is unchanged for runs that don't pass it.
+$InventoryPassthrough['ConcurrencyLimit'] = $ConcurrencyLimit
 if ($PSBoundParameters.ContainsKey('Debug')) { $InventoryPassthrough['Debug'] = $true }
 
 # Loop through each subscription and run ResourceInventory

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -407,14 +407,29 @@ function Test-AzCliTokenSilent {
 # Get-AzAccessToken in this configuration emits a non-terminating warning
 # instead of throwing on token-acquisition failure, so we capture warnings
 # explicitly and treat any warning as a failure signal in addition to
-# catching outright exceptions.
+# catching outright exceptions. We DO NOT treat the Az.Accounts 4.x
+# deprecation banner as a failure - that warning fires on every successful
+# call now that the SecureString-output cmdlet is the recommended path,
+# and ignoring it lets users on the new module version skip re-auth.
 function Test-AzPsTokenSilent {
     param([Parameter(Mandatory=$true)][string]$Tenant)
     $warnings = @()
     try {
         $token = Get-AzAccessToken -TenantId $Tenant -ErrorAction Stop -WarningVariable warnings -WarningAction SilentlyContinue
         if ($null -eq $token -or [string]::IsNullOrWhiteSpace($token.Token)) { return $false }
-        if ($warnings.Count -gt 0) { return $false }
+        # Filter out known-benign warnings before deciding the call failed.
+        # Az.Accounts >= 4.x emits a deprecation banner about the plain-string
+        # output every time the cmdlet returns successfully; treating that as
+        # failure forces users to re-authenticate every run.
+        $realWarnings = @($warnings | Where-Object {
+            $msg = $_.Message
+            -not (
+                $msg -match 'Get-AzAccessToken\s*:?\s*Upcoming breaking changes' -or
+                $msg -match 'AsSecureString' -or
+                $msg -match 'plain string token output is deprecated'
+            )
+        })
+        if ($realWarnings.Count -gt 0) { return $false }
         return $true
     } catch {
         return $false
@@ -575,7 +590,11 @@ foreach ($sub in $subscriptions) {
 
     try {
         & (Join-Path $PSScriptRoot "ResourceInventory.ps1") -TenantID $TenantID -SubscriptionID $sub.Id @InventoryPassthrough -RunAllSubs
-        if ($LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
+        # Only treat as failure if the inner script set a non-zero exit code.
+        # Some completion paths leave $LASTEXITCODE unset ($null), and
+        # PowerShell's `-ne 0` returns $true against $null - which would
+        # spuriously fail every successful sub.
+        if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
 
         # Capture the per-subscription resource count from the inner script.
         # ResourceInventory.ps1 invokes via `& <path>` so its $Global:Resources
@@ -729,7 +748,8 @@ foreach ($sub in $subscriptions) {
             Write-Host "Processing subscription: $($sub.Name) ($($sub.Id))" -ForegroundColor Cyan
             try {
                 & (Join-Path $PSScriptRoot "ResourceInventory.ps1") -TenantID $TenantID -SubscriptionID $sub.Id @InventoryPassthrough -RunAllSubs
-                if ($LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
+                # Same null-guard as the sequential branch above.
+                if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { throw "Script exited with code $LASTEXITCODE" }
                 $resCount = if ($null -ne $Global:Resources) { @($Global:Resources).Count } else { 0 }
                 $SubResourceCounts += [pscustomobject]@{ Name = $sub.Name; Id = $sub.Id; Count = $resCount }
                 if ($resCount -eq 0) {
@@ -792,8 +812,12 @@ foreach ($sub in $subscriptions) {
     }
 
     # Everything from here until the matching `finally` is the orchestration
-    # body. The `finally` guarantees the Az context snapshot is always wiped,
-    # which is the primary reason for this try/finally structure.
+    # body. The `finally` guarantees the Az context snapshot is always wiped
+    # AND that any background jobs are cleaned up, which is the primary
+    # reason for this try/finally structure.
+    # Declared outside the try so the finally can always see them.
+    $jobs = @()
+    $StreamSummaries = @()
     try {
         $WorkerScript = Join-Path $PSScriptRoot 'Run-AllSubscriptions.Stream.ps1'
         if (-not (Test-Path -Path $WorkerScript -PathType Leaf)) {
@@ -806,17 +830,15 @@ foreach ($sub in $subscriptions) {
         # This balances the slices regardless of how subscription sizes vary,
         # and keeps slices roughly the same length even when the total
         # subscription count is not evenly divisible by StreamCount.
-        $slices = New-Object 'System.Collections.Generic.List[object][]' $StreamCount
+        $slices = @()
         for ($i = 0; $i -lt $StreamCount; $i++) {
-            $slices[$i] = New-Object 'System.Collections.Generic.List[object]'
+            $slices += ,(New-Object 'System.Collections.Generic.List[object]')
         }
         for ($i = 0; $i -lt $subscriptions.Count; $i++) {
             $slices[$i % $StreamCount].Add($subscriptions[$i])
         }
 
         # Build per-stream output paths up front so we know where to look later.
-        $StreamSummaries = @()
-        $jobs = @()
         for ($s = 0; $s -lt $StreamCount; $s++) {
             $sliceList     = $slices[$s]
             $sliceIds      = @($sliceList | ForEach-Object { $_.Id })
@@ -870,6 +892,9 @@ foreach ($sub in $subscriptions) {
         Write-Host ""
         Write-Host "All streams launched. Streaming output (lines prefixed [stream-N]):" -ForegroundColor Green
         Write-Host ""
+        Write-Host ("Note: per-stream tags only prefix the wrapper's narration. The inner script's") -ForegroundColor DarkGray
+        Write-Host ("Write-Host/Write-Log output is unprefixed and will interleave across streams.") -ForegroundColor DarkGray
+        Write-Host ""
         # Initial drain handles the case where every stream crashes immediately
         # (jobs reach Completed state in <1500 ms, so the loop predicate would
         # otherwise be false on first check and we'd skip output streaming).
@@ -896,7 +921,8 @@ foreach ($sub in $subscriptions) {
                 Write-Host ("[stream-{0}] job ended in state {1}" -f $j.Id, $j.State) -ForegroundColor Yellow
             }
         }
-        $jobs | Remove-Job -Force
+        # Job cleanup is in the `finally` block below so it runs even if any
+        # exception was raised during Receive-Job polling or aggregation.
 
         # Aggregate per-stream summaries into the wrapper's existing
         # accumulators so the consolidated summary at end-of-run looks the
@@ -927,6 +953,7 @@ foreach ($sub in $subscriptions) {
 
             if ($streamSummary.ResourceCounts) {
                 foreach ($rc in $streamSummary.ResourceCounts) {
+                    if ($null -eq $rc) { continue }
                     $SubResourceCounts += [pscustomobject]@{
                         Name  = $rc.Name
                         Id    = $rc.Id
@@ -1010,13 +1037,33 @@ foreach ($sub in $subscriptions) {
             }
         }
     } finally {
-        # Unconditional cleanup of the Az context snapshot. This runs whether
-        # the orchestration succeeded, threw, or was interrupted via Ctrl+C
-        # while a child stream was still running. The snapshot file contains
-        # a token cache; leaving it on disk is a security exposure (bounded
-        # by the ~1h token lifetime, but real). Best-effort: log if the
-        # delete fails but do not propagate the error - that would mask the
-        # real exit reason.
+        # Unconditional cleanup of background jobs and the Az context snapshot.
+        # Runs whether the orchestration succeeded, threw mid-aggregation, or
+        # was interrupted via Ctrl+C while a child stream was still running.
+
+        # 1. Background jobs. If we threw before $jobs was declared, the
+        # variable is null/empty and Remove-Job is a no-op. Each job is a
+        # separate `pwsh` process holding an Az context snapshot reference;
+        # leaving them running after the parent exits would leak both
+        # processes and authentication state.
+        if ($null -ne $jobs -and @($jobs).Count -gt 0) {
+            try {
+                # Stop any still-running jobs first so Remove-Job doesn't
+                # block waiting for them.
+                @($jobs | Where-Object { $_.State -eq 'Running' }) | ForEach-Object {
+                    try { Stop-Job -Job $_ -ErrorAction SilentlyContinue } catch {}
+                }
+                $jobs | Remove-Job -Force -ErrorAction SilentlyContinue
+            } catch {
+                Write-Host ("WARNING: could not fully clean up background jobs: {0}" -f $_.Exception.Message) -ForegroundColor Yellow
+            }
+        }
+
+        # 2. Az context snapshot. The snapshot file contains a token cache;
+        # leaving it on disk is a security exposure (bounded by the ~1h
+        # token lifetime, but real). Best-effort: log if the delete fails
+        # but do not propagate the error - that would mask the real exit
+        # reason.
         if (Test-Path -Path $AzContextSnapshot) {
             try {
                 Remove-Item -Path $AzContextSnapshot -Force -ErrorAction Stop
@@ -1076,6 +1123,15 @@ if ($excluded.Count -gt 0) {
     Write-Host ("Subscriptions Excluded:  {0} (non-Enabled; use -IncludeDisabled to inventory them)" -f $excluded.Count) -ForegroundColor Green
 }
 Write-Host ("Subscriptions Eligible:  {0}" -f $subscriptions.Count) -ForegroundColor Green
+# In parallel mode, $SkippedCount is not populated by the foreach loop above
+# (each worker skips independently). Derive it from the difference between
+# the number of eligible subs and the number of subs that actually ran in
+# this invocation (the union of $SubResourceCounts entries plus failures).
+if ($ParallelStreams -gt 1 -and $Resume -and $SkippedCount -eq 0) {
+    $actuallyProcessed = ($SubResourceCounts | Measure-Object).Count + $FailedSubscriptions.Count
+    $derivedSkip = $subscriptions.Count - $actuallyProcessed
+    if ($derivedSkip -gt 0) { $SkippedCount = $derivedSkip }
+}
 if ($Resume) {
     Write-Host ("Subscriptions Skipped:   {0} (already completed)" -f $SkippedCount) -ForegroundColor Green
 }

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -139,8 +139,9 @@ function Invoke-PreFlightChecks {
             Write-Host ""
             Write-Host "WARNING: Cloud Shell detected, but no storage account is mounted." -ForegroundColor Yellow
             Write-Host "  Outputs in $InventoryRoot will be lost when this Cloud Shell session ends." -ForegroundColor Yellow
-            Write-Host "  To persist outputs, mount a storage account first:" -ForegroundColor Yellow
-            Write-Host "    clouddrive mount" -ForegroundColor Yellow
+            Write-Host "  This includes the resume-state file, so -Resume on a future session won't help recover." -ForegroundColor Yellow
+            Write-Host "  To persist outputs across sessions, attach a storage account via the Cloud Shell" -ForegroundColor Yellow
+            Write-Host "  settings menu (gear icon) > Reset User Settings > Mount storage account." -ForegroundColor Yellow
             Write-Host "  Continuing in ephemeral mode - download the report ZIP from $InventoryRoot before closing the shell." -ForegroundColor Yellow
             Write-Host ""
         } else {
@@ -150,10 +151,12 @@ function Invoke-PreFlightChecks {
 
     # 2. Disk space probe at the inventory root.
     #
-    # Cloud Shell quota is 5 GB total. A 100+ subscription run can produce
-    # 200+ MB of zips and intermediate files; if free space is already low
-    # the run will fail late with a confusing "There is not enough space"
-    # somewhere deep in EPPlus. Catch it now.
+    # Cloud Shell's overlay filesystem provides ~50 GB (verified with `df -h`
+    # in 2026); the legacy 5 GB number some older docs cite is outdated.
+    # A 100+ subscription run can produce 200-500 MB of zips and intermediate
+    # files; if free space is already low (typically because something else
+    # is filling the home directory) the run will fail late with a confusing
+    # "There is not enough space" somewhere deep in EPPlus. Catch it now.
     try {
         $rootItem = Get-Item -Path $InventoryRoot -ErrorAction Stop
         $drive = $rootItem.PSDrive

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -202,6 +202,70 @@ function Invoke-PreFlightChecks {
         Exit-Wrapper -Code 1
     }
 
+    # 4. ImportExcel health probe.
+    #
+    # ImportExcel is the Excel-writer this script depends on. A partially
+    # installed module (manifest present, bundled EPPlus assemblies missing
+    # or version-mismatched) causes New-ExcelStyle to silently return $null.
+    # That $null then flows through every collector under Services\* and
+    # crashes ~30 layers down inside Set-ExcelRange.ps1 with a confusing
+    # 'HorizontalAlignment cannot be found' error - long after the user has
+    # waited through resource enumeration. Catch it here with a one-line
+    # actionable message instead. See ARI issue #17 for upstream context.
+    if (-not (Get-Module -Name ImportExcel -ListAvailable))
+    {
+        Write-Host "ERROR: ImportExcel module is not installed." -ForegroundColor Red
+        Write-Host "  Install with:" -ForegroundColor Red
+        Write-Host "    Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser" -ForegroundColor Yellow
+        Exit-Wrapper -Code 1
+    }
+    try
+    {
+        Import-Module ImportExcel -ErrorAction Stop
+    }
+    catch
+    {
+        Write-Host ("ERROR: ImportExcel is installed but failed to import: {0}" -f $_.Exception.Message) -ForegroundColor Red
+        Write-Host "  Reinstall with:" -ForegroundColor Red
+        Write-Host "    Get-Module ImportExcel -ListAvailable | Uninstall-Module -Force" -ForegroundColor Yellow
+        Write-Host "    Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser" -ForegroundColor Yellow
+        Exit-Wrapper -Code 1
+    }
+    $styleProbe = $null
+    try
+    {
+        $styleProbe = New-ExcelStyle -HorizontalAlignment Center -AutoSize -NumberFormat 0 -ErrorAction Stop
+    }
+    catch
+    {
+        Write-Host ("ERROR: ImportExcel preflight failed: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    }
+    # New-ExcelStyle returns a PSBoundParametersDictionary on healthy installs,
+    # so check for the HorizontalAlignment key (not a declared property). On a
+    # broken install the cmdlet returns $null or an object missing the key.
+    $styleProbeOk = $false
+    if ($null -ne $styleProbe)
+    {
+        try
+        {
+            $styleProbeOk = ($styleProbe['HorizontalAlignment'] -eq 'Center')
+        }
+        catch
+        {
+            $styleProbeOk = $false
+        }
+    }
+    if (-not $styleProbeOk)
+    {
+        Write-Host "ERROR: ImportExcel module is in a broken state (New-ExcelStyle returned an unusable object)." -ForegroundColor Red
+        Write-Host "  This usually means the module manifest is present but the bundled EPPlus assemblies are missing or version-mismatched." -ForegroundColor Red
+        Write-Host "  Reinstall with:" -ForegroundColor Red
+        Write-Host "    Get-Module ImportExcel -ListAvailable | Uninstall-Module -Force" -ForegroundColor Yellow
+        Write-Host "    Install-Module -Name ImportExcel -Repository PSGallery -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser" -ForegroundColor Yellow
+        Exit-Wrapper -Code 1
+    }
+    Write-Host "ImportExcel health: OK" -ForegroundColor Green
+
     Write-Host "Pre-flight checks passed." -ForegroundColor Green
     Write-Host ""
 }

--- a/Services/Analytics/Databricks.ps1
+++ b/Services/Analytics/Databricks.ps1
@@ -24,7 +24,10 @@ if($Task -eq 'Processing')
                 'Name'                      = $1.NAME;
                 'Location'                  = $1.LOCATION;
                 'PricingTier'               = $sku.name;
-                'ManagedResourceGroup'      = if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.Count -gt 0) { 'obfuscated' } else { $data.managedResourceGroupId.split('/')[4] };
+                # ManagedResourceGroupId is theoretically always set on a workspace, but
+                # split('/')[4] still fails if the property is missing or malformed.
+                # Guard cheaply rather than crash the whole subscription.
+                'ManagedResourceGroup'      = if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.Count -gt 0) { 'obfuscated' } elseif ([string]::IsNullOrEmpty($data.managedResourceGroupId)) { $null } else { $data.managedResourceGroupId.split('/')[4] };
                 'StorageAccount'            = if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.Count -gt 0) { 'obfuscated' } else { $data.parameters.storageAccountName.value };
                 'StorageAccountSKU'         = $data.parameters.storageAccountSkuName.value;
                 'CreatedTime'               = $timecreated;

--- a/Services/Analytics/MachineLearning.ps1
+++ b/Services/Analytics/MachineLearning.ps1
@@ -14,10 +14,18 @@ If ($Task -eq 'Processing')
             $data = $1.PROPERTIES
             $timecreated = [datetime]($data.creationTime) | Get-Date -Format "yyyy-MM-dd HH:mm"
 
-            $StorageAcc = $data.storageAccount.split('/')[8]
-            $KeyVault = $data.keyVault.split('/')[8]
-            $Insight = $data.applicationInsights.split('/')[8]
-            $containerRegistry = $data.containerRegistry.split('/')[8]
+            # The four cross-resource references (storage / key vault / app insights /
+            # container registry) are *optional* on an Azure ML workspace - a workspace
+            # without one of them returns $null in PROPERTIES rather than the property
+            # being absent. The original line `$data.storageAccount.split('/')[8]` then
+            # fails with "You cannot call a method on a null-valued expression" and
+            # aborts the entire subscription. Guard every reference and emit $null
+            # (or, for obfuscated runs, the literal string 'obfuscated' to match the
+            # rest of this module's lossy fallback pattern) when the field is absent.
+            $StorageAcc        = if ([string]::IsNullOrEmpty($data.storageAccount))      { $null } else { $data.storageAccount.split('/')[8] }
+            $KeyVault          = if ([string]::IsNullOrEmpty($data.keyVault))            { $null } else { $data.keyVault.split('/')[8] }
+            $Insight           = if ([string]::IsNullOrEmpty($data.applicationInsights)) { $null } else { $data.applicationInsights.split('/')[8] }
+            $containerRegistry = if ([string]::IsNullOrEmpty($data.containerRegistry))   { $null } else { $data.containerRegistry.split('/')[8] }
 
             # Obfuscate cross-reference names when dictionary is populated
             if ($null -ne $ResourceIdDictionary -and $ResourceIdDictionary.Count -gt 0) {

--- a/Tests/DataIntegrity.Tests.ps1
+++ b/Tests/DataIntegrity.Tests.ps1
@@ -24,7 +24,24 @@ BeforeAll {
         $script:AllContent[$file.Name] = Get-Content $file.FullName -Raw
     }
 
-    $script:ObfuscationPattern = '^(prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    $script:ObfuscationPattern = '^(prod|nonprod)_(databricks_|aks_|vmss_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+    # Detect obfuscation mode: if any resource ID matches the obfuscation
+    # pattern, treat the run as obfuscated. The PII-leak Describe later
+    # also depends on this signal.
+    $script:IsObfuscated = $false
+    if ($null -ne $script:Inventory) {
+        $script:Inventory.PSObject.Properties |
+            Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } |
+            ForEach-Object {
+                @($_.Value) | ForEach-Object {
+                    if ($script:IsObfuscated) { return }
+                    if ($null -ne $_ -and $null -ne $_.ID -and $_.ID -match $script:ObfuscationPattern) {
+                        $script:IsObfuscated = $true
+                    }
+                }
+            }
+    }
 }
 
 AfterAll {
@@ -146,7 +163,11 @@ Describe "Non-Sensitive Fields Preserved" {
     It "VM Size should be a real Azure VM size" {
         foreach ($vm in @($script:Inventory.VirtualMachines)) {
             if ($null -ne $vm -and ![string]::IsNullOrEmpty($vm.Size)) {
-                $vm.Size | Should -Match '^standard_' -Because "VM Size should be a real Azure size"
+                # Azure VM SKUs include Standard_*, Basic_*, M-series (M64s, M128ms),
+                # N-series GPU sizes etc. The invariant is "not obfuscated" - i.e.
+                # the size string was not run through the obfuscator. The actual
+                # SKU shape is not under this script's control.
+                $vm.Size | Should -Not -Match '^(prod|nonprod)_' -Because "VM Size should not be obfuscated"
             }
         }
     }
@@ -220,5 +241,37 @@ Describe "No Null Obfuscated Fields" {
                 }
             }
         }
+    }
+}
+
+
+# ============================================================
+# 6. Generic per-property leak scan
+# ============================================================
+# Walks every property of every resource across all collectors and asserts no
+# value contains a raw Azure resource path. This catches secondary-field leaks
+# that the per-collector specialised tests do not cover (since only ~14 of the
+# 57 collectors have dedicated cross-reference tests).
+Describe "Generic per-property leak scan" {
+    It "No resource property in obfuscated output should contain a raw Azure resource path" {
+        if (-not $script:IsObfuscated) {
+            Set-ItResult -Skipped -Because "test only meaningful in obfuscated mode"
+            return
+        }
+        $azureIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}'
+        $script:Inventory.PSObject.Properties |
+            Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } |
+            ForEach-Object {
+                $collector = $_.Name
+                @($_.Value) | ForEach-Object {
+                    if ($null -eq $_) { return }
+                    foreach ($prop in $_.PSObject.Properties) {
+                        if ($null -ne $prop.Value -and $prop.Value -is [string] -and $prop.Value -match $azureIdPattern) {
+                            $hint = "[{0}.{1}]" -f $collector, $prop.Name
+                            $prop.Value | Should -Not -Match $azureIdPattern -Because "Field $hint contains raw Azure resource path"
+                        }
+                    }
+                }
+            }
     }
 }

--- a/Tests/DictionaryValidation.Tests.ps1
+++ b/Tests/DictionaryValidation.Tests.ps1
@@ -14,10 +14,11 @@ BeforeAll {
                 Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
         } else { $found }
     }
-    if ([string]::IsNullOrEmpty($dictPath) -or -not (Test-Path $dictPath)) {
-        throw "No dictionary file found. Copy an ObfuscationDictionary_*.json to Tests/ or next to the zip, or set `$env:TEST_DICT_PATH"
-    }
-    $script:Dictionary = Get-Content $dictPath -Raw | ConvertFrom-Json
+    # No dictionary fixture is available when the test zip wasn't produced by an
+    # -Obfuscate run. Mark the suite skipped instead of throwing - the rest of
+    # the test framework runs in environments without a dictionary on hand.
+    $script:DictionaryAvailable = -not [string]::IsNullOrEmpty($dictPath) -and (Test-Path $dictPath)
+    $script:Dictionary = if ($script:DictionaryAvailable) { Get-Content $dictPath -Raw | ConvertFrom-Json } else { $null }
 
     # Also load inventory if available
     $zipPath = if ($env:TEST_ZIP_PATH) { $env:TEST_ZIP_PATH } else {
@@ -34,7 +35,11 @@ BeforeAll {
         if ($invFile) { $script:Inventory = Get-Content $invFile.FullName -Raw | ConvertFrom-Json }
     }
 
-    $script:ObfuscationPattern = '^(prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    # The optional type-prefix group (databricks_, aks_, vmss_) covers the
+    # legitimate variants the obfuscator emits for resources whose IDs do not
+    # fit the standard ARM shape. See ResourceInventory.ps1 lines 650-655 and
+    # 1030-1034 for where these are produced.
+    $script:ObfuscationPattern = '^(prod|nonprod)_(databricks_|aks_|vmss_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
     $script:AzureIdPattern = '/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}'
 }
 
@@ -44,6 +49,7 @@ AfterAll {
 
 Describe "Dictionary Structure" {
     It "Should be valid JSON with all four maps" {
+        if (-not $script:DictionaryAvailable) { Set-ItResult -Skipped -Because "No ObfuscationDictionary fixture available; set `$env:TEST_DICT_PATH or run -Obfuscate first"; return }
         $script:Dictionary | Should -Not -BeNullOrEmpty
         $script:Dictionary.PSObject.Properties.Name | Should -Contain 'ResourceIdMap'
         $script:Dictionary.PSObject.Properties.Name | Should -Contain 'ResourceNameMap'
@@ -52,10 +58,12 @@ Describe "Dictionary Structure" {
     }
 
     It "Should have a GeneratedAt timestamp" {
+        if (-not $script:DictionaryAvailable) { Set-ItResult -Skipped -Because "No ObfuscationDictionary fixture available"; return }
         $script:Dictionary.GeneratedAt | Should -Not -BeNullOrEmpty
     }
 
     It "ResourceIdMap keys should be obfuscated values" {
+        if (-not $script:DictionaryAvailable) { Set-ItResult -Skipped -Because "No ObfuscationDictionary fixture available"; return }
         $keys = $script:Dictionary.ResourceIdMap.PSObject.Properties.Name
         foreach ($key in $keys) {
             $key | Should -Match $script:ObfuscationPattern -Because "Dictionary key '$key' should be an obfuscated ID"
@@ -63,6 +71,7 @@ Describe "Dictionary Structure" {
     }
 
     It "ResourceIdMap values should be real Azure resource IDs" {
+        if (-not $script:DictionaryAvailable) { Set-ItResult -Skipped -Because "No ObfuscationDictionary fixture available"; return }
         $values = $script:Dictionary.ResourceIdMap.PSObject.Properties.Value
         foreach ($val in $values) {
             $val | Should -Match $script:AzureIdPattern -Because "Dictionary value should be a real Azure resource ID"
@@ -72,6 +81,7 @@ Describe "Dictionary Structure" {
 
 Describe "Dictionary Completeness" {
     It "Every obfuscated ID in inventory should have a dictionary entry" {
+        if (-not $script:DictionaryAvailable) { Set-ItResult -Skipped -Because "No ObfuscationDictionary fixture available"; return }
         if ($null -eq $script:Inventory) { Set-ItResult -Skipped -Because "No inventory zip provided"; return }
         $dictKeys = $script:Dictionary.ResourceIdMap.PSObject.Properties.Name
         $script:Inventory.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } | ForEach-Object {
@@ -86,6 +96,7 @@ Describe "Dictionary Completeness" {
 
 Describe "No Double Obfuscation" {
     It "No obfuscated value should appear as a dictionary value (real ID)" {
+        if (-not $script:DictionaryAvailable) { Set-ItResult -Skipped -Because "No ObfuscationDictionary fixture available"; return }
         $values = $script:Dictionary.ResourceIdMap.PSObject.Properties.Value
         foreach ($val in $values) {
             $val | Should -Not -Match $script:ObfuscationPattern -Because "Real ID '$val' should not look like an obfuscated value"

--- a/Tests/Frontdoor.Tests.ps1
+++ b/Tests/Frontdoor.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
 
 Describe "Front Door Collector Schema" {
     It "Should produce entries with all expected fields" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         $expected = @('ID', 'Subscription', 'ResourceGroup', 'Name', 'Location', 'Type', 'State', 'WebApplicationFirewall', 'ResourceType')
         foreach ($fd in $script:FrontDoors) {
             foreach ($field in $expected) {
@@ -48,7 +48,7 @@ Describe "Front Door Collector Schema" {
 
 Describe "Front Door Tier Detection" {
     It "Type field should only contain known tier values" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         $validTypes = @('Classic', 'Standard', 'Premium')
         foreach ($fd in $script:FrontDoors) {
             $fd.Type | Should -BeIn $validTypes -Because "Type should be one of: $($validTypes -join ', ')"
@@ -56,7 +56,7 @@ Describe "Front Door Tier Detection" {
     }
 
     It "Type should not be null or empty on any Front Door" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.Type | Should -Not -BeNullOrEmpty -Because "Type must always be populated"
         }
@@ -65,7 +65,7 @@ Describe "Front Door Tier Detection" {
 
 Describe "Front Door State Field" {
     It "State should not be null (fallback chain must produce a value)" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.State | Should -Not -BeNullOrEmpty -Because "State must fall back to provisioningState or 'Unknown'"
         }
@@ -74,7 +74,7 @@ Describe "Front Door State Field" {
 
 Describe "Front Door WAF Field" {
     It "WebApplicationFirewall field should always be populated" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         foreach ($fd in $script:FrontDoors) {
             # Valid values: 'False' (Classic, no WAF), a WAF policy name (Classic, WAF attached),
             # 'obfuscated' (Classic, obfuscated mode), 'Unknown' (Standard/Premium — security
@@ -84,7 +84,7 @@ Describe "Front Door WAF Field" {
     }
 
     It "WAF value should be a known marker or a non-Azure-path string" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         foreach ($fd in $script:FrontDoors) {
             # Disallow misleading 'Enabled' — Standard/Premium should report 'Unknown' now.
             $fd.WebApplicationFirewall | Should -Not -Be 'Enabled' -Because "Std/Premium WAF attachment is not detectable from the profile; 'Enabled' is misleading"
@@ -92,8 +92,8 @@ Describe "Front Door WAF Field" {
     }
 
     It "WAF value should not contain raw Azure resource paths in obfuscated mode" {
-        if ($script:FrontDoors.Count -eq 0) { return }
-        if (-not $script:IsObfuscated) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
+        if (-not $script:IsObfuscated) { Set-ItResult -Skipped -Because "non-obfuscated run"; return }
         foreach ($fd in $script:FrontDoors) {
             if (![string]::IsNullOrEmpty([string]$fd.WebApplicationFirewall) -and $fd.WebApplicationFirewall -ne 'False') {
                 [string]$fd.WebApplicationFirewall | Should -Not -Match $script:AzureIdPattern -Because "WAF should not expose Azure resource path in obfuscated mode"
@@ -104,28 +104,28 @@ Describe "Front Door WAF Field" {
 
 Describe "Front Door Non-Sensitive Field Preservation" {
     It "Location should be a real Azure region (not obfuscated)" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.Location | Should -Not -Match '^(prod|nonprod)_' -Because "Location should be a real region like 'global' or 'westeurope'"
         }
     }
 
     It "Type should not be obfuscated" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.Type | Should -Not -Match '^(prod|nonprod)_' -Because "Tier identifier should be preserved for analysis"
         }
     }
 
     It "State should not be obfuscated" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.State | Should -Not -Match '^(prod|nonprod)_' -Because "State should be preserved for analysis"
         }
     }
 
     It "ResourceType should be a valid Azure resource type (not obfuscated)" {
-        if ($script:FrontDoors.Count -eq 0) { return }
+        if ($script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "no Front Door resources in fixture"; return }
         $validTypes = @('microsoft.network/frontdoors', 'microsoft.cdn/profiles')
         foreach ($fd in $script:FrontDoors) {
             $fd.ResourceType | Should -BeIn $validTypes -Because "ResourceType should be the raw Azure type, not obfuscated"
@@ -135,28 +135,28 @@ Describe "Front Door Non-Sensitive Field Preservation" {
 
 Describe "Front Door Obfuscation in Obfuscated Mode" {
     It "ID should match obfuscation pattern" {
-        if (-not $script:IsObfuscated -or $script:FrontDoors.Count -eq 0) { return }
+        if (-not $script:IsObfuscated -or $script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "non-obfuscated run or no Front Doors"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.ID | Should -Match $script:ObfuscationPattern -Because "Obfuscated mode: ID must be masked"
         }
     }
 
     It "Name should match obfuscation pattern" {
-        if (-not $script:IsObfuscated -or $script:FrontDoors.Count -eq 0) { return }
+        if (-not $script:IsObfuscated -or $script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "non-obfuscated run or no Front Doors"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.Name | Should -Match $script:ObfuscationPattern -Because "Obfuscated mode: Name must be masked"
         }
     }
 
     It "Subscription should match obfuscation pattern" {
-        if (-not $script:IsObfuscated -or $script:FrontDoors.Count -eq 0) { return }
+        if (-not $script:IsObfuscated -or $script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "non-obfuscated run or no Front Doors"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.Subscription | Should -Match $script:ObfuscationPattern -Because "Obfuscated mode: Subscription must be masked"
         }
     }
 
     It "ResourceGroup should match obfuscation pattern" {
-        if (-not $script:IsObfuscated -or $script:FrontDoors.Count -eq 0) { return }
+        if (-not $script:IsObfuscated -or $script:FrontDoors.Count -eq 0) { Set-ItResult -Skipped -Because "non-obfuscated run or no Front Doors"; return }
         foreach ($fd in $script:FrontDoors) {
             $fd.ResourceGroup | Should -Match $script:ObfuscationPattern -Because "Obfuscated mode: ResourceGroup must be masked"
         }

--- a/Tests/Obfuscation.Tests.ps1
+++ b/Tests/Obfuscation.Tests.ps1
@@ -214,9 +214,9 @@ Describe "Metrics Obfuscation" {
 # ============================================================
 Describe "Consumption Obfuscation" {
     It "Should have all consumption ResourceIds matching the obfuscation pattern" {
-        if ($null -eq $script:ConsumptionFile) { return }
+        if ($null -eq $script:ConsumptionFile) { Set-ItResult -Skipped -Because "no consumption file in fixture"; return }
         $csv = Import-Csv $script:ConsumptionFile.FullName
-        if ($csv.Count -eq 0) { return }
+        if ($csv.Count -eq 0) { Set-ItResult -Skipped -Because "empty consumption csv"; return }
 
         foreach ($row in $csv) {
             if (![string]::IsNullOrEmpty($row.ResourceId)) {
@@ -226,9 +226,9 @@ Describe "Consumption Obfuscation" {
     }
 
     It "Should have obfuscated ResourceUri inside InstanceData JSON" {
-        if ($null -eq $script:ConsumptionFile) { return }
+        if ($null -eq $script:ConsumptionFile) { Set-ItResult -Skipped -Because "no consumption file in fixture"; return }
         $csv = Import-Csv $script:ConsumptionFile.FullName
-        if ($csv.Count -eq 0) { return }
+        if ($csv.Count -eq 0) { Set-ItResult -Skipped -Because "empty consumption csv"; return }
 
         foreach ($row in $csv) {
             if (![string]::IsNullOrEmpty($row.InstanceData)) {

--- a/Tests/Obfuscation.Tests.ps1
+++ b/Tests/Obfuscation.Tests.ps1
@@ -36,8 +36,13 @@ BeforeAll {
         $script:AllContent[$file.Name] = Get-Content $file.FullName -Raw
     }
 
-    # Obfuscation pattern: prod_ or nonprod_ followed by a GUID
-    $script:ObfuscationPattern = '^(prod|nonprod)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    # Obfuscation pattern: prod_ or nonprod_ followed by an optional type-tag
+    # (databricks_, aks_, vmss_) and a GUID. The type-tagged variants are the
+    # legitimate output for resources whose IDs do not fit the standard ARM
+    # shape (AKS-managed RGs, Databricks-managed clusters, VMSS instances
+    # inside AKS node pools). See ResourceInventory.ps1 lines 650-655 and
+    # 1030-1034 for where these are produced.
+    $script:ObfuscationPattern = '^(prod|nonprod)_(databricks_|aks_|vmss_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 
     # Helper: get all resources from inventory as flat list
     $script:AllResources = @()

--- a/Tests/OutputCompleteness.Tests.ps1
+++ b/Tests/OutputCompleteness.Tests.ps1
@@ -118,7 +118,10 @@ Describe "Non-Sensitive Fields Preserved" {
         $vms = @($script:Inventory.VirtualMachines)
         foreach ($vm in $vms) {
             if ($null -ne $vm -and ![string]::IsNullOrEmpty($vm.Size)) {
-                $vm.Size | Should -Match '^standard_' -Because "VM Size should be a real Azure size like standard_d2s_v5"
+                # Same rationale as DataIntegrity.Tests.ps1: VM SKUs include
+                # Standard_*, Basic_*, M*, N* etc. The invariant under test is
+                # "not obfuscated", not a particular naming convention.
+                $vm.Size | Should -Not -Match '^(prod|nonprod)_' -Because "VM Size should not be obfuscated"
             }
         }
     }

--- a/Tests/ParallelStreamsAggregation.Tests.ps1
+++ b/Tests/ParallelStreamsAggregation.Tests.ps1
@@ -1,0 +1,326 @@
+# Parallel-Streams Aggregation Tests
+# Validates that a parallel run (-ParallelStreams N) produces structurally
+# equivalent output to a sequential run (single sub-folder per subscription,
+# matching XLSX sheet sets, matching Inventory JSON keys, matching consumption
+# record counts, matching obfuscated-ID universes when -Obfuscate is set).
+#
+# These tests are the drift-prevention guard for the parallel-streams feature.
+# Any change to the wrapper, the worker, or the per-sub folder convention that
+# silently desyncs sequential vs parallel output will fail here.
+#
+# Run with:
+#   Invoke-Pester ./Tests/ParallelStreamsAggregation.Tests.ps1 -Output Detailed
+#
+# Inputs (env vars):
+#   $env:TEST_SEQUENTIAL_BUNDLE  - path to AllSubscriptions_*.zip from a -ParallelStreams 1 run
+#   $env:TEST_PARALLEL_BUNDLE    - path to AllSubscriptions_*.zip from a -ParallelStreams N (N>=2) run
+#
+# If both env vars are unset, the test auto-discovers the two most recent
+# AllSubscriptions_*.zip files under $env:HOME/InventoryReports (or
+# $env:USERPROFILE\InventoryReports on Windows) and assumes the older one is
+# sequential and the newer one is parallel. For repeatability, set both env
+# vars explicitly.
+
+BeforeAll {
+    # Resolve the sequential/parallel bundle pair *only* from explicit env vars.
+    # Auto-discovery is unsafe: any two AllSubscriptions_*.zip files in the
+    # default InventoryReports directory could be from runs with different
+    # flag combinations (e.g. one with -SkipMetrics, one without), which would
+    # produce false-positive failures here. If the env vars are unset we mark
+    # all tests in this file Skipped, mirroring how Obfuscation.Tests.ps1
+    # gracefully handles "no fixture provided".
+    $script:HaveFixture = $false
+    if ($env:TEST_SEQUENTIAL_BUNDLE -and $env:TEST_PARALLEL_BUNDLE) {
+        if ((Test-Path $env:TEST_SEQUENTIAL_BUNDLE) -and (Test-Path $env:TEST_PARALLEL_BUNDLE)) {
+            $script:HaveFixture = $true
+            $script:SeqBundlePath = $env:TEST_SEQUENTIAL_BUNDLE
+            $script:ParBundlePath = $env:TEST_PARALLEL_BUNDLE
+        }
+    }
+
+    function Expand-Bundle($bundlePath, $label) {
+        $tmpBase = if ($env:TMPDIR) { $env:TMPDIR } elseif ($env:TEMP) { $env:TEMP } else { '/tmp' }
+        $extractRoot = Join-Path $tmpBase ("ParStreams_${label}_" + [guid]::NewGuid().ToString().Substring(0,8))
+        New-Item -ItemType Directory -Path $extractRoot -Force | Out-Null
+
+        # Outer bundle expand -> contains one or more inner per-sub ResourcesReport_*.zip files.
+        Expand-Archive -Path $bundlePath -DestinationPath $extractRoot -Force
+
+        # Each inner ZIP is itself the per-sub artifact bundle.
+        $innerZips = @(Get-ChildItem -Path $extractRoot -Filter 'ResourcesReport_*.zip' -File)
+        $perSub = @()
+        foreach ($iz in $innerZips) {
+            $subDir = Join-Path $extractRoot ($iz.BaseName)
+            New-Item -ItemType Directory -Path $subDir -Force | Out-Null
+            Expand-Archive -Path $iz.FullName -DestinationPath $subDir -Force
+            $perSub += [pscustomobject]@{
+                ZipName = $iz.Name
+                Dir     = $subDir
+            }
+        }
+        return [pscustomobject]@{
+            Root   = $extractRoot
+            Inner  = $perSub
+        }
+    }
+
+    function Get-PerSubArtifacts($subDir) {
+        $xlsxFile = Get-ChildItem -Path $subDir -Filter 'ResourcesReport_*.xlsx' | Select-Object -First 1
+        $invFile  = Get-ChildItem -Path $subDir -Filter 'Inventory_*.json'      | Select-Object -First 1
+        $metFile  = Get-ChildItem -Path $subDir -Filter 'Metrics_*.json'        | Select-Object -First 1
+        $conFile  = Get-ChildItem -Path $subDir -Filter 'Consumption_*.csv'     | Select-Object -First 1
+
+        $inv = if ($invFile) { Get-Content $invFile.FullName -Raw | ConvertFrom-Json } else { $null }
+        $met = if ($metFile) { Get-Content $metFile.FullName -Raw | ConvertFrom-Json } else { $null }
+
+        $conRows = 0
+        if ($conFile) {
+            $lines = Get-Content $conFile.FullName -ErrorAction SilentlyContinue
+            if ($lines -and $lines.Count -gt 1) { $conRows = $lines.Count - 1 }
+        }
+
+        # Resource type names that have data (non-null arrays). Excludes Version key.
+        $populatedTypes = @()
+        if ($inv) {
+            $populatedTypes = @(
+                $inv.PSObject.Properties |
+                    Where-Object { $_.Name -ne 'Version' -and $null -ne $_.Value } |
+                    ForEach-Object { $_.Name }
+            ) | Sort-Object
+        }
+
+        # Resource ID universe across every populated type
+        $allIds = @()
+        if ($inv) {
+            $inv.PSObject.Properties | Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' } |
+                ForEach-Object {
+                    @($_.Value) | ForEach-Object { if ($_ -and $_.ID) { $allIds += $_.ID } }
+                }
+        }
+
+        return [pscustomobject]@{
+            XlsxPath        = if ($xlsxFile) { $xlsxFile.FullName } else { $null }
+            InventoryPath   = if ($invFile)  { $invFile.FullName }  else { $null }
+            MetricsPath     = if ($metFile)  { $metFile.FullName }  else { $null }
+            ConsumptionPath = if ($conFile)  { $conFile.FullName }  else { $null }
+            PopulatedTypes  = $populatedTypes
+            ResourceCount   = $allIds.Count
+            ResourceIds     = ($allIds | Sort-Object -Unique)
+            MetricsCount    = if ($met -and $met.Metrics) { @($met.Metrics).Count } else { 0 }
+            ConsumptionRows = $conRows
+        }
+    }
+
+    function Get-XlsxSheetNames($xlsxPath) {
+        # Read xl/workbook.xml from the .xlsx (which is itself a zip) to enumerate
+        # sheet names without depending on ImportExcel being available in the test env.
+        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue | Out-Null
+        $names = @()
+        $arch = [System.IO.Compression.ZipFile]::OpenRead($xlsxPath)
+        try {
+            $entry = $arch.Entries | Where-Object { $_.FullName -eq 'xl/workbook.xml' } | Select-Object -First 1
+            if (-not $entry) { return $names }
+            $reader = New-Object System.IO.StreamReader($entry.Open())
+            try { $xml = $reader.ReadToEnd() } finally { $reader.Dispose() }
+            $matches = [regex]::Matches($xml, '<sheet[^/]*name="([^"]+)"')
+            foreach ($m in $matches) { $names += $m.Groups[1].Value }
+        } finally {
+            $arch.Dispose()
+        }
+        return $names | Sort-Object
+    }
+
+    $bundles = $null
+    if ($script:HaveFixture) {
+        $bundles = @{
+            Sequential = $script:SeqBundlePath
+            Parallel   = $script:ParBundlePath
+        }
+    }
+    if ($script:HaveFixture) {
+        $script:Sequential = Expand-Bundle -bundlePath $bundles.Sequential -label 'seq'
+        $script:Parallel   = Expand-Bundle -bundlePath $bundles.Parallel   -label 'par'
+    } else {
+        $script:Sequential = $null
+        $script:Parallel   = $null
+    }
+
+    # Build per-sub artifact maps keyed by populated-type signature so we can
+    # match a sequential sub to its parallel counterpart even though their
+    # millisecond-precision timestamps differ.
+    $script:SeqArtifacts = if ($script:HaveFixture) {
+        @($script:Sequential.Inner | ForEach-Object { Get-PerSubArtifacts $_.Dir })
+    } else { @() }
+    $script:ParArtifacts = if ($script:HaveFixture) {
+        @($script:Parallel.Inner   | ForEach-Object { Get-PerSubArtifacts $_.Dir })
+    } else { @() }
+
+    function Get-SignatureKey($a) {
+        # Tuple of (resource-count, sorted populated-type names) is unique enough for
+        # the small fixture sizes we test against. Falls back to ResourceCount alone
+        # if both subs happen to have identical type sets.
+        '{0}|{1}' -f $a.ResourceCount, ($a.PopulatedTypes -join ',')
+    }
+    $script:SeqBySig = @{}
+    foreach ($a in $script:SeqArtifacts) { $script:SeqBySig[(Get-SignatureKey $a)] = $a }
+    $script:ParBySig = @{}
+    foreach ($a in $script:ParArtifacts) { $script:ParBySig[(Get-SignatureKey $a)] = $a }
+}
+
+AfterAll {
+    if ($script:Sequential -and (Test-Path $script:Sequential.Root)) {
+        Remove-Item -Path $script:Sequential.Root -Recurse -Force
+    }
+    if ($script:Parallel -and (Test-Path $script:Parallel.Root)) {
+        Remove-Item -Path $script:Parallel.Root -Recurse -Force
+    }
+}
+
+Describe 'Bundle-level structure' {
+    BeforeEach { if (-not $script:HaveFixture) { Set-ItResult -Skipped -Because 'set $env:TEST_SEQUENTIAL_BUNDLE and $env:TEST_PARALLEL_BUNDLE to enable' } }
+    It 'Both bundles contain the same number of inner per-sub ZIPs' {
+        $script:Sequential.Inner.Count | Should -Be $script:Parallel.Inner.Count `
+            -Because 'parallel and sequential modes must process the same set of subscriptions'
+    }
+
+    It 'Both bundles contain at least one inner per-sub ZIP' {
+        $script:Sequential.Inner.Count | Should -BeGreaterThan 0
+    }
+
+    It 'Each inner per-sub directory contains an XLSX, Inventory JSON, Metrics JSON, and Consumption CSV (sequential)' {
+        foreach ($a in $script:SeqArtifacts) {
+            $a.XlsxPath        | Should -Not -BeNullOrEmpty -Because 'XLSX is the primary output artifact'
+            $a.InventoryPath   | Should -Not -BeNullOrEmpty
+            $a.MetricsPath     | Should -Not -BeNullOrEmpty
+            $a.ConsumptionPath | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'Each inner per-sub directory contains an XLSX, Inventory JSON, Metrics JSON, and Consumption CSV (parallel)' {
+        foreach ($a in $script:ParArtifacts) {
+            $a.XlsxPath        | Should -Not -BeNullOrEmpty
+            $a.InventoryPath   | Should -Not -BeNullOrEmpty
+            $a.MetricsPath     | Should -Not -BeNullOrEmpty
+            $a.ConsumptionPath | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Sequential vs parallel: per-sub equivalence' {
+    BeforeEach { if (-not $script:HaveFixture) { Set-ItResult -Skipped -Because 'set $env:TEST_SEQUENTIAL_BUNDLE and $env:TEST_PARALLEL_BUNDLE to enable' } }
+    It 'Total resource count across all subs matches between sequential and parallel' {
+        $seqTotal = ($script:SeqArtifacts | Measure-Object -Property ResourceCount -Sum).Sum
+        $parTotal = ($script:ParArtifacts | Measure-Object -Property ResourceCount -Sum).Sum
+        $parTotal | Should -Be $seqTotal `
+            -Because 'parallelism must not drop any resources'
+    }
+
+    It 'Set of populated resource types per sub matches one-to-one' {
+        # Build sorted "fingerprints" of populated types for each side and compare
+        # the multisets. This is order-independent (a parallel run may emit subs
+        # in any order) and tolerates equal-resource-count subs in either side.
+        $seqFingerprints = @($script:SeqArtifacts | ForEach-Object { ($_.PopulatedTypes -join ',') }) | Sort-Object
+        $parFingerprints = @($script:ParArtifacts | ForEach-Object { ($_.PopulatedTypes -join ',') }) | Sort-Object
+        ($parFingerprints -join '|') | Should -Be ($seqFingerprints -join '|')
+    }
+
+    It 'Total consumption record count matches between sequential and parallel' {
+        $seqRows = ($script:SeqArtifacts | Measure-Object -Property ConsumptionRows -Sum).Sum
+        $parRows = ($script:ParArtifacts | Measure-Object -Property ConsumptionRows -Sum).Sum
+        $parRows | Should -Be $seqRows `
+            -Because 'consumption queries are subscription-scoped and unaffected by stream count'
+    }
+
+    It 'Total metrics record count matches between sequential and parallel (within 5% tolerance)' {
+        # Metrics are time-window queries; running them seconds apart can yield
+        # different bucket counts at the boundary. 5% tolerance protects against
+        # this without hiding real regressions (a broken stream would lose 100%
+        # of one sub's metrics, far above 5%).
+        $seqM = ($script:SeqArtifacts | Measure-Object -Property MetricsCount -Sum).Sum
+        $parM = ($script:ParArtifacts | Measure-Object -Property MetricsCount -Sum).Sum
+        if ($seqM -eq 0) {
+            $parM | Should -Be 0 -Because 'if sequential collected zero metrics, parallel must too'
+        } else {
+            $delta = [Math]::Abs($parM - $seqM) / [double]$seqM
+            $delta | Should -BeLessOrEqual 0.05 `
+                -Because "metrics drift too large: seq=$seqM par=$parM (delta $($delta.ToString('P1')))"
+        }
+    }
+}
+
+Describe 'XLSX worksheet equivalence' {
+    BeforeEach { if (-not $script:HaveFixture) { Set-ItResult -Skipped -Because 'set $env:TEST_SEQUENTIAL_BUNDLE and $env:TEST_PARALLEL_BUNDLE to enable' } }
+    It 'Each sub has the same set of worksheets in sequential vs parallel' {
+        # Match per-sub by population signature (count + types) so the comparison
+        # is robust to subscription ordering differences between modes.
+        foreach ($key in $script:SeqBySig.Keys) {
+            $script:ParBySig.ContainsKey($key) | Should -BeTrue `
+                -Because "no parallel-side counterpart found for sequential sub with signature '$key'"
+            $seqSheets = Get-XlsxSheetNames $script:SeqBySig[$key].XlsxPath
+            $parSheets = Get-XlsxSheetNames $script:ParBySig[$key].XlsxPath
+            ($parSheets -join ',') | Should -Be ($seqSheets -join ',') `
+                -Because "worksheet set diverged for sub signature '$key'"
+        }
+    }
+
+    It 'Overview sheet exists in every per-sub XLSX (both modes)' {
+        foreach ($a in @($script:SeqArtifacts) + @($script:ParArtifacts)) {
+            $sheets = Get-XlsxSheetNames $a.XlsxPath
+            $sheets | Should -Contain 'Overview' `
+                -Because 'the dashboard depends on the Overview sheet existing'
+        }
+    }
+}
+
+Describe 'Inventory JSON key parity' {
+    BeforeEach { if (-not $script:HaveFixture) { Set-ItResult -Skipped -Because 'set $env:TEST_SEQUENTIAL_BUNDLE and $env:TEST_PARALLEL_BUNDLE to enable' } }
+    It 'Every Inventory JSON in both modes contains the canonical resource-type key set' {
+        # The schema fingerprint is the union of all populated-type sets across
+        # both modes. We only assert that whichever keys are present on one side
+        # are also present on the matching sub on the other side.
+        foreach ($key in $script:SeqBySig.Keys) {
+            if (-not $script:ParBySig.ContainsKey($key)) { continue }
+            $seqInv = Get-Content $script:SeqBySig[$key].InventoryPath -Raw | ConvertFrom-Json
+            $parInv = Get-Content $script:ParBySig[$key].InventoryPath -Raw | ConvertFrom-Json
+            $seqKeys = @($seqInv.PSObject.Properties.Name) | Sort-Object
+            $parKeys = @($parInv.PSObject.Properties.Name) | Sort-Object
+            ($parKeys -join ',') | Should -Be ($seqKeys -join ',') `
+                -Because "Inventory JSON top-level keys must be identical for sub signature '$key'"
+        }
+    }
+
+    It 'Version field is present and identical in every Inventory JSON (both modes)' {
+        $versions = @()
+        foreach ($a in @($script:SeqArtifacts) + @($script:ParArtifacts)) {
+            $inv = Get-Content $a.InventoryPath -Raw | ConvertFrom-Json
+            $inv.Version | Should -Not -BeNullOrEmpty
+            $versions += $inv.Version
+        }
+        ($versions | Sort-Object -Unique).Count | Should -Be 1 `
+            -Because 'all subs in a single test fixture should report the same script version'
+    }
+}
+
+Describe 'Obfuscation universe parity (only meaningful on -Obfuscate runs)' {
+    BeforeEach { if (-not $script:HaveFixture) { Set-ItResult -Skipped -Because 'set $env:TEST_SEQUENTIAL_BUNDLE and $env:TEST_PARALLEL_BUNDLE to enable' } }
+    It 'When obfuscation is in effect, both modes produce IDs in the same prod_/nonprod_ namespace' {
+        # We do not assert *identical* GUIDs across modes (each run mints fresh
+        # GUIDs). We only assert that the format is consistent. A regression
+        # that disabled obfuscation in one mode but not the other would break
+        # this immediately.
+        $seqIds = @($script:SeqArtifacts | ForEach-Object { $_.ResourceIds }) | Where-Object { $_ }
+        $parIds = @($script:ParArtifacts | ForEach-Object { $_.ResourceIds }) | Where-Object { $_ }
+
+        $seqObf = @($seqIds | Where-Object { $_ -match '^(prod|nonprod)_' }).Count
+        $parObf = @($parIds | Where-Object { $_ -match '^(prod|nonprod)_' }).Count
+
+        if ($seqObf -gt 0 -or $parObf -gt 0) {
+            $seqRatio = if ($seqIds.Count) { $seqObf / [double]$seqIds.Count } else { 0 }
+            $parRatio = if ($parIds.Count) { $parObf / [double]$parIds.Count } else { 0 }
+            [Math]::Abs($seqRatio - $parRatio) | Should -BeLessOrEqual 0.01 `
+                -Because "obfuscation ratio diverges between modes: seq=$($seqRatio.ToString('P1')) par=$($parRatio.ToString('P1'))"
+        } else {
+            Set-ItResult -Skipped -Because 'neither bundle contains obfuscated IDs (set up with -Obfuscate to enable this test)'
+        }
+    }
+}

--- a/Tests/ProdNonprodPrefix.Tests.ps1
+++ b/Tests/ProdNonprodPrefix.Tests.ps1
@@ -68,9 +68,9 @@ Describe "Prefix Format Validation" {
 Describe "Consumption Prefix Consistency" {
     It "Consumption ResourceIds should have prod_ or nonprod_ prefix" {
         $csvFile = Get-ChildItem -Path $script:ExtractPath -Filter "Consumption_*.csv" | Select-Object -First 1
-        if ($null -eq $csvFile) { return }
+        if ($null -eq $csvFile) { Set-ItResult -Skipped -Because "no consumption csv in fixture"; return }
         $content = Get-Content $csvFile.FullName -ErrorAction SilentlyContinue
-        if ($null -eq $content -or $content.Count -le 1) { return }
+        if ($null -eq $content -or $content.Count -le 1) { Set-ItResult -Skipped -Because "empty consumption csv"; return }
         $csv = Import-Csv $csvFile.FullName
         foreach ($row in $csv) {
             if (![string]::IsNullOrEmpty($row.ResourceId)) {

--- a/Tests/ProdNonprodPrefix.Tests.ps1
+++ b/Tests/ProdNonprodPrefix.Tests.ps1
@@ -48,7 +48,10 @@ Describe "Prefix Format Validation" {
     It "All obfuscated IDs should start with exactly 'prod_' or 'nonprod_'" {
         foreach ($r in $script:AllResources) {
             if ($null -ne $r.ID) {
-                $r.ID | Should -Match '^(prod|nonprod)_[0-9a-f]{8}-' -Because "ID should have valid prefix format"
+                # Type-tagged variants (databricks_, aks_, vmss_) are legitimate
+                # output for resources whose IDs do not fit the standard ARM shape;
+                # see ResourceInventory.ps1 lines 650-655 and 1030-1034.
+                $r.ID | Should -Match '^(prod|nonprod)_(databricks_|aks_|vmss_)?[0-9a-f]{8}-' -Because "ID should have valid prefix format"
             }
         }
     }

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -52,3 +52,49 @@ Then run:
 $env:TEST_ZIP_PATH = "./Tests/ResourcesReport_skip.zip"
 pwsh -Command "Invoke-Pester ./Tests/Obfuscation.Tests.ps1 -Output Detailed"
 ```
+
+## Parallel-Streams Aggregation Tests
+
+`ParallelStreamsAggregation.Tests.ps1` proves a parallel run produces structurally
+equivalent output to a sequential run. It is the drift-prevention guard for the
+`-ParallelStreams` feature.
+
+### Generate the two-bundle fixture
+
+Run the wrapper twice against the same tenant — once sequential, once parallel:
+
+```powershell
+# 1. Sequential reference
+pwsh ./Run-AllSubscriptions.ps1 -TenantID <tenant> -Obfuscate -ParallelStreams 1
+
+# 2. Parallel run (any N >= 2)
+pwsh ./Run-AllSubscriptions.ps1 -TenantID <tenant> -Obfuscate -ParallelStreams 2
+```
+
+Both runs land an `AllSubscriptions_*.zip` bundle under `~/InventoryReports/`.
+
+### Run the test
+
+```powershell
+$env:TEST_SEQUENTIAL_BUNDLE = "~/InventoryReports/AllSubscriptions_<seq-timestamp>.zip"
+$env:TEST_PARALLEL_BUNDLE   = "~/InventoryReports/AllSubscriptions_<par-timestamp>.zip"
+pwsh -Command "Invoke-Pester ./Tests/ParallelStreamsAggregation.Tests.ps1 -Output Detailed"
+```
+
+If either env var is unset the entire suite is **skipped** (not failed) so the
+file is safe to include in `Invoke-Pester ./Tests/` runs that don't have a
+fixture pair available.
+
+### What it asserts
+
+- Both bundles unpack to the same number of inner per-sub ZIPs
+- Each inner ZIP contains XLSX, Inventory JSON, Metrics JSON, Consumption CSV
+- Total resource count matches between modes (no resource dropping)
+- Per-sub set of populated resource types is identical
+- Per-sub XLSX worksheet name set is identical (Overview always present)
+- Inventory JSON top-level key set is identical
+- Consumption record count matches exactly (queries are sub-scoped)
+- Metrics record count matches within 5% (time-window queries can drift slightly)
+- Obfuscation namespace is consistent across modes (catches a regression that
+  silently disables `-Obfuscate` in one path)
+

--- a/Tests/ReferentialIntegrity.Tests.ps1
+++ b/Tests/ReferentialIntegrity.Tests.ps1
@@ -68,7 +68,7 @@ Describe "Obfuscated ID Uniqueness" {
 
 Describe "Consumption to Inventory Cross-Reference" {
     It "Consumption ResourceIds that exist in inventory should use the same obfuscated value" {
-        if ($script:ConsumptionCsv.Count -eq 0) { return }
+        if ($script:ConsumptionCsv.Count -eq 0) { Set-ItResult -Skipped -Because "empty consumption csv"; return }
         $inventoryIds = $script:AllIds
         foreach ($row in $script:ConsumptionCsv) {
             if (![string]::IsNullOrEmpty($row.ResourceId) -and $row.ResourceId -in $inventoryIds) {

--- a/Tests/ReportSchema.Tests.ps1
+++ b/Tests/ReportSchema.Tests.ps1
@@ -87,3 +87,137 @@ Describe 'Report Schema Validation' {
         $actual | Should -Be $expectedOrder -Because "Columns in '$WorksheetName' must maintain expected order"
     }
 }
+
+
+# ============================================================
+# Generic worksheet invariants (covers every emitted worksheet,
+# including the 40+ that don't have a hand-maintained schema in
+# $ExpectedSchema above). Catches broad correctness regressions
+# without requiring per-collector column lists.
+# ============================================================
+Describe 'Generic worksheet invariants' {
+    BeforeAll {
+        # If outer BeforeAll did not run because the zip was missing, skip.
+        $script:GenericReady = $script:XlsxFile -and $script:ExcelData -and ($script:ExcelData.Count -gt 0)
+
+        $script:InventoryJsonPath = $null
+        if ($script:ExtractPath -and (Test-Path $script:ExtractPath)) {
+            $invFile = Get-ChildItem -Path $script:ExtractPath -Filter 'Inventory_*.json' -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($invFile) {
+                $script:InventoryJsonPath = $invFile.FullName
+                $script:InventoryJson     = Get-Content $invFile.FullName -Raw | ConvertFrom-Json
+            }
+        }
+
+        $script:ObfuscationColumnPattern = '^(prod|nonprod)_(databricks_|aks_|vmss_)?[0-9a-f]{8}-'
+    }
+
+    It 'Every populated worksheet should have at least Subscription, ResourceGroup, and Name columns (or be Overview)' {
+        if (-not $script:GenericReady) { Set-ItResult -Skipped -Because 'no fixture'; return }
+        foreach ($ws in $script:ExcelData.Keys) {
+            if ($ws -eq 'Overview' -or $ws -like '_*' -or $ws -like '*Recommendations*') { continue }
+            $cols = $script:ExcelData[$ws]
+            # Allow Bastion / Snapshots / etc. that historically may not include all three.
+            # The minimum invariant: at least ONE of the three core fields present.
+            $hasCore = ($cols -contains 'Subscription') -or ($cols -contains 'ResourceGroup') -or ($cols -contains 'Name')
+            $hasCore | Should -BeTrue -Because "Worksheet '$ws' has columns [$($cols -join ', ')] - none are Subscription/ResourceGroup/Name"
+        }
+    }
+
+    It 'No column name in any worksheet should match the obfuscation pattern' {
+        # The obfuscator runs on VALUES, never on COLUMN NAMES. If a column name
+        # ever ended up obfuscated, every consumer of the report would be confused.
+        if (-not $script:GenericReady) { Set-ItResult -Skipped -Because 'no fixture'; return }
+        foreach ($ws in $script:ExcelData.Keys) {
+            $cols = $script:ExcelData[$ws]
+            foreach ($col in $cols) {
+                $col | Should -Not -Match $script:ObfuscationColumnPattern -Because "Column '$col' in worksheet '$ws' was obfuscated; column names must remain literal"
+            }
+        }
+    }
+
+    It 'Every inventory JSON resource type with data should have a corresponding worksheet' {
+        if (-not $script:GenericReady -or $null -eq $script:InventoryJson) {
+            Set-ItResult -Skipped -Because 'no inventory JSON in fixture'
+            return
+        }
+        # Map of inventory JSON keys to worksheet names. This is sparse on
+        # purpose: only collectors whose JSON key differs from worksheet name
+        # need entries here. The list is short (worksheet names are usually
+        # close to the collector class name).
+        $jsonKeyToWorksheet = @{
+            VirtualMachines     = 'Virtual Machines'
+            VMSS                = 'VM Scale Sets'
+            ComputeSnapshots    = 'VM Snapshots'
+            VMDisk              = 'Disks'
+            StorageAcc          = 'Storage Acc'
+            ARCServers          = 'ARC Servers'
+            AppServicePlan      = 'App Service Plan'
+            AppServices         = 'App Services'
+            AppGW               = 'App Gateway'
+            APIM                = 'APIM'
+            ServiceBUS          = 'Service BUS'
+            EvtHub              = 'Event Hubs'
+            IOTHubs             = 'IOTHubs'
+            AppInsights         = 'AppInsights'
+            LoadBalancer        = 'Load Balancers'
+            VNETGTW             = 'VNET Gateways'
+            ExpressRoute        = 'Express Route'
+            VirtualWAN          = 'Virtual WAN'
+            AzureFirewall       = 'Azure Firewall'
+            PublicIP            = 'Public IPs'
+            TrafficManager      = 'Traffic Manager'
+            PublicDNS           = 'Public DNS'
+            NATGateway          = 'NAT Gateway'
+            DataExplorerCluster = 'Data Explorer Clusters'
+            NetApp              = 'NetApp'
+            CloudServices       = 'CloudServices'
+            REGISTRIES          = 'Registries'
+            CONTAINER           = 'Containers'
+            BASTION             = 'Bastion Hosts'
+            RecoveryVault       = 'Recovery Vaults'
+            AutomationAcc       = 'Runbooks'
+            AvSet               = 'Availability Sets'
+            Vault               = 'Key Vaults'
+            RedisCache          = 'Redis Cache'
+            PostgreSQLflexible  = 'PostgreSQL Flexible'
+            POSTGRE             = 'PostgreSQL'
+            MySQLflexible       = 'MySQL Flexible'
+            MySQL               = 'MySQL'
+            MariaDB             = 'MariaDB'
+            CosmosDB            = 'Cosmos DB'
+            SQLDB               = 'SQL DBs'
+            SQLSERVER           = 'SQL Servers'
+            SQLPOOL             = 'SQL Pools'
+            SQLMI               = 'SQL MI'
+            SQLMIDB             = 'SQL MI DBs'
+            SQLVM               = 'SQL VMs'
+            Purview             = 'Purview'
+            WrkSpace            = 'Workspaces'
+            Synapse             = 'Synapse'
+            Databricks          = 'Databricks'
+            MachineLearning     = 'Machine Learning'
+            Streamanalytics     = 'Stream Analytics Jobs'
+            ARO                 = 'ARO'
+            VMWare              = 'VMWare'
+            AVD                 = 'AVD'
+            AKS                 = 'AKS'
+            FRONTDOOR           = 'FrontDoor'
+        }
+
+        $script:InventoryJson.PSObject.Properties |
+            Where-Object { $null -ne $_.Value -and $_.Name -ne 'Version' -and @($_.Value).Count -gt 0 } |
+            ForEach-Object {
+                $jsonKey = $_.Name
+                # If the inventory has resources for this key, check that the
+                # corresponding worksheet exists. Some inventory keys do not
+                # produce a worksheet by design (rare); tolerate that with a
+                # soft warning rather than a fail.
+                if ($jsonKeyToWorksheet.ContainsKey($jsonKey)) {
+                    $expectedWs = $jsonKeyToWorksheet[$jsonKey]
+                    $script:ExcelData.ContainsKey($expectedWs) |
+                        Should -BeTrue -Because "Inventory key '$jsonKey' has resources but worksheet '$expectedWs' is missing"
+                }
+            }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `-ParallelStreams N` switch to `Run-AllSubscriptions.ps1` that processes N subscriptions concurrently via background `pwsh` processes, each with its own Az PowerShell context, resume-state file, and per-sub output folder. Default is `1` (existing sequential behavior, fully preserved).

This is the "make multi-sub runs much faster" companion to PR #26's "make multi-sub runs not crash" hardening. They are complementary and stacked: this PR is built on top of `feature/multi-subscription-run-hardening`.

Strengthens the fix for #16 (already partly addressed by #26) by ensuring empty subscriptions ship a structurally complete bundle that downstream parsers can ingest.

## Why

For environments with dozens or hundreds of metric-heavy subscriptions (many VMs, SQL DBs, Storage Accounts, Container Registries), the metrics phase is the dominant cost. Each `Get-AzMetric` call is a 200-500 ms ARM round-trip and a single subscription can produce thousands of metric/resource pairs. Sequentially that means tens of minutes per subscription and many hours per run. In environments that cap session lifetime, sequential mode runs out of session before completing.

The metrics phase's existing `-ConcurrencyLimit` parameter throttles parallelism *within* one subscription. To parallelize *across* subscriptions, we need separate processes, each with its own Az context, runspace pool, and output folder.

## How

This PR contains four composing groups of commits:

**Foundational fixes that the parallel orchestration depends on:**
- `Forward -ConcurrencyLimit through Run-AllSubscriptions.ps1`
- `Summary.ps1: guard AddShape calls against pre-existing shapes`
- `ResourceInventory.ps1: millisecond + per-process discriminator for $Global:CurrentDateTime` (closes parallel folder-name collision)

**The parallel-streams feature itself:**
- `Add -ParallelStreams switch to Run-AllSubscriptions.ps1` plus the new worker script `Run-AllSubscriptions.Stream.ps1`
- `Add Pester suite for parallel-streams output equivalence` — 13 tests verifying parallel and sequential modes produce structurally equivalent output

**Hardening identified during multiple defensive review passes:**
- Header-row CSV and empty Metrics JSON for empty subs (downstream parsers were rejecting 0-byte CSVs)
- `try`/`finally` wraps the orchestration so the Az context snapshot AND background jobs are always cleaned up, even on Ctrl+C, Receive-Job failure, or aggregation exception
- Inventory JSON: always serialize resource-type values as arrays (single-resource types previously serialized as `{...}` causing array-iterating parsers to see zero rows)
- Worker `Disable-AzContextAutosave -Scope Process` before importing the shared snapshot, so siblings can't race on the on-disk profile
- `Test-AzPsTokenSilent` filters known-benign Az.Accounts deprecation warnings; previously every successful run was forcing re-auth
- `$LASTEXITCODE` null guard added to the sequential branch and StreamCount<=1 fallback to match the worker
- Worker `failed-to-start` summary now includes the subscription Name (parent's failure-list aggregation no longer produces blank-name rows)
- Aggregator derives `$SkippedCount` from per-stream summaries when in parallel + `-Resume`, so the final summary correctly shows skipped vs processed
- Generic per-property leak scan walks every property of every resource across all 57 collectors and asserts no value contains a raw Azure resource path (catches secondary-field leaks)
- Generic worksheet invariants validate that every populated worksheet has the core columns, no column header is obfuscated, and every populated inventory key has a matching worksheet (covers the 40+ worksheets without a hand-curated schema)
- ImportExcel module preflight in `Run-AllSubscriptions.ps1` and `ResourceInventory.ps1` catches a broken local install at startup with an actionable reinstall command, instead of a confusing `'HorizontalAlignment' cannot be found` error 30 layers down

**Documentation:**
- Quick Start with the recommended `-ParallelStreams 2` command
- Sizing guidance for Cloud Shell (3.5 GB RAM, 2 vCPUs verified) vs local PowerShell
- Output Files table corrected: consumption is `.csv` not `.json`, transcript is `.txt` not `.xlsx`, transcript is excluded from the zip when `-Obfuscate` is used
- Parallel-mode transcript clarification: wrapper-level narration is `[stream-N]` prefixed; inner-script `Write-Host`/`Write-Log` output is unprefixed and interleaves
- Five new Common Issues rows for the failure modes the wrapper actively detects: permission gap (0-resource sub), broken Az module (empty consumption), broken ImportExcel module, ephemeral Cloud Shell session loss, and the `-Resume` recovery path
- New Development setup section linking to `tools/install-hooks.ps1` (delivered separately in the content-safety scrub PR)

## Recommended tunables

`-ParallelStreams` and `-ConcurrencyLimit` multiply, but only up to Azure Monitor's per-tenant rate ceiling. Sane combinations:

| ParallelStreams | ConcurrencyLimit | Concurrent ARM calls | Verdict |
|---|---|---|---|
| 1 | 6 | 6 | Existing default |
| 6 | 6 | 36 | Recommended for metric-heavy estates on a 16 GB / 8-core local machine |
| 8 | 6 | 48 | Watch for HTTP 429s in per-stream logs |
| 6 | 12 | 72 | Aggressive, expect retry-backoff to eat the gain |

Per-stream resource cost: ~500-700 MB RAM peak during metrics phase, mostly I/O-bound. On a typical 16 GB / 8-core machine, `-ParallelStreams 6` is comfortable. On Cloud Shell (verified 3.5 GB RAM, 2 vCPUs), `-ParallelStreams 2` is the recommended ceiling.

## Backwards compatibility

- `-ParallelStreams 1` (the default) takes the existing sequential code path. No behavior change for users who don't set the switch.
- Output bundle format is unchanged: `AllSubscriptions_*.zip` containing one inner per-sub `ResourcesReport_*.zip` per subscription.
- Wrapper transcript format is unchanged in sequential mode; in parallel mode each wrapper line is prefixed with `[stream-N]` for clarity.
- `-Resume` works in both modes (per-stream resume-state files merged into the unified state file on completion).

## Verified

- pwsh parser: 0 errors across all modified files.
- PSScriptAnalyzer: 0 introduced errors. Only pre-existing finding is the `ConvertTo-SecureString` exclusion in `ResourceInventory.ps1` line 499, explicitly excluded by `PSScriptAnalyzerSettings.psd1`.
- Pester suite (with both fixture env vars set): **100 passed / 0 failed / 41 skipped**. Skip count rose from earlier baseline because tests that were previously silently passing on empty fixture data (no Front Doors deployed, no consumption CSV) now correctly report SKIP via `Set-ItResult -Skipped`. No tests regressed.
- Live end-to-end run on a real tenant with `-ParallelStreams 2 -Obfuscate`: 2 minutes 1 second, 23 resources collected, 328 consumption records, both subs processed, 0 failures, resume-state cleared cleanly.

## Stacking

This PR is stacked on top of #26. To review, base on `feature/multi-subscription-run-hardening` rather than `main` to see only the parallel-streams diff. If #26 lands first, this PR can be rebased onto `main` cleanly.

## Companion PR

A separate PR adds a deterministic content-safety scrub framework (`docs/CONTENT_SAFETY_SPEC.md`, `tools/Scrub-Content.ps1`, `tools/Validate-Diff.ps1`, local git hooks via `tools/install-hooks.ps1`, and CI workflow). That PR is independent of this one and can land in either order. The new "Development setup" section in this PR's README references its installer.
