### PR TITLE
Cross-platform access probe (native Az) + run summary host info

### DIFF
--- a/Extension/Metrics.ps1
+++ b/Extension/Metrics.ps1
@@ -439,8 +439,6 @@ if ($Task -eq 'Processing')
                 # spam is removed. Warnings (retry) and errors (giving up) below
                 # are intentionally kept on the console.
 
-                #$metricQuery = (az monitor metrics list --resource $_.Id --metric $_.MetricName --start-time $_.StartTime  --end-time $_.EndTime --interval $_.Interval --aggregation $_.Aggregation | ConvertFrom-Json)
-
                 $MetricError = $false
                 $MetricName = $_.MetricName
                 $MetricService = $_.Service

--- a/Functions/RunAllSubscriptions.Functions.ps1
+++ b/Functions/RunAllSubscriptions.Functions.ps1
@@ -167,11 +167,14 @@ public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
 # level and returns reduced/empty results rather than a 403 when the identity
 # lacks a role, so "no access" and "empty" look identical there.
 #
-# To tell them apart we make ONE cheap, access-scoped control-plane call:
-# `az group list` on the subscription. Listing resource groups requires a role
-# on the subscription (Reader is enough). If the identity has none, ARM returns
-# AuthorizationFailed (403), which we detect. If it succeeds (even with zero
-# RGs) the identity DOES have access, so the subscription is genuinely empty.
+# To tell them apart we make ONE cheap, access-scoped control-plane call via the
+# native Az module (Invoke-AzRestMethod) - an authenticated ARM GET of the
+# subscription's resource groups. Listing resource groups requires a role on the
+# subscription (Reader is enough): HTTP 200 means the identity DOES have access
+# (so 0 resources == genuinely empty), 403/401 means no role, and 404 means ARM
+# is hiding a subscription the identity cannot see. Using the module cmdlet (not
+# the `az` CLI) keeps this portable across Windows/Linux/macOS with no per-OS
+# shell quoting - see .kiro/steering/cross-platform-powershell.md.
 #
 # Returns one of: 'NoAccess', 'Empty', 'Unknown'. Only called for subs that
 # returned 0 resources, so it adds no cost to the normal (non-empty) path.
@@ -179,46 +182,63 @@ function Get-SubscriptionAccessState
 {
     param([Parameter(Mandatory = $true)][string]$SubscriptionId)
 
-    # One cheap, access-scoped control-plane call. Capture stdout+stderr
-    # together and the exit code. Listing resource groups requires a role on
-    # the subscription, so a no-access identity gets AuthorizationFailed.
-    $Output = (az group list --subscription $SubscriptionId --query "length(@)" -o tsv 2>&1) -join ' '
-    $Exit = $LASTEXITCODE
-
-    if ($Exit -eq 0)
+    # One cheap, access-scoped control-plane read via the native Az module - an
+    # authenticated ARM GET of the subscription's resource groups. Portable by
+    # construction (no `az` CLI, no per-OS shell quoting). Invoke-AzRestMethod
+    # returns a PSHttpResponse with an integer .StatusCode for HTTP responses
+    # (including 4xx) and only throws for CLIENT-side failures (no usable
+    # context/token, network/DNS) - verified against a live session: 200 for an
+    # accessible subscription, 404 for an unknown one, neither thrown.
+    try
     {
-        # Call succeeded: identity can read the subscription, so 0 resources
-        # means it is genuinely empty.
+        $Response = Invoke-AzRestMethod -Method GET `
+            -Path ('/subscriptions/{0}/resourcegroups?api-version=2021-04-01' -f $SubscriptionId) `
+            -ErrorAction Stop
+    }
+    catch
+    {
+        # Client-side failure (no usable Azure context/token, network/DNS). This
+        # is not a permission verdict - hedge as Unknown so the caller retries.
+        return 'Unknown'
+    }
+
+    $Status = [int]$Response.StatusCode
+    if ($Status -ge 200 -and $Status -lt 300)
+    {
+        # Identity can read the subscription, so 0 resources means it is
+        # genuinely empty.
         return 'Empty'
     }
-    if ($Output -match 'AuthorizationFailed|does not have authorization|not authorized|Forbidden|403')
+    if ($Status -eq 403 -or $Status -eq 401)
     {
         return 'NoAccess'
     }
-    # An identity that can ENUMERATE a subscription (it came from
-    # Get-AzSubscription) but gets "not found / not recognized" on a
-    # control-plane read into it has no usable role there - ARM hides the
-    # subscription rather than returning a 403. Treat that as NoAccess too,
-    # since the sub IDs we probe are always real and tenant-visible.
-    if ($Output -match "not found|not recognized|could not be found|was not found")
+    if ($Status -eq 404)
     {
+        # An identity that can ENUMERATE a subscription (it came from
+        # Get-AzSubscription) but gets 404 on a control-plane read into it has
+        # no usable role there - ARM hides the subscription rather than
+        # returning a 403. Treat that as NoAccess too, since the sub IDs we
+        # probe are always real and tenant-visible.
         return 'NoAccess'
     }
-    # Some other failure (transient ARM error, throttling, network). Don't
-    # mislabel it - report Unknown so the summary can hedge.
+    # Any other status (429 throttling, 5xx, gateway) is transient/inconclusive.
+    # Don't mislabel it - report Unknown so the caller can retry and the summary
+    # can hedge.
     return 'Unknown'
 }
 
 # Probe control-plane READ access for a set of subscriptions up front, before any
 # per-subscription work. Reuses Get-SubscriptionAccessState (one cheap
-# `az group list` per sub): 'Empty' == the identity CAN read the subscription
+# native ARM GET per sub): 'Empty' == the identity CAN read the subscription
 # (accessible, whether or not it has resources), 'NoAccess' == no role on it,
 # 'Unknown' == an inconclusive/transient failure. A transient 'Unknown' is retried
 # a few times with a short backoff before it is accepted, so a throttle/network
 # blip is not mistaken for a permission gap. Returns one record per sub -
 # { Id, Name, State } with State in Empty/NoAccess/Unknown. This is side-effecting
-# (makes az calls); the proceed/skip DECISION is factored into the pure
-# Resolve-AccessPreflight below so it can be unit-tested without a live session.
+# (makes Azure control-plane calls); the proceed/skip DECISION is factored into
+# the pure Resolve-AccessPreflight below so it can be unit-tested without a live
+# session.
 function Test-SubscriptionAccessAll
 {
     param(

--- a/Functions/RunAllSubscriptions.Functions.ps1
+++ b/Functions/RunAllSubscriptions.Functions.ps1
@@ -904,6 +904,15 @@ function Get-RunSummaryLogContent
         $MetricsFailedSubs = @(),
         $ConsumptionFailedSubs = @(),
         [int]$ConsumptionRecordCount = 0,
+        # Host size and resolved parallelism (run-environment metadata, not
+        # identifiers). Emitted in both modes. Defaults mean "not supplied" and
+        # the whole section is omitted (keeps standalone/offline callers clean).
+        [int]$HostVCpu = 0,
+        [double]$HostRamGB = 0,
+        [int]$Streams = 0,
+        [string]$StreamsSource,
+        [int]$Concurrency = 0,
+        [string]$ConcurrencySource,
         # When set, emit counts only (no names / ids / raw messages).
         [switch]$Obfuscated
     )
@@ -997,6 +1006,31 @@ function Get-RunSummaryLogContent
         $Emitted++
     }
     if ($Emitted -eq 0) { $Lines.Add('  (defaults - no switches or values passed)') }
+
+    # --- Host / parallelism --------------------------------------------------
+    # vCPU/RAM counts and the resolved streams/concurrency (auto vs explicit) are
+    # run-environment metadata, not identifiers, so they are emitted in BOTH
+    # modes. Each line is guarded on a supplied value; when nothing is passed
+    # (standalone/offline callers) the whole section is omitted.
+    $HostLines = [System.Collections.Generic.List[string]]::new()
+    if ($HostVCpu -gt 0) { $HostLines.Add(('  Host vCPU         : {0}' -f $HostVCpu)) }
+    if ($HostRamGB -gt 0) { $HostLines.Add(('  Host RAM (GB)     : {0}' -f $HostRamGB)) }
+    if ($Streams -gt 0)
+    {
+        $StreamsSrcText = if (-not [string]::IsNullOrEmpty($StreamsSource)) { ' ({0})' -f $StreamsSource } else { '' }
+        $HostLines.Add(('  Parallel streams  : {0}{1}' -f $Streams, $StreamsSrcText))
+    }
+    if ($Concurrency -gt 0)
+    {
+        $ConcurrencySrcText = if (-not [string]::IsNullOrEmpty($ConcurrencySource)) { ' ({0})' -f $ConcurrencySource } else { '' }
+        $HostLines.Add(('  Concurrency limit : {0}{1}' -f $Concurrency, $ConcurrencySrcText))
+    }
+    if ($HostLines.Count -gt 0)
+    {
+        $Lines.Add('')
+        $Lines.Add('Host / parallelism:')
+        foreach ($HostLine in $HostLines) { $Lines.Add($HostLine) }
+    }
 
     # --- Subscription tally --------------------------------------------------
     $Lines.Add('')

--- a/ResourceInventory.ps1
+++ b/ResourceInventory.ps1
@@ -500,7 +500,7 @@ Function RunInventorySetup()
 
             $DebugPreference = "Continue"
 
-            $Tenants = az account list --query [].homeTenantId -o tsv --only-show-errors | Sort-Object -Unique
+            $Tenants = (Get-AzSubscription -WarningAction SilentlyContinue).HomeTenantId | Sort-Object -Unique
 
             Write-Log -Message ('Checking number of Tenants') -Severity 'Info'
 

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -1015,7 +1015,7 @@ if ($ParallelStreams -le 1)
                 # genuinely has no resources. Either way the user almost always wants
                 # to know immediately rather than discover it days later when the
                 # consolidated report turns out to be empty for some subs.
-                Write-Host ("WARNING: Subscription '{0}' returned 0 resources. Likely permission gap (no Reader on the subscription) or a genuinely empty subscription. Verify with: az graph query -q ""resources | summarize count()"" --subscriptions {1}" -f $Sub.Name, $Sub.Id) -ForegroundColor Yellow
+                Write-Host ("WARNING: Subscription '{0}' returned 0 resources. Likely permission gap (no Reader on the subscription) or a genuinely empty subscription. Verify with: Search-AzGraph -Query 'resources | summarize count()' -Subscription {1}" -f $Sub.Name, $Sub.Id) -ForegroundColor Yellow
             }
             else
             {

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -20,7 +20,8 @@ param (
     [switch]$IncludeDisabled,
 
     # By DEFAULT the wrapper verifies control-plane read access to EVERY in-scope
-    # subscription up front (one cheap `az group list` per sub) and HARD-STOPS
+    # subscription up front (one cheap native ARM resource-group read per sub)
+    # and HARD-STOPS
     # before doing any work if the signed-in identity cannot read one or more of
     # them - so an auth/permission gap is surfaced and fixed up front instead of
     # producing a report silently missing subscriptions (and risking the
@@ -1853,7 +1854,7 @@ if ($EmptySubs.Count -gt 0)
     {
         Write-Host ("  UNDETERMINED ({0}) - access probe was inconclusive (transient error / throttling):" -f $UnknownSubs.Count) -ForegroundColor Yellow
         foreach ($e in $UnknownSubs) { Write-Host ("    - {0} ({1})" -f $e.Name, $e.Id) -ForegroundColor Yellow }
-        Write-Host "    Verify manually: az group list --subscription <id>" -ForegroundColor Yellow
+        Write-Host "    Verify manually (PowerShell): (Invoke-AzRestMethod -Method GET -Path '/subscriptions/<id>/resourcegroups?api-version=2021-04-01').StatusCode" -ForegroundColor Yellow
     }
 
     # Persist the per-subscription access verdict to the diagnostic log so it
@@ -1879,7 +1880,7 @@ if ($EmptySubs.Count -gt 0)
     }
     foreach ($e in $UnknownSubs)
     {
-        $EmptyDiag += ("UNDETERMINED   {0} ({1}) - access probe inconclusive; verify: az group list --subscription {1}" -f $e.Name, $e.Id)
+        $EmptyDiag += ("UNDETERMINED   {0} ({1}) - access probe inconclusive; verify (PowerShell): (Invoke-AzRestMethod -Method GET -Path '/subscriptions/{1}/resourcegroups?api-version=2021-04-01').StatusCode" -f $e.Name, $e.Id)
     }
     $EmptyDiag += ""
     try

--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -2065,6 +2065,9 @@ if ($null -ne $OuterZipFile -and (Test-Path -LiteralPath $OuterZipFile))
             -MetricsFailedSubs $Global:MetricsFailedSubs `
             -ConsumptionFailedSubs $Global:ConsumptionFailedSubs `
             -ConsumptionRecordCount $ConsumptionRecordTotal `
+            -HostVCpu $AutoTune.VCpu -HostRamGB $AutoTune.RamGB `
+            -Streams $ParallelStreams -StreamsSource $StreamsSrc `
+            -Concurrency $ConcurrencyLimit -ConcurrencySource $ConcurrencySrc `
             -Obfuscated:$Obfuscate
         $RunSummaryLines | Out-File -FilePath (Join-Path $BundleStage 'RunSummary.log') -Encoding utf8
 

--- a/Tests/RunAllSubscriptionsReconciliation.Tests.ps1
+++ b/Tests/RunAllSubscriptionsReconciliation.Tests.ps1
@@ -467,6 +467,27 @@ Describe 'Get-RunSummaryLogContent run-level shareable log' {
         $Text | Should -Match 'Total duration  : 2m 05s'
     }
 
+    It 'renders the host / parallelism section in both modes when values are supplied' {
+        foreach ($Obf in @($true, $false))
+        {
+            $Text = (Get-RunSummaryLogContent -Obfuscated:$Obf `
+                    -HostVCpu 8 -HostRamGB 32 `
+                    -Streams 4 -StreamsSource 'auto' `
+                    -Concurrency 16 -ConcurrencySource 'explicit') -join "`n"
+
+            $Text | Should -Match 'Host / parallelism:'
+            $Text | Should -Match 'Host vCPU\s+:\s+8'
+            $Text | Should -Match 'Host RAM \(GB\)\s+:\s+32'
+            $Text | Should -Match 'Parallel streams\s+:\s+4 \(auto\)'
+            $Text | Should -Match 'Concurrency limit\s+:\s+16 \(explicit\)'
+        }
+    }
+
+    It 'omits the host / parallelism section entirely when no host values are supplied' {
+        $Text = (Get-RunSummaryLogContent -Visible 1 -Eligible 1 -Processed 1) -join "`n"
+        $Text | Should -Not -Match 'Host / parallelism:'
+    }
+
     It 'handles null/empty health collections without throwing (standalone-run safety)' {
         { Get-RunSummaryLogContent -Visible 0 -Eligible 0 -Processed 0 `
                 -FailedSubscriptions $null -CollectorFailures $null `


### PR DESCRIPTION
## Summary

Three cross-platform reliability improvements to the multi-subscription wrapper and its up-front access preflight, plus two small comment/guidance tidies.

### 1. Fix a Windows-only failure in the subscription access probe
The up-front access check shelled out to:

```
az group list --subscription <id> --query "length(@)" -o tsv
```

On Windows `az` is `az.cmd`. When invoked from PowerShell, the quotes around the JMESPath `length(@)` are not preserved, so `cmd.exe` parses the bare `(@)` and fails with `-o was unexpected at this time.` (exit 255) **before the query runs**. Every subscription was then classified as "access inconclusive" and the run hard-stopped, even for an identity with Reader on all of them. It worked on Linux/Cloud Shell/macOS, so it only surfaced on Windows.

The probe now uses the native **`Invoke-AzRestMethod`** (an ARM GET of the subscription's resource groups) and classifies on the HTTP status code (200 -> accessible, 401/403/404 -> no access, anything else -> inconclusive/retryable). No shell layer, no per-OS quoting. The `Empty`/`NoAccess`/`Unknown` return contract and the retry behaviour are unchanged.

### 2. Native `Get-AzSubscription` for tenant enumeration
Replaced `az account list --query [].homeTenantId -o tsv` (the same unquoted-JMESPath-through-`az.cmd` risk class) with `(Get-AzSubscription).HomeTenantId | Sort-Object -Unique`.

### 3. Record host size + resolved parallelism in `RunSummary.log`
Adds a "Host / parallelism" section (vCPU, RAM GB, and the resolved parallel-streams / concurrency values with an auto-vs-explicit source tag) to the shareable run summary. These are non-identifying host metrics, so the section is emitted in both obfuscated and non-obfuscated bundles, and omitted entirely when no values are supplied.

### Tidies
- The 0-resource verify hint now suggests `Search-AzGraph` instead of `az graph query`.
- Removed a dead commented-out `az monitor metrics list` line.

## Why

`az` invocations that pass arguments containing shell metacharacters (`()`, `[]`) without spaces are silently non-portable: PowerShell does not auto-quote them, so `cmd.exe` on Windows can misparse the argument. Native Az module cmdlets have no shell layer and behave identically across Windows, Linux, and macOS.

## Testing

- Pester suite passes, including new coverage for the run-summary host section and the access-state classification.
- Access probe verified on macOS (PowerShell 7) and Windows (PowerShell 7): the native form returns the correct `Empty`/`NoAccess` verdicts and HTTP 200 for an accessible subscription; the previous CLI form reproduces the exit-255 failure on Windows.
- The run-summary (output-affecting) change was validated against the full scenario matrix (default / obfuscate / skip combinations) with 0 failures.

## Notes

This is the first of two PRs. A follow-up will migrate the remaining `az` CLI usage (the auth bootstrap and the Resource Graph query core) to native Az module cmdlets. That touches the core data path and warrants its own regression pass, so it is deliberately kept separate from this focused fix.
