### PR TITLE
Fix: -Resume silently reprocesses all subscriptions (completed-ids seed collapses to $null)

### DIFF
--- a/Run-AllSubscriptions.ps1
+++ b/Run-AllSubscriptions.ps1
@@ -716,7 +716,17 @@ Write-Host ("Subscriptions to process: {0}" -f $Subscriptions.Count) -Foreground
 # controls whether we *use* that list to skip subscriptions; reading it
 # either way ensures the per-iteration writes below append to existing
 # state instead of overwriting it.
-$CompletedIds = Get-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID
+#
+# The @(...) wrap is REQUIRED, not cosmetic. Get-CompletedSubscriptionIds
+# returns @() on a fresh run, and an empty array captured from a function call
+# collapses to $null on assignment. Without the wrap, the first
+# `$CompletedIds += $Sub.Id` below evaluates `$null + '<id>'`, which STRING-
+# concatenates instead of array-appending - so the completed set becomes one
+# mashed-together id string. That silently breaks -Resume (its `-contains`
+# never matches the mashed string, so every subscription is reprocessed) and
+# any downstream membership check. @(...) guarantees a real (possibly empty)
+# array so `+=` always appends.
+$CompletedIds = @(Get-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID)
 # Always seed $FailedAttempts the same way. Read on every run so the writes
 # below preserve any existing failure history; -ResumeFailedOnly is what
 # uses it to filter the subscription list.

--- a/Tests/RunAllSubscriptionsReconciliation.Tests.ps1
+++ b/Tests/RunAllSubscriptionsReconciliation.Tests.ps1
@@ -42,7 +42,7 @@ BeforeAll {
     # Guard: the functions under test must be defined by the shared file. If a
     # future change renames or removes one, fail loudly here rather than with a
     # confusing "command not found" mid-test.
-    $TargetFunctions = @('Get-StreamResumeStateFiles', 'Merge-FailedAttempts', 'Get-WrapperExitCode', 'Add-FailedAttempt', 'Remove-FailedAttempt', 'Get-ConsumptionAccessOutcome', 'Resolve-AccessPreflight', 'Test-SubscriptionAccessAll')
+    $TargetFunctions = @('Get-StreamResumeStateFiles', 'Merge-FailedAttempts', 'Get-WrapperExitCode', 'Add-FailedAttempt', 'Remove-FailedAttempt', 'Get-ConsumptionAccessOutcome', 'Resolve-AccessPreflight', 'Test-SubscriptionAccessAll', 'Get-CompletedSubscriptionIds')
     foreach ($Fn in $TargetFunctions)
     {
         if (-not (Get-Command $Fn -CommandType Function -ErrorAction SilentlyContinue))
@@ -492,5 +492,41 @@ Describe 'Get-RunSummaryLogContent run-level shareable log' {
         { Get-RunSummaryLogContent -Visible 0 -Eligible 0 -Processed 0 `
                 -FailedSubscriptions $null -CollectorFailures $null `
                 -MetricsFailedSubs $null -ConsumptionFailedSubs $null } | Should -Not -Throw
+    }
+}
+
+Describe 'Resume-state completed-ids seed array-ness (regression: null-collapse -> string concat)' {
+
+    # A PowerShell gotcha broke the sequential resume path: an empty array
+    # captured from a FUNCTION CALL collapses to $null on assignment, so
+    #     $CompletedIds = Get-CompletedSubscriptionIds ...   # returns @() on a fresh run
+    # left $CompletedIds as $null. The per-subscription loop's
+    #     $CompletedIds += $Sub.Id
+    # then evaluated `$null + '<id>'`, which STRING-concatenates rather than
+    # array-appending - mashing every completed id into one string. That silently
+    # broke -Resume (its `-contains` never matches the mashed string, so every
+    # subscription is reprocessed). The fix wraps the seed in @(...). These tests
+    # lock in both the behaviour and the source form.
+
+    It 'seeds a fresh-run (absent-file) completed list as an array so += appends instead of concatenating' {
+        $AbsentPath = Join-Path $script:TestRoot ('no-such-state-' + [guid]::NewGuid().ToString('N') + '.json')
+        # Mirror the wrapper's FIXED seed expression exactly.
+        $CompletedIds = @(Get-CompletedSubscriptionIds -Path $AbsentPath -Tenant 'tenant-fresh')
+        $CompletedIds += 'sub-a'
+        $CompletedIds += 'sub-b'
+        @($CompletedIds).Count | Should -Be 2 -Because 'each += must append a distinct element, not concatenate a string'
+        ($CompletedIds -join '|') | Should -Be 'sub-a|sub-b'
+        ($CompletedIds -contains 'sub-a') | Should -BeTrue -Because '-Resume relies on -contains matching each completed id'
+    }
+
+    It 'keeps the @(...) wrap on the completed-ids seed in Run-AllSubscriptions.ps1 (guards against reverting the fix)' {
+        $WrapperPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'Run-AllSubscriptions.ps1'
+        Test-Path $WrapperPath | Should -BeTrue
+        # Match CODE lines only: drop whole-line comments so an explanatory
+        # comment that happens to show the unwrapped form can never false-fail
+        # the negative guard below.
+        $CodeText = ((Get-Content -Path $WrapperPath) | Where-Object { $_ -notmatch '^\s*#' }) -join "`n"
+        ($CodeText -match '\$CompletedIds\s*=\s*@\(\s*Get-CompletedSubscriptionIds') | Should -BeTrue -Because 'the completed-ids seed must be @()-wrapped so an empty result stays an array'
+        ($CodeText -match '\$CompletedIds\s*=\s*Get-CompletedSubscriptionIds') | Should -BeFalse -Because 'an unwrapped seed collapses @() to $null on a fresh run and breaks -Resume'
     }
 }


### PR DESCRIPTION
## Summary

On a fresh run (no existing resume-state file), `Run-AllSubscriptions.ps1` seeded its
completed-subscriptions list directly from `Get-CompletedSubscriptionIds`, which returns
an empty array `@()` when there is no prior state. PowerShell unrolls an empty array to
`$null` on assignment, so `$CompletedIds` became `$null` rather than an empty array.

The first `$CompletedIds += $Sub.Id` in the sequential loop then evaluated `$null + '<id>'`,
which performs **string concatenation** instead of array append. The completed set turned
into one mashed-together string (`id1id2id3...`) rather than a list of IDs.

Because that corrupted value is persisted to the resume-state file, a later `-Resume`
run cannot match any individual subscription ID (`-contains` never matches the mashed
string), so it silently reprocesses **every** subscription from scratch - defeating the
purpose of `-Resume`.

## Scope

- Affects the parent **sequential** path only, and only from an empty (fresh) start.
- The parallel/worker path is unaffected - it seeds with an `@()` array literal, which is safe.
- `$FailedAttempts` is unaffected - it is normalized through its Add/Remove/Merge helpers.

## Fix

Wrap the seed in `@(...)` so an empty result stays a real (possibly empty) array:

```powershell
$CompletedIds = @(Get-CompletedSubscriptionIds -Path $ResumeStateFile -Tenant $TenantID)
```

An explanatory comment is added at the call site so the wrap is not mistaken for cosmetic
and removed later.

## Testing

- A regression test is added that drives the exact seed / append / persist path from an
  empty start and asserts the persisted completed set round-trips as a multi-element array
  rather than a single concatenated string. It also includes a source guard so the `@(...)`
  wrap cannot be removed unnoticed.
- The new test fails against the pre-fix code and passes with the fix; the full offline
  Pester suite passes.

## Notes for reviewers

- The code change is one line and deliberately comment-free; this description carries the rationale.
- `Get-CompletedSubscriptionIds` returns `@()` on a fresh run (no resume-state file). Assigning a function's empty-array output directly leaves the variable `$null`, so the loop's first `$CompletedIds += $Sub.Id` evaluates `$null + '<id>'` and string-concatenates instead of appending. The completed set becomes one mashed-together string; `-Resume`'s `-contains` never matches it and every subscription is reprocessed. `@(...)` guarantees a real (possibly empty) array so `+=` always appends.
- The regression test covers both the behaviour (fresh-run seed appends two ids as two elements) and the source form (the seed stays `@()`-wrapped, and the unwrapped form is absent from code lines).
